### PR TITLE
Fix response to chemical stimulus trait definition

### DIFF
--- a/src/patterns/dosdp-patterns/response_to_chemical_stimulus_trait.yaml
+++ b/src/patterns/dosdp-patterns/response_to_chemical_stimulus_trait.yaml
@@ -37,7 +37,7 @@ annotations:
       - chemical
       
 def:
-  text: "A trait that affects to the response to a stimulus with %s."
+  text: "A trait that affects the response to a stimulus with %s."
   vars:
     - chemical
 


### PR DESCRIPTION
Fix text definition of response to chemical stimulus trait pattern template.
See comment https://github.com/obophenotype/bio-attribute-ontology/pull/64/files#r859719357
This commit is related to #53.