### PR TITLE
adding missing TopMED phenotypes

### DIFF
--- a/src/ontology/modules/entity_attribute.csv
+++ b/src/ontology/modules/entity_attribute.csv
@@ -7297,3 +7297,8 @@ OBA:1001081,,UBERON:0000358,blastocyst,PATO:0000051,morphology
 OBA:1001082,,UBERON:0002292,costovertebral joint,PATO:0000051,morphology
 OBA:1001083,,UBERON:0003709,circle of Willis,PATO:0000051,morphology
 OBA:1001084,,UBERON:0001988,feces,PATO:0002027,osmolality
+OBA:1001085,waist circumference,PATO:0001648,circumference,UBERON:0002417,abdominal section of trunk
+OBA:1001086,QRS duration,PATO:0001309,duration,EFO:0005054,QRS complex
+OBA:1001087,heart rate,PATO:0000161,rate,GO:0060047,heart contraction
+OBA:1001088,race,SIO:001015,race,UBERON:0000468,multicellular organism
+OBA:1001089,sex,PATO:0000047,UBERON:0000468,multicellular organism


### PR DESCRIPTION
This adds five new OBA classes to accommodate TopMED phenotypes for commons. 
See https://docs.google.com/spreadsheets/d/1xl4fCLFC33ebbqS9dFDiAyno1OgJCOrUjhWrsXs_EQE/edit?ts=5ba1593c#gid=0