### PR TITLE
Adjust order of vars in pattern to correspond to column order in CSVs

### DIFF
--- a/src/ontology/patterns/entity_attribute.yaml
+++ b/src/ontology/patterns/entity_attribute.yaml
@@ -7,8 +7,8 @@ relations:
   inheres in part of: RO_0002314
     
 vars: 
-  attribute: "'Thing'"
   entity: "'Thing'"
+  attribute: "'Thing'"
 
 name:
   text: "%s %s"

--- a/src/ontology/patterns/entity_attribute_location.yaml
+++ b/src/ontology/patterns/entity_attribute_location.yaml
@@ -7,8 +7,8 @@ relations:
   inheres in part of: RO_0002314
     
 vars: 
-  attribute: "'Thing'"
   entity: "'Thing'"
+  attribute: "'Thing'"
   location: "'Thing'"
 
 name:


### PR DESCRIPTION
The INCAForm table-editor uses the DOSDP pattern YAML file to determine the order of columns presented in the table. Specifically, the order of fields in `vars` is used to determine this order, which is expected to match the order and name of columns in imported/exported XSV files.

I would like to adjust the two pattern files `entity_attribute.yaml` and `entity_attribute_location.yaml` so that their `vars` are in the same order as in the filenames (entity, attribute) and (entity, attribute, location), respectively. 

This corresponds to the column order in [attribute_location.yaml](https://github.com/obophenotype/bio-attribute-ontology/blob/master/src/ontology/patterns/attribute_location.yaml) and [entity_attribute_location.csv](https://github.com/obophenotype/bio-attribute-ontology/blob/master/src/ontology/modules/entity_attribute_location.csv), respectively.

It might be nice to adjust the DOSDP guidelines to have pattern file `x_y_z.yaml` order its `vars` as (x, y, z), to reduce decision overhead when managing patterns, pattern files, and XSV. @cmungall @dosumis might have an opinion here.

Note: Of course, with some effort, the INCAForm/table-editor code can be extended to deal with this issue, including the ability to import non-conforming XSV and export this XSV back into the same non-conforming XSV. But that's more work.
