### PR TITLE
Add new entity_attribute term OBA:VT0010917

### DIFF
--- a/src/patterns/data/default/entity_attribute.tsv
+++ b/src/patterns/data/default/entity_attribute.tsv
@@ -7247,3 +7247,4 @@ OBA:2040146	cell width	CL:0000003	native cell	PATO:0000921	width
 OBA:2040151	shelled egg length	UBERON:0007379	shelled egg	PATO:0000122	length
 OBA:2040152	shelled egg width	UBERON:0007379	shelled egg	PATO:0000921	width
 OBA:VT0010119		UBERON:0001134	skeletal muscle tissue	PATO:0000025	composition
+OBA:VT0010917		CHEBI:3098	bile acid	PATO:0000070	amount


### PR DESCRIPTION
This commit intends to add new entity_attribute term 'OBA:VT0010917 bile acid amount'.

Part of #85.