### PR TITLE
Fix duplicate definition errors

### DIFF
--- a/src/patterns/data/default/entity_attribute_location.tsv
+++ b/src/patterns/data/default/entity_attribute_location.tsv
@@ -176,7 +176,7 @@ OBA:VT0010808	milk sulfur amount	CHEBI:26833	sulfur atom	PATO:0000070	amount	UBE
 OBA:VT0000199	blood albumin amount	CHEBI:166964	albumin type	PATO:0000070	amount	UBERON:0000178	blood
 OBA:VT0010918	liver bile acid amount	CHEBI:3098	bile acid	PATO:0000070	amount	UBERON:0002107	liver
 OBA:VT0010711	milk iron amount	CHEBI:18248	iron atom	PATO:0000070	amount	UBERON:0001913	milk
-OBA:VT0005567	blood total protein amount	CHEBI:36080	protein	PATO:0000070	amount	UBERON:0000178	blood
+OBA:VT0005567	blood total protein amount	CHEBI:36080	protein	PATO:0000125	mass	UBERON:0000178	blood
 OBA:VT0002492	blood immunoglobulin E amount	GO:0071743	IgE immunoglobulin complex, circulating	PATO:0000070	amount	UBERON:0000178	blood
 OBA:VT0008497	blood immunoglobulin G2b amount	PR:000050260	IgG2b heavy chain protein	PATO:0000070	amount	UBERON:0000178	blood
 OBA:VT0010694	blood fructosamine amount	CHEBI:24103	fructosamine	PATO:0000070	amount	UBERON:0000178	blood
@@ -194,7 +194,7 @@ OBA:VT1000047	blood creatine kinase amount	PR:000029971	creatine kinase	PATO:000
 OBA:VT0010616	blood lactate amount	CHEBI:24996	lactate	PATO:0000070	amount	UBERON:0000178	blood
 OBA:VT0010695	blood ghrelin amount	PR:000007973	appetite-regulating hormone	PATO:0000070	amount	UBERON:0000178	blood
 OBA:VT0008897	blood immunoglobulin G2c amount	PR:000050261	IgG2c heavy chain protein	PATO:0000070	amount	UBERON:0000178	blood
-OBA:VT0010474	blood non-HDL cholesterol amount	CHEBI:47775	high-density lipoprotein cholesterol	PATO:0000070	amount	UBERON:0000178	blood
+OBA:VT0010474		CHEBI:50404	lipoprotein cholesterol	PATO:0000025	composition	UBERON:0000178	blood
 OBA:VT0000203	blood aspartate transaminase amount	PR:000008153	aspartate aminotransferase, cytoplasmic	PATO:0000070	amount	UBERON:0000178	blood
 OBA:VT0005119	blood thyroid-stimulating hormone amount	PR:000028269	thyroid stimulating hormone	PATO:0000070	amount	UBERON:0000178	blood
 OBA:VT0008550	blood interferon-beta amount	PR:000024939	interferon beta	PATO:0000070	amount	UBERON:0000178	blood


### PR DESCRIPTION
This commit intends to
1. Use *PATO:0000125	mass* quality with *OBA:VT0005567 blood total protein amount* to avoid blood protein amount duplicates.
2. Use *PATO:0000025	composition* and *CHEBI:50404	lipoprotein cholesterol* with *OBA:VT0010474 blood non-HDL cholesterol* to avoid negation in logical definition.

Part of #85.