### PR TITLE
Add protein in blood serum traits

### DIFF
--- a/src/patterns/data/default/entity_attribute_location.tsv
+++ b/src/patterns/data/default/entity_attribute_location.tsv
@@ -268,3 +268,4743 @@ OBA:2040180		CHEBI:16038	phosphatidylethanolamine	PATO:0000070	amount	UBERON:000
 OBA:2040181		CHEBI:28874	phosphatidylinositol	PATO:0000070	amount	UBERON:0001062	anatomical entity
 OBA:2040182		CHEBI:64583	sphingomyelin	PATO:0000070	amount	UBERON:0001062	anatomical entity
 OBA:2040183		CHEBI:17855	triglyceride	PATO:0000070	amount	UBERON:0001062	anatomical entity
+OBA:2040184	level of succinate dehydrogenase assembly factor 1, mitochondrial (human) in blood serum	PR:A6NFY7	succinate dehydrogenase assembly factor 1, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040185	level of fatty acid-binding protein 12 (human) in blood serum	PR:A6NFH5	fatty acid-binding protein 12 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040186	level of single-pass membrane and coiled-coil domain-containing protein 2 (human) in blood serum	PR:A6NFE2	single-pass membrane and coiled-coil domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040187	level of transmembrane protein 8B (human) in blood serum	PR:A6NDV4	transmembrane protein 8B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040188	level of leucine-rich repeat, immunoglobulin-like domain and transmembrane domain-containing protein 2 (human) in blood serum	PR:A6NDA9	leucine-rich repeat, immunoglobulin-like domain and transmembrane domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040189	level of microtubule-associated proteins 1A/1B light chain 3 beta 2 (human) in blood serum	PR:A6NCE7	microtubule-associated proteins 1A/1B light chain 3 beta 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040190	level of glutaredoxin-like protein C5orf63 (human) in blood serum	PR:A6NC05	glutaredoxin-like protein C5orf63 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040191	level of protein FAM221B (human) in blood serum	PR:A6H8Z2	protein FAM221B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040192	level of transcription factor TFIIIB component B'' homolog (human) in blood serum	PR:A6H8Y1	transcription factor TFIIIB component B'' homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040193	level of CCR4-NOT transcription complex subunit 1 (human) in blood serum	PR:A5YKK6	CCR4-NOT transcription complex subunit 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040194	level of trafficking protein particle complex subunit 13 (human) in blood serum	PR:A5PLN9	trafficking protein particle complex subunit 13 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040195	level of PH and SEC7 domain-containing protein 1 (human) in blood serum	PR:A5PKW4	PH and SEC7 domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040196	level of probable inactive serine protease 37 (human) in blood serum	PR:A4D1T9	probable inactive serine protease 37 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040197	level of GTP-binding protein 10 (human) in blood serum	PR:A4D1E9	GTP-binding protein 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040198	level of protein FAM221A (human) in blood serum	PR:A4D161	protein FAM221A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040199	level of D-ribitol-5-phosphate cytidylyltransferase (human) in blood serum	PR:A4D126	D-ribitol-5-phosphate cytidylyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040200	level of colipase-like protein 1 (human) in blood serum	PR:A2RUU4	colipase-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040201	level of tRNA wybutosine-synthesizing protein 5 (human) in blood serum	PR:A2RUC4	tRNA wybutosine-synthesizing protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040202	level of homeobox protein HMX2 (human) in blood serum	PR:A2RU54	homeobox protein HMX2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040203	level of hydroxylysine kinase (human) in blood serum	PR:A2RU49	hydroxylysine kinase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040204	level of dystrotelin (human) in blood serum	PR:A2CJ06	dystrotelin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040205	level of ADP-ribose glycohydrolase MACROD2 (human) in blood serum	PR:A1Z1Q3	ADP-ribose glycohydrolase MACROD2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040206	level of CBY1-interacting BAR domain-containing protein 1 (human) in blood serum	PR:A1XBS5	CBY1-interacting BAR domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040207	level of SH3 and PX domain-containing protein 2B (human) in blood serum	PR:A1X283	SH3 and PX domain-containing protein 2B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040208	level of NADH dehydrogenase [ubiquinone] 1 alpha subcomplex assembly factor 8 (human) in blood serum	PR:A1L188	NADH dehydrogenase [ubiquinone] 1 alpha subcomplex assembly factor 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040209	level of uncharacterized protein C1orf226 (human) in blood serum	PR:A1L170	uncharacterized protein C1orf226 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040210	level of uncharacterized protein C20orf202 (human) in blood serum	PR:A1L168	uncharacterized protein C20orf202 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040211	level of probable oxidoreductase PXDNL (human) in blood serum	PR:A1KZ92	probable oxidoreductase PXDNL (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040212	level of putative uncharacterized protein SLC66A1L (human) in blood serum	PR:A1A4F0	putative uncharacterized protein SLC66A1L (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040213	level of TLD domain-containing protein 2 (human) in blood serum	PR:A0PJX2	TLD domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040214	level of ubiquitin-like modifier-activating enzyme 6 (human) in blood serum	PR:A0AVT1	ubiquitin-like modifier-activating enzyme 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040215	level of protein Frey (human) in blood serum	PR:C9JXX5	protein Frey (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040216	level of ankyrin repeat domain-containing protein 63 (human) in blood serum	PR:C9JTQ0	ankyrin repeat domain-containing protein 63 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040217	level of protein phosphatase 1 regulatory subunit 3G (human) in blood serum	PR:B7ZBB8	protein phosphatase 1 regulatory subunit 3G (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040218	level of endogenous retrovirus group V member 1 Env polyprotein (human) in blood serum	PR:B6SEH8	endogenous retrovirus group V member 1 Env polyprotein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040219	level of von Willebrand factor C domain-containing protein 2-like (human) in blood serum	PR:B2RUY7	von Willebrand factor C domain-containing protein 2-like (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040220	level of isthmin-1 (human) in blood serum	PR:B1AKI9	isthmin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040221	level of espin (human) in blood serum	PR:B1AK53	espin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040222	level of uroplakin-3b-like protein 1 (human) in blood serum	PR:B0FP48	uroplakin-3b-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040223	level of collagen alpha-5(VI) chain (human) in blood serum	PR:A8TX70	collagen alpha-5(VI) chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040224	level of endosome/lysosome-associated apoptosis and autophagy regulator family member 2 (human) in blood serum	PR:A8MWY0	endosome/lysosome-associated apoptosis and autophagy regulator family member 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040225	level of protein FAM171A2 (human) in blood serum	PR:A8MVW0	protein FAM171A2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040226	level of synaptonemal complex central element protein 1-like (human) in blood serum	PR:A8MT33	synaptonemal complex central element protein 1-like (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040227	level of cysteine-rich tail protein 1 (human) in blood serum	PR:A8MQ03	cysteine-rich tail protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040228	level of calcium-activated chloride channel regulator 1 (human) in blood serum	PR:A8K7I4	calcium-activated chloride channel regulator 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040229	level of CMRF35-like molecule 7 (human) in blood serum	PR:A8K4G0	CMRF35-like molecule 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040230	level of alpha-2-macroglobulin-like protein 1 (human) in blood serum	PR:A8K2U0	alpha-2-macroglobulin-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040231	level of YjeF N-terminal domain-containing protein 3 (human) in blood serum	PR:A6XGL0	YjeF N-terminal domain-containing protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040232	level of dorsal root ganglia homeobox protein (human) in blood serum	PR:A6NNA5	dorsal root ganglia homeobox protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040233	level of sentan (human) in blood serum	PR:A6NMZ2	sentan (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040234	level of leucine-rich repeat-containing protein 37A2 (human) in blood serum	PR:A6NM11	leucine-rich repeat-containing protein 37A2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040235	level of tetratricopeptide repeat protein 36 (human) in blood serum	PR:A6NLP5	tetratricopeptide repeat protein 36 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040236	level of Purkinje cell protein 4-like protein 1 (human) in blood serum	PR:A6NKN8	Purkinje cell protein 4-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040237	level of AT-rich interactive domain-containing protein 3C (human) in blood serum	PR:A6NKF2	AT-rich interactive domain-containing protein 3C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040238	level of protein unc-119 homolog B (human) in blood serum	PR:A6NIH7	protein unc-119 homolog B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040239	level of coiled-coil domain-containing protein 69 (human) in blood serum	PR:A6NI79	coiled-coil domain-containing protein 69 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040240	level of leukocyte immunoglobulin-like receptor subfamily A member 5 (human) in blood serum	PR:A6NI73	leukocyte immunoglobulin-like receptor subfamily A member 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040241	level of homeobox protein HMX3 (human) in blood serum	PR:A6NHT5	homeobox protein HMX3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040242	level of MANSC domain-containing protein 4 (human) in blood serum	PR:A6NHS7	MANSC domain-containing protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040243	level of glycolipid transfer protein domain-containing protein 2 (human) in blood serum	PR:A6NH11	glycolipid transfer protein domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040244	level of small integral membrane protein 9 (human) in blood serum	PR:A6NGZ8	small integral membrane protein 9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040245	level of IgLON family member 5 (human) in blood serum	PR:A6NGN9	IgLON family member 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040246	level of pyruvate dehydrogenase protein X component, mitochondrial (human) in blood serum	PR:O00330	pyruvate dehydrogenase protein X component, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040247	level of ETS translocation variant 2 (human) in blood serum	PR:O00321	ETS translocation variant 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040248	level of NEDD4-like E3 ubiquitin-protein ligase WWP2 (human) in blood serum	PR:O00308	NEDD4-like E3 ubiquitin-protein ligase WWP2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040249	level of voltage-dependent L-type calcium channel subunit beta-4 (human) in blood serum	PR:O00305	voltage-dependent L-type calcium channel subunit beta-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040250	level of tubby-related protein 1 (human) in blood serum	PR:O00294	tubby-related protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040251	level of left-right determination factor 2 (human) in blood serum	PR:O00292	left-right determination factor 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040252	level of regulatory factor X-associated protein (human) in blood serum	PR:O00287	regulatory factor X-associated protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040253	level of DNA fragmentation factor subunit alpha (human) in blood serum	PR:O00273	DNA fragmentation factor subunit alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040254	level of membrane-associated progesterone receptor component 1 (human) in blood serum	PR:O00264	membrane-associated progesterone receptor component 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040255	level of menin (human) in blood serum	PR:O00255	menin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040256	level of copper transport protein ATOX1 (human) in blood serum	PR:O00244	copper transport protein ATOX1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040257	level of signal-regulatory protein beta-1 isoforms 1/2 (human) in blood serum	PR:O00241	signal-regulatory protein beta-1 isoforms 1/2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040258	level of bone morphogenetic protein receptor type-1B (human) in blood serum	PR:O00238	bone morphogenetic protein receptor type-1B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040259	level of 26S proteasome non-ATPase regulatory subunit 9 (human) in blood serum	PR:O00233	26S proteasome non-ATPase regulatory subunit 9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040260	level of 26S proteasome non-ATPase regulatory subunit 11 (human) in blood serum	PR:O00231	26S proteasome non-ATPase regulatory subunit 11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040261	level of Rho-related GTP-binding protein RhoD (human) in blood serum	PR:O00212	Rho-related GTP-binding protein RhoD (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040262	level of sulfotransferase 2B1 (human) in blood serum	PR:O00204	sulfotransferase 2B1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040263	level of activator of apoptosis harakiri (human) in blood serum	PR:O00198	activator of apoptosis harakiri (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040264	level of Ras-related protein Rab-27B (human) in blood serum	PR:O00194	Ras-related protein Rab-27B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040265	level of AP-4 complex subunit mu-1 (human) in blood serum	PR:O00189	AP-4 complex subunit mu-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040266	level of eyes absent homolog 2 (human) in blood serum	PR:O00167	eyes absent homolog 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040267	level of HCLS1-associated protein X-1 (human) in blood serum	PR:O00165	HCLS1-associated protein X-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040268	level of synaptosomal-associated protein 23 (human) in blood serum	PR:O00161	synaptosomal-associated protein 23 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040269	level of PDZ and LIM domain protein 1 (human) in blood serum	PR:O00151	PDZ and LIM domain protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040270	level of frizzled-9 (human) in blood serum	PR:O00144	frizzled-9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040271	level of thymidine kinase 2, mitochondrial (human) in blood serum	PR:O00142	thymidine kinase 2, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040272	level of serine/threonine-protein kinase Sgk1 (human) in blood serum	PR:O00141	serine/threonine-protein kinase Sgk1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040273	level of interferon lambda-4 (human) in blood serum	PR:K9M1U5	interferon lambda-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040274	level of uncharacterized protein C19orf84 (human) in blood serum	PR:I3L1E1	uncharacterized protein C19orf84 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040275	level of protein FAM229A (human) in blood serum	PR:H3BQW9	protein FAM229A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040276	level of short transmembrane mitochondrial protein 1 (human) in blood serum	PR:E0CX11	short transmembrane mitochondrial protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040277	level of suppressor of cytokine signaling 7 (human) in blood serum	PR:O14512	suppressor of cytokine signaling 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040278	level of pro-neuregulin-2, membrane-bound isoform (human) in blood serum	PR:O14511	pro-neuregulin-2, membrane-bound isoform (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040279	level of AT-rich interactive domain-containing protein 1A (human) in blood serum	PR:O14497	AT-rich interactive domain-containing protein 1A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040280	level of ubiquitin-conjugating enzyme E2 C (human) in blood serum	PR:O00762	ubiquitin-conjugating enzyme E2 C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040281	level of fructose-1,6-bisphosphatase isozyme 2 (human) in blood serum	PR:O00757	fructose-1,6-bisphosphatase isozyme 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040282	level of nucleoside diphosphate kinase, mitochondrial (human) in blood serum	PR:O00746	nucleoside diphosphate kinase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040283	level of protein Wnt-10b (human) in blood serum	PR:O00744	protein Wnt-10b (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040284	level of importin subunit alpha-3 (human) in blood serum	PR:O00629	importin subunit alpha-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040285	level of pirin (human) in blood serum	PR:O00625	pirin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040286	level of CCN family member 1 (human) in blood serum	PR:O00622	CCN family member 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040287	level of beta-1,3-N-acetylglucosaminyltransferase manic fringe (human) in blood serum	PR:O00587	beta-1,3-N-acetylglucosaminyltransferase manic fringe (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040288	level of syntenin-1 (human) in blood serum	PR:O00560	syntenin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040289	level of receptor-binding cancer antigen expressed on SiSo cells (human) in blood serum	PR:O00559	receptor-binding cancer antigen expressed on SiSo cells (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040290	level of ladinin-1 (human) in blood serum	PR:O00515	ladinin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040291	level of Myc box-dependent-interacting protein 1 (human) in blood serum	PR:O00499	Myc box-dependent-interacting protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040292	level of zinc finger protein 593 (human) in blood serum	PR:O00488	zinc finger protein 593 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040293	level of nuclear receptor subfamily 5 group A member 2 (human) in blood serum	PR:O00482	nuclear receptor subfamily 5 group A member 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040294	level of butyrophilin subfamily 3 member A3 (human) in blood serum	PR:O00478	butyrophilin subfamily 3 member A3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040295	level of RNA polymerase II elongation factor ELL2 (human) in blood serum	PR:O00472	RNA polymerase II elongation factor ELL2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040296	level of procollagen-lysine,2-oxoglutarate 5-dioxygenase 2 (human) in blood serum	PR:O00469	procollagen-lysine,2-oxoglutarate 5-dioxygenase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040297	level of agrin (human) in blood serum	PR:O00468	agrin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040298	level of beta-mannosidase (human) in blood serum	PR:O00462	beta-mannosidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040299	level of interferon-related developmental regulator 1 (human) in blood serum	PR:O00458	interferon-related developmental regulator 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040300	level of leukocyte-specific transcript 1 protein (human) in blood serum	PR:O00453	leukocyte-specific transcript 1 protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040301	level of synaptotagmin-5 (human) in blood serum	PR:O00445	synaptotagmin-5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040302	level of phosphatidylinositol 4-phosphate 3-kinase C2 domain-containing subunit alpha (human) in blood serum	PR:O00443	phosphatidylinositol 4-phosphate 3-kinase C2 domain-containing subunit alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040303	level of dynamin-1-like protein (human) in blood serum	PR:O00429	dynamin-1-like protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040304	level of histone deacetylase complex subunit SAP18 (human) in blood serum	PR:O00422	histone deacetylase complex subunit SAP18 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040305	level of actin nucleation-promoting factor WASL (human) in blood serum	PR:O00401	actin nucleation-promoting factor WASL (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040306	level of sulfhydryl oxidase 1 (human) in blood serum	PR:O00391	sulfhydryl oxidase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040307	level of sulfotransferase 1C2 (human) in blood serum	PR:O00338	sulfotransferase 1C2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040308	level of complexin-1 (human) in blood serum	PR:O14810	complexin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040309	level of Ras-related protein M-Ras (human) in blood serum	PR:O14807	Ras-related protein M-Ras (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040310	level of SH2 domain-containing protein 1B (human) in blood serum	PR:O14796	SH2 domain-containing protein 1B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040311	level of heparan sulfate glucosamine 3-O-sulfotransferase 1 (human) in blood serum	PR:O14792	heparan sulfate glucosamine 3-O-sulfotransferase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040312	level of kinesin-like protein KIF3C (human) in blood serum	PR:O14782	kinesin-like protein KIF3C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040313	level of kinetochore protein NDC80 (human) in blood serum	PR:O14777	kinetochore protein NDC80 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040314	level of tripeptidyl-peptidase 1 (human) in blood serum	PR:O14773	tripeptidyl-peptidase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040315	level of homeobox protein Meis2 (human) in blood serum	PR:O14770	homeobox protein Meis2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040316	level of Na(+)/H(+) exchange regulatory cofactor NHE-RF1 (human) in blood serum	PR:O14745	Na(+)/H(+) exchange regulatory cofactor NHE-RF1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040317	level of programmed cell death protein 5 (human) in blood serum	PR:O14737	programmed cell death protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040318	level of acyl-coenzyme A thioesterase 8 (human) in blood serum	PR:O14734	acyl-coenzyme A thioesterase 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040319	level of inositol monophosphatase 2 (human) in blood serum	PR:O14732	inositol monophosphatase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040320	level of apoptotic protease-activating factor 1 (human) in blood serum	PR:O14727	apoptotic protease-activating factor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040321	level of tRNA (cytosine(38)-C(5))-methyltransferase (human) in blood serum	PR:O14717	tRNA (cytosine(38)-C(5))-methyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040322	level of histone-lysine N-methyltransferase 2D (human) in blood serum	PR:O14686	histone-lysine N-methyltransferase 2D (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040323	level of tumor protein p53-inducible protein 11 (human) in blood serum	PR:O14683	tumor protein p53-inducible protein 11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040324	level of lysosomal cobalamin transporter ABCD4 (human) in blood serum	PR:O14678	lysosomal cobalamin transporter ABCD4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040325	level of axonemal dynein light intermediate polypeptide 1 (human) in blood serum	PR:O14645	axonemal dynein light intermediate polypeptide 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040326	level of segment polarity protein dishevelled homolog DVL-2 (human) in blood serum	PR:O14641	segment polarity protein dishevelled homolog DVL-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040327	level of guanine nucleotide-binding protein G(I)/G(S)/G(O) subunit gamma-T2 (human) in blood serum	PR:O14610	guanine nucleotide-binding protein G(I)/G(S)/G(O) subunit gamma-T2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040328	level of eukaryotic translation initiation factor 1A, Y-chromosomal (human) in blood serum	PR:O14602	eukaryotic translation initiation factor 1A, Y-chromosomal (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040329	level of neurocan core protein (human) in blood serum	PR:O14594	neurocan core protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040330	level of coatomer subunit epsilon (human) in blood serum	PR:O14579	coatomer subunit epsilon (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040331	level of heat shock protein beta-6 (human) in blood serum	PR:O14558	heat shock protein beta-6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040332	level of glyceraldehyde-3-phosphate dehydrogenase, testis-specific (human) in blood serum	PR:O14556	glyceraldehyde-3-phosphate dehydrogenase, testis-specific (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040333	level of cytochrome c oxidase subunit 7A-related protein, mitochondrial (human) in blood serum	PR:O14548	cytochrome c oxidase subunit 7A-related protein, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040334	level of suppressor of cytokine signaling 3 (human) in blood serum	PR:O14543	suppressor of cytokine signaling 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040335	level of dihydropyrimidinase-related protein 4 (human) in blood serum	PR:O14531	dihydropyrimidinase-related protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040336	level of phospholipid transfer protein C2CD2L (human) in blood serum	PR:O14523	phospholipid transfer protein C2CD2L (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040337	level of cyclin-dependent kinase 2-associated protein 1 (human) in blood serum	PR:O14519	cyclin-dependent kinase 2-associated protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040338	level of adhesion G protein-coupled receptor B1 (human) in blood serum	PR:O14514	adhesion G protein-coupled receptor B1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040339	level of syntaphilin (human) in blood serum	PR:O15079	syntaphilin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040340	level of serine/threonine-protein kinase DCLK1 (human) in blood serum	PR:O15075	serine/threonine-protein kinase DCLK1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040341	level of a disintegrin and metalloproteinase with thrombospondin motifs 3 (human) in blood serum	PR:O15072	a disintegrin and metalloproteinase with thrombospondin motifs 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040342	level of guanine nucleotide exchange factor DBS (human) in blood serum	PR:O15068	guanine nucleotide exchange factor DBS (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040343	level of kinesin-like protein KIF3B (human) in blood serum	PR:O15066	kinesin-like protein KIF3B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040344	level of microtubule-associated serine/threonine-protein kinase 4 (human) in blood serum	PR:O15021	microtubule-associated serine/threonine-protein kinase 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040345	level of Rho guanine nucleotide exchange factor 10 (human) in blood serum	PR:O15013	Rho guanine nucleotide exchange factor 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040346	level of synapsin-3 (human) in blood serum	PR:O14994	synapsin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040347	level of heterogeneous nuclear ribonucleoprotein D-like (human) in blood serum	PR:O14979	heterogeneous nuclear ribonucleoprotein D-like (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040348	level of zinc finger protein 263 (human) in blood serum	PR:O14978	zinc finger protein 263 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040349	level of antizyme inhibitor 1 (human) in blood serum	PR:O14977	antizyme inhibitor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040350	level of long-chain fatty acid transport protein 2 (human) in blood serum	PR:O14975	long-chain fatty acid transport protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040351	level of hepatocyte growth factor-regulated tyrosine kinase substrate (human) in blood serum	PR:O14964	hepatocyte growth factor-regulated tyrosine kinase substrate (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040352	level of leukocyte cell-derived chemotaxin-2 (human) in blood serum	PR:O14960	leukocyte cell-derived chemotaxin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040353	level of calsequestrin-2 (human) in blood serum	PR:O14958	calsequestrin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040354	level of myosin regulatory light chain 12B (human) in blood serum	PR:O14950	myosin regulatory light chain 12B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040355	level of peripheral plasma membrane protein CASK (human) in blood serum	PR:O14936	peripheral plasma membrane protein CASK (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040356	level of mitochondrial import inner membrane translocase subunit Tim23 (human) in blood serum	PR:O14925	mitochondrial import inner membrane translocase subunit Tim23 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040357	level of regulator of G-protein signaling 13 (human) in blood serum	PR:O14921	regulator of G-protein signaling 13 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040358	level of inhibitor of nuclear factor kappa-B kinase subunit beta (human) in blood serum	PR:O14920	inhibitor of nuclear factor kappa-B kinase subunit beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040359	level of protocadherin-17 (human) in blood serum	PR:O14917	protocadherin-17 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040360	level of protein lin-7 homolog A (human) in blood serum	PR:O14910	protein lin-7 homolog A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040361	level of PDZ domain-containing protein GIPC1 (human) in blood serum	PR:O14908	PDZ domain-containing protein GIPC1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040362	level of Tax1-binding protein 3 (human) in blood serum	PR:O14907	Tax1-binding protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040363	level of interferon regulatory factor 6 (human) in blood serum	PR:O14896	interferon regulatory factor 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040364	level of interferon-induced protein with tetratricopeptide repeats 3 (human) in blood serum	PR:O14879	interferon-induced protein with tetratricopeptide repeats 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040365	level of transcription regulator protein BACH1 (human) in blood serum	PR:O14867	transcription regulator protein BACH1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040366	level of interferon-inducible protein AIM2 (human) in blood serum	PR:O14862	interferon-inducible protein AIM2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040367	level of phytanoyl-CoA dioxygenase, peroxisomal (human) in blood serum	PR:O14832	phytanoyl-CoA dioxygenase, peroxisomal (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040368	level of proteasome subunit alpha type-7 (human) in blood serum	PR:O14818	proteasome subunit alpha type-7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040369	level of calpain-9 (human) in blood serum	PR:O14815	calpain-9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040370	level of chondroadherin (human) in blood serum	PR:O15335	chondroadherin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040371	level of inositol polyphosphate 4-phosphatase type II (human) in blood serum	PR:O15327	inositol polyphosphate 4-phosphatase type II (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040372	level of phosphomannomutase 2 (human) in blood serum	PR:O15305	phosphomannomutase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040373	level of protein phosphatase 1D (human) in blood serum	PR:O15297	protein phosphatase 1D (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040374	level of polyunsaturated fatty acid lipoxygenase ALOX15B (human) in blood serum	PR:O15296	polyunsaturated fatty acid lipoxygenase ALOX15B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040375	level of UDP-N-acetylglucosamine--peptide N-acetylglucosaminyltransferase 110 kDa subunit (human) in blood serum	PR:O15294	UDP-N-acetylglucosamine--peptide N-acetylglucosaminyltransferase 110 kDa subunit (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040376	level of telethonin (human) in blood serum	PR:O15273	telethonin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040377	level of serine palmitoyltransferase 2 (human) in blood serum	PR:O15270	serine palmitoyltransferase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040378	level of serine palmitoyltransferase 1 (human) in blood serum	PR:O15269	serine palmitoyltransferase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040379	level of short stature homeobox protein (human) in blood serum	PR:O15266	short stature homeobox protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040380	level of defensin beta 4A (human) in blood serum	PR:O15263	defensin beta 4A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040381	level of protein RER1 (human) in blood serum	PR:O15258	protein RER1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040382	level of chloride intracellular channel protein 2 (human) in blood serum	PR:O15247	chloride intracellular channel protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040383	level of kynurenine 3-monooxygenase (human) in blood serum	PR:O15229	kynurenine 3-monooxygenase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040384	level of glutathione S-transferase A4 (human) in blood serum	PR:O15217	glutathione S-transferase A4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040385	level of ubiquitin D (human) in blood serum	PR:O15205	ubiquitin D (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040386	level of ADAM DEC1 (human) in blood serum	PR:O15204	ADAM DEC1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040387	level of villin-like protein (human) in blood serum	PR:O15195	villin-like protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040388	level of CTD small phosphatase-like protein (human) in blood serum	PR:O15194	CTD small phosphatase-like protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040389	level of centrin-3 (human) in blood serum	PR:O15182	centrin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040390	level of membrane-associated progesterone receptor component 2 (human) in blood serum	PR:O15173	membrane-associated progesterone receptor component 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040391	level of low-density lipoprotein receptor class A domain-containing protein 4 (human) in blood serum	PR:O15165	low-density lipoprotein receptor class A domain-containing protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040392	level of DNA-directed RNA polymerases I and III subunit RPAC1 (human) in blood serum	PR:O15160	DNA-directed RNA polymerases I and III subunit RPAC1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040393	level of protein Mdm4 (human) in blood serum	PR:O15151	protein Mdm4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040394	level of muscle, skeletal receptor tyrosine-protein kinase (human) in blood serum	PR:O15146	muscle, skeletal receptor tyrosine-protein kinase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040395	level of actin-related protein 2/3 complex subunit 3 (human) in blood serum	PR:O15145	actin-related protein 2/3 complex subunit 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040396	level of actin-related protein 2/3 complex subunit 2 (human) in blood serum	PR:O15144	actin-related protein 2/3 complex subunit 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040397	level of importin subunit alpha-6 (human) in blood serum	PR:O15131	importin subunit alpha-6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040398	level of pro-FMRFamide-related neuropeptide FF (human) in blood serum	PR:O15130	pro-FMRFamide-related neuropeptide FF (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040399	level of T-box transcription factor TBX3 (human) in blood serum	PR:O15119	T-box transcription factor TBX3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040400	level of U6 snRNA-associated Sm-like protein LSm1 (human) in blood serum	PR:O15116	U6 snRNA-associated Sm-like protein LSm1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040401	level of homeobox protein Hox-C11 (human) in blood serum	PR:O43248	homeobox protein Hox-C11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040402	level of kallikrein-10 (human) in blood serum	PR:O43240	kallikrein-10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040403	level of cytoplasmic dynein 1 light intermediate chain 2 (human) in blood serum	PR:O43237	cytoplasmic dynein 1 light intermediate chain 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040404	level of Rho GTPase-activating protein 6 (human) in blood serum	PR:O43182	Rho GTPase-activating protein 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040405	level of NADH dehydrogenase [ubiquinone] iron-sulfur protein 4, mitochondrial (human) in blood serum	PR:O43181	NADH dehydrogenase [ubiquinone] iron-sulfur protein 4, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040406	level of D-3-phosphoglycerate dehydrogenase (human) in blood serum	PR:O43175	D-3-phosphoglycerate dehydrogenase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040407	level of sia-alpha-2,3-Gal-beta-1,4-GlcNAc-R:alpha 2,8-sialyltransferase (human) in blood serum	PR:O43173	sia-alpha-2,3-Gal-beta-1,4-GlcNAc-R:alpha 2,8-sialyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040408	level of Arf-GAP with SH3 domain, ANK repeat and PH domain-containing protein 2 (human) in blood serum	PR:O43150	Arf-GAP with SH3 domain, ANK repeat and PH domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040409	level of P2X purinoceptor 6 (human) in blood serum	PR:O15547	P2X purinoceptor 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040410	level of regulator of G-protein signaling 5 (human) in blood serum	PR:O15539	regulator of G-protein signaling 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040411	level of retinoschisin (human) in blood serum	PR:O15537	retinoschisin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040412	level of tapasin (human) in blood serum	PR:O15533	tapasin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040413	level of transcription factor MafG (human) in blood serum	PR:O15525	transcription factor MafG (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040414	level of actin-related protein 2/3 complex subunit 5 (human) in blood serum	PR:O15511	actin-related protein 2/3 complex subunit 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040415	level of insulin-induced gene 1 protein (human) in blood serum	PR:O15503	insulin-induced gene 1 protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040416	level of homeobox protein goosecoid-2 (human) in blood serum	PR:O15499	homeobox protein goosecoid-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040417	level of regulator of G-protein signaling 16 (human) in blood serum	PR:O15492	regulator of G-protein signaling 16 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040418	level of glycogenin-2 (human) in blood serum	PR:O15488	glycogenin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040419	level of prolyl 4-hydroxylase subunit alpha-2 (human) in blood serum	PR:O15460	prolyl 4-hydroxylase subunit alpha-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040420	level of Toll-like receptor 3 (human) in blood serum	PR:O15455	Toll-like receptor 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040421	level of monocarboxylate transporter 4 (human) in blood serum	PR:O15427	monocarboxylate transporter 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040422	level of TOX high mobility group box family member 3 (human) in blood serum	PR:O15405	TOX high mobility group box family member 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040423	level of syntaxin-7 (human) in blood serum	PR:O15400	syntaxin-7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040424	level of neural cell adhesion molecule 2 (human) in blood serum	PR:O15394	neural cell adhesion molecule 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040425	level of transcription factor YY2 (human) in blood serum	PR:O15391	transcription factor YY2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040426	level of sialic acid-binding Ig-like lectin 5 (human) in blood serum	PR:O15389	sialic acid-binding Ig-like lectin 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040427	level of branched-chain-amino-acid aminotransferase, mitochondrial (human) in blood serum	PR:O15382	branched-chain-amino-acid aminotransferase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040428	level of nuclear valosin-containing protein-like (human) in blood serum	PR:O15381	nuclear valosin-containing protein-like (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040429	level of protein phosphatase 1G (human) in blood serum	PR:O15355	protein phosphatase 1G (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040430	level of prosaposin receptor GPR37 (human) in blood serum	PR:O15354	prosaposin receptor GPR37 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040431	level of high mobility group protein B3 (human) in blood serum	PR:O15347	high mobility group protein B3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040432	level of E3 ubiquitin-protein ligase RNF13 (human) in blood serum	PR:O43567	E3 ubiquitin-protein ligase RNF13 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040433	level of regulator of G-protein signaling 14 (human) in blood serum	PR:O43566	regulator of G-protein signaling 14 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040434	level of linker for activation of T-cells family member 1 (human) in blood serum	PR:O43561	linker for activation of T-cells family member 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040435	level of progonadoliberin-2 (human) in blood serum	PR:O43555	progonadoliberin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040436	level of carbohydrate sulfotransferase 10 (human) in blood serum	PR:O43529	carbohydrate sulfotransferase 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040437	level of forkhead box protein O3 (human) in blood serum	PR:O43524	forkhead box protein O3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040438	level of DNA repair protein RAD51 homolog 3 (human) in blood serum	PR:O43502	DNA repair protein RAD51 homolog 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040439	level of prominin-1 (human) in blood serum	PR:O43490	prominin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040440	level of krueppel-like factor 4 (human) in blood serum	PR:O43474	krueppel-like factor 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040441	level of voltage-gated potassium channel subunit beta-3 (human) in blood serum	PR:O43448	voltage-gated potassium channel subunit beta-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040442	level of peptidyl-prolyl cis-trans isomerase H (human) in blood serum	PR:O43447	peptidyl-prolyl cis-trans isomerase H (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040443	level of eukaryotic translation initiation factor 4 gamma 3 (human) in blood serum	PR:O43432	eukaryotic translation initiation factor 4 gamma 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040444	level of acidic fibroblast growth factor intracellular-binding protein (human) in blood serum	PR:O43427	acidic fibroblast growth factor intracellular-binding protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040445	level of glutamate receptor ionotropic, delta-2 (human) in blood serum	PR:O43424	glutamate receptor ionotropic, delta-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040446	level of acidic leucine-rich nuclear phosphoprotein 32 family member C (human) in blood serum	PR:O43423	acidic leucine-rich nuclear phosphoprotein 32 family member C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040447	level of cochlin (human) in blood serum	PR:O43405	cochlin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040448	level of ER membrane protein complex subunit 8 (human) in blood serum	PR:O43402	ER membrane protein complex subunit 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040449	level of tumor protein D54 (human) in blood serum	PR:O43399	tumor protein D54 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040450	level of thioredoxin-like protein 1 (human) in blood serum	PR:O43396	thioredoxin-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040451	level of heterogeneous nuclear ribonucleoprotein R (human) in blood serum	PR:O43390	heterogeneous nuclear ribonucleoprotein R (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040452	level of receptor-interacting serine/threonine-protein kinase 2 (human) in blood serum	PR:O43353	receptor-interacting serine/threonine-protein kinase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040453	level of LYR motif-containing protein 1 (human) in blood serum	PR:O43325	LYR motif-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040454	level of eukaryotic translation elongation factor 1 epsilon-1 (human) in blood serum	PR:O43324	eukaryotic translation elongation factor 1 epsilon-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040455	level of paired box protein Pax-4 (human) in blood serum	PR:O43316	paired box protein Pax-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040456	level of leucine-rich repeat transmembrane neuronal protein 2 (human) in blood serum	PR:O43300	leucine-rich repeat transmembrane neuronal protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040457	level of zinc finger protein 264 (human) in blood serum	PR:O43296	zinc finger protein 264 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040458	level of death-associated protein kinase 3 (human) in blood serum	PR:O43293	death-associated protein kinase 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040459	level of beta-1,4-galactosyltransferase 5 (human) in blood serum	PR:O43286	beta-1,4-galactosyltransferase 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040460	level of embryonal Fyn-associated substrate (human) in blood serum	PR:O43281	embryonal Fyn-associated substrate (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040461	level of bifunctional 3'-phosphoadenosine 5'-phosphosulfate synthase 1 (human) in blood serum	PR:O43252	bifunctional 3'-phosphoadenosine 5'-phosphosulfate synthase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040462	level of RNA binding protein fox-1 homolog 2 (human) in blood serum	PR:O43251	RNA binding protein fox-1 homolog 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040463	level of glutathione S-transferase LANCL1 (human) in blood serum	PR:O43813	glutathione S-transferase LANCL1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040464	level of cleavage and polyadenylation specificity factor subunit 5 (human) in blood serum	PR:O43809	cleavage and polyadenylation specificity factor subunit 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040465	level of microtubule nucleation factor SSNA1 (human) in blood serum	PR:O43805	microtubule nucleation factor SSNA1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040466	level of speckle-type POZ protein (human) in blood serum	PR:O43791	speckle-type POZ protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040467	level of asparagine--tRNA ligase, cytoplasmic (human) in blood serum	PR:O43776	asparagine--tRNA ligase, cytoplasmic (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040468	level of synaptogyrin-3 (human) in blood serum	PR:O43761	synaptogyrin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040469	level of syntaxin-6 (human) in blood serum	PR:O43752	syntaxin-6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040470	level of cytohesin-3 (human) in blood serum	PR:O43739	cytohesin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040471	level of integral membrane protein 2A (human) in blood serum	PR:O43736	integral membrane protein 2A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040472	level of TP53-regulated inhibitor of apoptosis 1 (human) in blood serum	PR:O43715	TP53-regulated inhibitor of apoptosis 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040473	level of maleylacetoacetate isomerase (human) in blood serum	PR:O43708	maleylacetoacetate isomerase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040474	level of alpha-actinin-4 (human) in blood serum	PR:O43707	alpha-actinin-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040475	level of sulfotransferase 1B1 (human) in blood serum	PR:O43704	sulfotransferase 1B1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040476	level of peptidase inhibitor 15 (human) in blood serum	PR:O43692	peptidase inhibitor 15 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040477	level of A-kinase anchor protein 7 isoforms beta/alpha (human) in blood serum	PR:O43687	A-kinase anchor protein 7 isoforms beta/alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040478	level of mitotic checkpoint serine/threonine-protein kinase BUB1 (human) in blood serum	PR:O43683	mitotic checkpoint serine/threonine-protein kinase BUB1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040479	level of ATPase GET3 (human) in blood serum	PR:O43681	ATPase GET3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040480	level of transcription factor 21 (human) in blood serum	PR:O43680	transcription factor 21 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040481	level of LIM domain-binding protein 2 (human) in blood serum	PR:O43679	LIM domain-binding protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040482	level of NADH dehydrogenase [ubiquinone] 1 alpha subcomplex subunit 2 (human) in blood serum	PR:O43678	NADH dehydrogenase [ubiquinone] 1 alpha subcomplex subunit 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040483	level of regulator of G-protein signaling 10 (human) in blood serum	PR:O43665	regulator of G-protein signaling 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040484	level of protein regulator of cytokinesis 1 (human) in blood serum	PR:O43663	protein regulator of cytokinesis 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040485	level of cytoplasmic protein NCK2 (human) in blood serum	PR:O43639	cytoplasmic protein NCK2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040486	level of charged multivesicular body protein 2a (human) in blood serum	PR:O43633	charged multivesicular body protein 2a (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040487	level of zinc finger protein SNAI2 (human) in blood serum	PR:O43623	zinc finger protein SNAI2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040488	level of trafficking protein particle complex subunit 3 (human) in blood serum	PR:O43617	trafficking protein particle complex subunit 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040489	level of 2'-deoxynucleoside 5'-phosphate N-hydrolase 1 (human) in blood serum	PR:O43598	2'-deoxynucleoside 5'-phosphate N-hydrolase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040490	level of proline-serine-threonine phosphatase-interacting protein 1 (human) in blood serum	PR:O43586	proline-serine-threonine phosphatase-interacting protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040491	level of density-regulated protein (human) in blood serum	PR:O43583	density-regulated protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040492	level of synaptotagmin-7 (human) in blood serum	PR:O43581	synaptotagmin-7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040493	level of carbonic anhydrase 12 (human) in blood serum	PR:O43570	carbonic anhydrase 12 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040494	level of syntaxin-10 (human) in blood serum	PR:O60499	syntaxin-10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040495	level of docking protein 2 (human) in blood serum	PR:O60496	docking protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040496	level of cubilin (human) in blood serum	PR:O60494	cubilin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040497	level of sorting nexin-3 (human) in blood serum	PR:O60493	sorting nexin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040498	level of myelin protein zero-like protein 2 (human) in blood serum	PR:O60487	myelin protein zero-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040499	level of homeobox protein DLX-3 (human) in blood serum	PR:O60479	homeobox protein DLX-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040500	level of mannosyl-oligosaccharide 1,2-alpha-mannosidase IB (human) in blood serum	PR:O60476	mannosyl-oligosaccharide 1,2-alpha-mannosidase IB (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040501	level of neuropilin-2 (human) in blood serum	PR:O60462	neuropilin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040502	level of lymphocyte antigen 75 isoform 4 and LY75-CD302 fusion isoforms V34-2/V33-2 (human) in blood serum	PR:O60449	lymphocyte antigen 75 isoform 4 and LY75-CD302 fusion isoforms V34-2/V33-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040503	level of lysine-specific histone demethylase 1A (human) in blood serum	PR:O60341	lysine-specific histone demethylase 1A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040504	level of protocadherin gamma-A12 (human) in blood serum	PR:O60330	protocadherin gamma-A12 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040505	level of E3 ubiquitin-protein ligase parkin (human) in blood serum	PR:O60260	E3 ubiquitin-protein ligase parkin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040506	level of phosphoribosyl pyrophosphate synthase-associated protein 2 (human) in blood serum	PR:O60256	phosphoribosyl pyrophosphate synthase-associated protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040507	level of adhesion G protein-coupled receptor B3 (human) in blood serum	PR:O60242	adhesion G protein-coupled receptor B3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040508	level of adhesion G protein-coupled receptor B2 (human) in blood serum	PR:O60241	adhesion G protein-coupled receptor B2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040509	level of BCL2/adenovirus E1B 19 kDa protein-interacting protein 3-like (human) in blood serum	PR:O60238	BCL2/adenovirus E1B 19 kDa protein-interacting protein 3-like (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040510	level of transmembrane protease serine 11D (human) in blood serum	PR:O60235	transmembrane protease serine 11D (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040511	level of protein SSX4 (human) in blood serum	PR:O60224	protein SSX4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040512	level of mitochondrial import inner membrane translocase subunit Tim8 A (human) in blood serum	PR:O60220	mitochondrial import inner membrane translocase subunit Tim8 A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040513	level of aldo-keto reductase family 1 member B10 (human) in blood serum	PR:O60218	aldo-keto reductase family 1 member B10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040514	level of retinal rod rhodopsin-sensitive cGMP 3',5'-cyclic phosphodiesterase subunit delta (human) in blood serum	PR:O43924	retinal rod rhodopsin-sensitive cGMP 3',5'-cyclic phosphodiesterase subunit delta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040515	level of carbohydrate sulfotransferase 1 (human) in blood serum	PR:O43916	carbohydrate sulfotransferase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040516	level of NKG2-F type II integral membrane protein (human) in blood serum	PR:O43908	NKG2-F type II integral membrane protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040517	level of growth arrest-specific protein 2 (human) in blood serum	PR:O43903	growth arrest-specific protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040518	level of tolloid-like protein 1 (human) in blood serum	PR:O43897	tolloid-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040519	level of kinesin-like protein KIF1C (human) in blood serum	PR:O43896	kinesin-like protein KIF1C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040520	level of S-adenosylhomocysteine hydrolase-like protein 1 (human) in blood serum	PR:O43865	S-adenosylhomocysteine hydrolase-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040521	level of EGF-like repeat and discoidin I-like domain-containing protein 3 (human) in blood serum	PR:O43854	EGF-like repeat and discoidin I-like domain-containing protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040522	level of angiopoietin-related protein 7 (human) in blood serum	PR:O43827	angiopoietin-related protein 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040523	level of beta-1,3-galactosyltransferase 2 (human) in blood serum	PR:O43825	beta-1,3-galactosyltransferase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040524	level of protein SCO2 homolog, mitochondrial (human) in blood serum	PR:O43819	protein SCO2 homolog, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040525	level of P antigen family member 4 (human) in blood serum	PR:O60829	P antigen family member 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040526	level of polyglutamine-binding protein 1 (human) in blood serum	PR:O60828	polyglutamine-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040527	level of target of Myb1 membrane trafficking protein (human) in blood serum	PR:O60784	target of Myb1 membrane trafficking protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040528	level of 28S ribosomal protein S14, mitochondrial (human) in blood serum	PR:O60783	28S ribosomal protein S14, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040529	level of general vesicular transport factor p115 (human) in blood serum	PR:O60763	general vesicular transport factor p115 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040530	level of hematopoietic prostaglandin D synthase (human) in blood serum	PR:O60760	hematopoietic prostaglandin D synthase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040531	level of cytohesin-interacting protein (human) in blood serum	PR:O60759	cytohesin-interacting protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040532	level of potassium/sodium hyperpolarization-activated cyclic nucleotide-gated channel 1 (human) in blood serum	PR:O60741	potassium/sodium hyperpolarization-activated cyclic nucleotide-gated channel 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040533	level of protein-tyrosine sulfotransferase 2 (human) in blood serum	PR:O60704	protein-tyrosine sulfotransferase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040534	level of UDP-glucose 6-dehydrogenase (human) in blood serum	PR:O60701	UDP-glucose 6-dehydrogenase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040535	level of importin subunit alpha-7 (human) in blood serum	PR:O60684	importin subunit alpha-7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040536	level of musculin (human) in blood serum	PR:O60682	musculin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040537	level of protein arginine N-methyltransferase 3 (human) in blood serum	PR:O60678	protein arginine N-methyltransferase 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040538	level of cystatin-8 (human) in blood serum	PR:O60676	cystatin-8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040539	level of cell cycle checkpoint protein RAD1 (human) in blood serum	PR:O60671	cell cycle checkpoint protein RAD1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040540	level of Fas apoptotic inhibitory molecule 3 (human) in blood serum	PR:O60667	Fas apoptotic inhibitory molecule 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040541	level of perilipin-3 (human) in blood serum	PR:O60664	perilipin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040542	level of kelch-like protein 41 (human) in blood serum	PR:O60662	kelch-like protein 41 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040543	level of selenoprotein F (human) in blood serum	PR:O60613	selenoprotein F (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040544	level of protein diaphanous homolog 1 (human) in blood serum	PR:O60610	protein diaphanous homolog 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040545	level of Toll-like receptor 5 (human) in blood serum	PR:O60602	Toll-like receptor 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040546	level of serine protease inhibitor Kazal-type 4 (human) in blood serum	PR:O60575	serine protease inhibitor Kazal-type 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040547	level of eukaryotic translation initiation factor 4E type 2 (human) in blood serum	PR:O60573	eukaryotic translation initiation factor 4E type 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040548	level of multifunctional procollagen lysine hydroxylase and glycosyltransferase LH3 (human) in blood serum	PR:O60568	multifunctional procollagen lysine hydroxylase and glycosyltransferase LH3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040549	level of glycylpeptide N-tetradecanoyltransferase 2 (human) in blood serum	PR:O60551	glycylpeptide N-tetradecanoyltransferase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040550	level of GDP-mannose 4,6 dehydratase (human) in blood serum	PR:O60547	GDP-mannose 4,6 dehydratase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040551	level of cAMP-responsive element-binding protein-like 2 (human) in blood serum	PR:O60519	cAMP-responsive element-binding protein-like 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040552	level of eukaryotic translation initiation factor 4E-binding protein 3 (human) in blood serum	PR:O60516	eukaryotic translation initiation factor 4E-binding protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040553	level of beta-1,4-galactosyltransferase 3 (human) in blood serum	PR:O60512	beta-1,4-galactosyltransferase 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040554	level of protein-tyrosine sulfotransferase 1 (human) in blood serum	PR:O60507	protein-tyrosine sulfotransferase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040555	level of vinexin (human) in blood serum	PR:O60504	vinexin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040556	level of low-density lipoprotein receptor-related protein 4 (human) in blood serum	PR:O75096	low-density lipoprotein receptor-related protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040557	level of slit homolog 3 protein (human) in blood serum	PR:O75094	slit homolog 3 protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040558	level of slit homolog 1 protein (human) in blood serum	PR:O75093	slit homolog 1 protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040559	level of frizzled-7 (human) in blood serum	PR:O75084	frizzled-7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040560	level of disintegrin and metalloproteinase domain-containing protein 11 (human) in blood serum	PR:O75078	disintegrin and metalloproteinase domain-containing protein 11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040561	level of disintegrin and metalloproteinase domain-containing protein 23 (human) in blood serum	PR:O75077	disintegrin and metalloproteinase domain-containing protein 23 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040562	level of glycosaminoglycan xylosylkinase (human) in blood serum	PR:O75063	glycosaminoglycan xylosylkinase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040563	level of immunoglobulin superfamily member 3 (human) in blood serum	PR:O75054	immunoglobulin superfamily member 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040564	level of SLIT-ROBO Rho GTPase-activating protein 2 (human) in blood serum	PR:O75044	SLIT-ROBO Rho GTPase-activating protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040565	level of heat shock factor 2-binding protein (human) in blood serum	PR:O75031	heat shock factor 2-binding protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040566	level of microphthalmia-associated transcription factor (human) in blood serum	PR:O75030	microphthalmia-associated transcription factor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040567	level of leukocyte immunoglobulin-like receptor subfamily B member 5 (human) in blood serum	PR:O75023	leukocyte immunoglobulin-like receptor subfamily B member 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040568	level of leukocyte immunoglobulin-like receptor subfamily B member 3 (human) in blood serum	PR:O75022	leukocyte immunoglobulin-like receptor subfamily B member 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040569	level of leukocyte immunoglobulin-like receptor subfamily A member 1 (human) in blood serum	PR:O75019	leukocyte immunoglobulin-like receptor subfamily A member 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040570	level of mRNA-capping enzyme (human) in blood serum	PR:O60942	mRNA-capping enzyme (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040571	level of sodium channel subunit beta-2 (human) in blood serum	PR:O60939	sodium channel subunit beta-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040572	level of keratocan (human) in blood serum	PR:O60938	keratocan (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040573	level of prefoldin subunit 1 (human) in blood serum	PR:O60925	prefoldin subunit 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040574	level of checkpoint protein HUS1 (human) in blood serum	PR:O60921	checkpoint protein HUS1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040575	level of beta-1,4-galactosyltransferase 2 (human) in blood serum	PR:O60909	beta-1,4-galactosyltransferase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040576	level of receptor activity-modifying protein 3 (human) in blood serum	PR:O60896	receptor activity-modifying protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040577	level of receptor activity-modifying protein 1 (human) in blood serum	PR:O60894	receptor activity-modifying protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040578	level of oligophrenin-1 (human) in blood serum	PR:O60890	oligophrenin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040579	level of protein CutA (human) in blood serum	PR:O60888	protein CutA (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040580	level of bromodomain-containing protein 4 (human) in blood serum	PR:O60885	bromodomain-containing protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040581	level of DnaJ homolog subfamily A member 2 (human) in blood serum	PR:O60884	DnaJ homolog subfamily A member 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040582	level of matrix metalloproteinase-20 (human) in blood serum	PR:O60882	matrix metalloproteinase-20 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040583	level of DNA/RNA-binding protein KIN17 (human) in blood serum	PR:O60870	DNA/RNA-binding protein KIN17 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040584	level of endothelial differentiation-related factor 1 (human) in blood serum	PR:O60869	endothelial differentiation-related factor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040585	level of growth arrest-specific protein 7 (human) in blood serum	PR:O60861	growth arrest-specific protein 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040586	level of zymogen granule membrane protein 16 (human) in blood serum	PR:O60844	zymogen granule membrane protein 16 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040587	level of vacuolar protein sorting-associated protein 26A (human) in blood serum	PR:O75436	vacuolar protein sorting-associated protein 26A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040588	level of metaxin-2 (human) in blood serum	PR:O75431	metaxin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040589	level of deformed epidermal autoregulatory factor 1 homolog (human) in blood serum	PR:O75398	deformed epidermal autoregulatory factor 1 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040590	level of 39S ribosomal protein L33, mitochondrial (human) in blood serum	PR:O75394	39S ribosomal protein L33, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040591	level of sperm-associated antigen 7 (human) in blood serum	PR:O75391	sperm-associated antigen 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040592	level of citrate synthase, mitochondrial (human) in blood serum	PR:O75390	citrate synthase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040593	level of tripartite motif-containing protein 3 (human) in blood serum	PR:O75382	tripartite motif-containing protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040594	level of vesicle-associated membrane protein 4 (human) in blood serum	PR:O75379	vesicle-associated membrane protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040595	level of adapter SH3BGRL (human) in blood serum	PR:O75368	adapter SH3BGRL (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040596	level of core histone macro-H2A.1 (human) in blood serum	PR:O75367	core histone macro-H2A.1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040597	level of protein tyrosine phosphatase type IVA 3 (human) in blood serum	PR:O75365	protein tyrosine phosphatase type IVA 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040598	level of pituitary homeobox 3 (human) in blood serum	PR:O75364	pituitary homeobox 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040599	level of ectonucleoside triphosphate diphosphohydrolase 6 (human) in blood serum	PR:O75354	ectonucleoside triphosphate diphosphohydrolase 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040600	level of vacuolar protein sorting-associated protein 4B (human) in blood serum	PR:O75351	vacuolar protein sorting-associated protein 4B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040601	level of tubulin-specific chaperone A (human) in blood serum	PR:O75347	tubulin-specific chaperone A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040602	level of inactive peptidyl-prolyl cis-trans isomerase FKBP6 (human) in blood serum	PR:O75344	inactive peptidyl-prolyl cis-trans isomerase FKBP6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040603	level of programmed cell death protein 6 (human) in blood serum	PR:O75340	programmed cell death protein 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040604	level of cartilage intermediate layer protein 1 (human) in blood serum	PR:O75339	cartilage intermediate layer protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040605	level of semaphorin-7A (human) in blood serum	PR:O75326	semaphorin-7A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040606	level of ubiquitin carboxyl-terminal hydrolase 12 (human) in blood serum	PR:O75317	ubiquitin carboxyl-terminal hydrolase 12 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040607	level of small integral membrane protein 24 (human) in blood serum	PR:O75264	small integral membrane protein 24 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040608	level of gamma-glutamylcyclotransferase (human) in blood serum	PR:O75223	gamma-glutamylcyclotransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040609	level of low-density lipoprotein receptor-related protein 5 (human) in blood serum	PR:O75197	low-density lipoprotein receptor-related protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040610	level of xylulose kinase (human) in blood serum	PR:O75191	xylulose kinase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040611	level of DnaJ homolog subfamily B member 6 (human) in blood serum	PR:O75190	DnaJ homolog subfamily B member 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040612	level of Rab11 family-interacting protein 3 (human) in blood serum	PR:O75154	Rab11 family-interacting protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040613	level of clustered mitochondria protein homolog (human) in blood serum	PR:O75153	clustered mitochondria protein homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040614	level of huntingtin-interacting protein 1-related protein (human) in blood serum	PR:O75146	huntingtin-interacting protein 1-related protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040615	level of microfibrillar-associated protein 3-like (human) in blood serum	PR:O75121	microfibrillar-associated protein 3-like (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040616	level of Rho-associated protein kinase 2 (human) in blood serum	PR:O75116	Rho-associated protein kinase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040617	level of retina-specific copper amine oxidase (human) in blood serum	PR:O75106	retina-specific copper amine oxidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040618	level of eukaryotic translation initiation factor 3 subunit G (human) in blood serum	PR:O75821	eukaryotic translation initiation factor 3 subunit G (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040619	level of ribonuclease P protein subunit p40 (human) in blood serum	PR:O75818	ribonuclease P protein subunit p40 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040620	level of paralemmin-1 (human) in blood serum	PR:O75781	paralemmin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040621	level of DNA repair protein RAD51 homolog 4 (human) in blood serum	PR:O75771	DNA repair protein RAD51 homolog 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040622	level of transcription elongation factor A protein 3 (human) in blood serum	PR:O75764	transcription elongation factor A protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040623	level of epididymal secretory glutathione peroxidase (human) in blood serum	PR:O75715	epididymal secretory glutathione peroxidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040624	level of protein phosphatase 1B (human) in blood serum	PR:O75688	protein phosphatase 1B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040625	level of ret finger protein-like 3 (human) in blood serum	PR:O75679	ret finger protein-like 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040626	level of TOM1-like protein 1 (human) in blood serum	PR:O75674	TOM1-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040627	level of TIP41-like protein (human) in blood serum	PR:O75663	TIP41-like protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040628	level of protein CREG1 (human) in blood serum	PR:O75629	protein CREG1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040629	level of GTP-binding protein REM 1 (human) in blood serum	PR:O75628	GTP-binding protein REM 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040630	level of PR domain zinc finger protein 1 (human) in blood serum	PR:O75626	PR domain zinc finger protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040631	level of ubiquitin carboxyl-terminal hydrolase 2 (human) in blood serum	PR:O75604	ubiquitin carboxyl-terminal hydrolase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040632	level of low-density lipoprotein receptor-related protein 6 (human) in blood serum	PR:O75581	low-density lipoprotein receptor-related protein 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040633	level of DNA-directed RNA polymerase III subunit RPC9 (human) in blood serum	PR:O75575	DNA-directed RNA polymerase III subunit RPC9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040634	level of interferon-inducible double-stranded RNA-dependent protein kinase activator A (human) in blood serum	PR:O75569	interferon-inducible double-stranded RNA-dependent protein kinase activator A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040635	level of cold shock domain-containing protein E1 (human) in blood serum	PR:O75534	cold shock domain-containing protein E1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040636	level of polycomb protein EED (human) in blood serum	PR:O75530	polycomb protein EED (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040637	level of transcriptional adapter 3 (human) in blood serum	PR:O75528	transcriptional adapter 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040638	level of enoyl-CoA Delta isomerase 2 (human) in blood serum	PR:O75521	enoyl-CoA Delta isomerase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040639	level of geminin (human) in blood serum	PR:O75496	geminin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040640	level of glypican-4 (human) in blood serum	PR:O75487	glypican-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040641	level of transcriptional adapter 2-alpha (human) in blood serum	PR:O75478	transcriptional adapter 2-alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040642	level of erlin-1 (human) in blood serum	PR:O75477	erlin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040643	level of PC4 and SFRS1-interacting protein (human) in blood serum	PR:O75475	PC4 and SFRS1-interacting protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040644	level of leucine-rich repeat-containing G-protein coupled receptor 5 (human) in blood serum	PR:O75473	leucine-rich repeat-containing G-protein coupled receptor 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040645	level of cytokine receptor-like factor 1 (human) in blood serum	PR:O75462	cytokine receptor-like factor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040646	level of serine/threonine-protein kinase/endoribonuclease IRE1 (human) in blood serum	PR:O75460	serine/threonine-protein kinase/endoribonuclease IRE1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040647	level of retinol dehydrogenase 16 (human) in blood serum	PR:O75452	retinol dehydrogenase 16 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040648	level of histone deacetylase complex subunit SAP30 (human) in blood serum	PR:O75446	histone deacetylase complex subunit SAP30 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040649	level of probable cytosolic iron-sulfur protein assembly protein CIAO1 (human) in blood serum	PR:O76071	probable cytosolic iron-sulfur protein assembly protein CIAO1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040650	level of gamma-synuclein (human) in blood serum	PR:O76070	gamma-synuclein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040651	level of E3 ubiquitin-protein ligase RNF8 (human) in blood serum	PR:O76064	E3 ubiquitin-protein ligase RNF8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040652	level of stanniocalcin-2 (human) in blood serum	PR:O76061	stanniocalcin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040653	level of E3 ubiquitin-protein ligase NEURL1 (human) in blood serum	PR:O76050	E3 ubiquitin-protein ligase NEURL1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040654	level of secretagogin (human) in blood serum	PR:O76038	secretagogin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040655	level of annexin A9 (human) in blood serum	PR:O76027	annexin A9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040656	level of keratin, type I cuticular Ha4 (human) in blood serum	PR:O76011	keratin, type I cuticular Ha4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040657	level of glutaredoxin-3 (human) in blood serum	PR:O76003	glutaredoxin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040658	level of carboxypeptidase D (human) in blood serum	PR:O75976	carboxypeptidase D (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040659	level of C1q-related factor (human) in blood serum	PR:O75973	C1q-related factor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040660	level of multiple PDZ domain protein (human) in blood serum	PR:O75970	multiple PDZ domain protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040661	level of triple functional domain protein (human) in blood serum	PR:O75962	triple functional domain protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040662	level of cyclin-dependent kinase 2-associated protein 2 (human) in blood serum	PR:O75956	cyclin-dependent kinase 2-associated protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040663	level of survival of motor neuron-related-splicing factor 30 (human) in blood serum	PR:O75940	survival of motor neuron-related-splicing factor 30 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040664	level of small EDRK-rich factor 1 (human) in blood serum	PR:O75920	small EDRK-rich factor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040665	level of PRA1 family protein 3 (human) in blood serum	PR:O75915	PRA1 family protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040666	level of short-chain dehydrogenase/reductase 3 (human) in blood serum	PR:O75911	short-chain dehydrogenase/reductase 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040667	level of sulfotransferase 1C4 (human) in blood serum	PR:O75897	sulfotransferase 1C4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040668	level of serine hydrolase RBBP9 (human) in blood serum	PR:O75884	serine hydrolase RBBP9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040669	level of attractin (human) in blood serum	PR:O75882	attractin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040670	level of protein SCO1 homolog, mitochondrial (human) in blood serum	PR:O75880	protein SCO1 homolog, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040671	level of isocitrate dehydrogenase [NADP] cytoplasmic (human) in blood serum	PR:O75874	isocitrate dehydrogenase [NADP] cytoplasmic (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040672	level of carcinoembryonic antigen-related cell adhesion molecule 4 (human) in blood serum	PR:O75871	carcinoembryonic antigen-related cell adhesion molecule 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040673	level of trafficking protein particle complex subunit 6A (human) in blood serum	PR:O75865	trafficking protein particle complex subunit 6A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040674	level of AP-1 complex subunit gamma-like 2 (human) in blood serum	PR:O75843	AP-1 complex subunit gamma-like 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040675	level of 26S proteasome non-ATPase regulatory subunit 10 (human) in blood serum	PR:O75832	26S proteasome non-ATPase regulatory subunit 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040676	level of serpin I2 (human) in blood serum	PR:O75830	serpin I2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040677	level of leukocyte cell-derived chemotaxin 1 (human) in blood serum	PR:O75829	leukocyte cell-derived chemotaxin 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040678	level of carbonyl reductase [NADPH] 3 (human) in blood serum	PR:O75828	carbonyl reductase [NADPH] 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040679	level of eukaryotic translation initiation factor 3 subunit J (human) in blood serum	PR:O75822	eukaryotic translation initiation factor 3 subunit J (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040680	level of elongator complex protein 1 (human) in blood serum	PR:O95163	elongator complex protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040681	level of neurexophilin-2 (human) in blood serum	PR:O95156	neurexophilin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040682	level of aflatoxin B1 aldehyde reductase member 3 (human) in blood serum	PR:O95154	aflatoxin B1 aldehyde reductase member 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040683	level of snurportin-1 (human) in blood serum	PR:O95149	snurportin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040684	level of Arf-GAP domain and FG repeat-containing protein 2 (human) in blood serum	PR:O95081	Arf-GAP domain and FG repeat-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040685	level of G2/mitotic-specific cyclin-B2 (human) in blood serum	PR:O95067	G2/mitotic-specific cyclin-B2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040686	level of GTP-binding protein Di-Ras1 (human) in blood serum	PR:O95057	GTP-binding protein Di-Ras1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040687	level of uridine phosphorylase 2 (human) in blood serum	PR:O95045	uridine phosphorylase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040688	level of protein HEXIM1 (human) in blood serum	PR:O94992	protein HEXIM1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040689	level of calsyntenin-1 (human) in blood serum	PR:O94985	calsyntenin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040690	level of AP-2 complex subunit alpha-2 (human) in blood serum	PR:O94973	AP-2 complex subunit alpha-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040691	level of ubiquitin carboxyl-terminal hydrolase 19 (human) in blood serum	PR:O94966	ubiquitin carboxyl-terminal hydrolase 19 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040692	level of SLIT and NTRK-like protein 3 (human) in blood serum	PR:O94933	SLIT and NTRK-like protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040693	level of actin-binding LIM protein 3 (human) in blood serum	PR:O94929	actin-binding LIM protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040694	level of glutaminase kidney isoform, mitochondrial (human) in blood serum	PR:O94925	glutaminase kidney isoform, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040695	level of D-glucuronyl C5-epimerase (human) in blood serum	PR:O94923	D-glucuronyl C5-epimerase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040696	level of pyridoxal phosphate homeostasis protein (human) in blood serum	PR:O94903	pyridoxal phosphate homeostasis protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040697	level of neurofascin (human) in blood serum	PR:O94856	neurofascin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040698	level of phospholipase DDHD2 (human) in blood serum	PR:O94830	phospholipase DDHD2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040699	level of kelch repeat and BTB domain-containing protein 11 (human) in blood serum	PR:O94819	kelch repeat and BTB domain-containing protein 11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040700	level of slit homolog 2 protein (human) in blood serum	PR:O94813	slit homolog 2 protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040701	level of tubulin polymerization-promoting protein (human) in blood serum	PR:O94811	tubulin polymerization-promoting protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040702	level of glutamine--fructose-6-phosphate aminotransferase [isomerizing] 2 (human) in blood serum	PR:O94808	glutamine--fructose-6-phosphate aminotransferase [isomerizing] 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040703	level of serine/threonine-protein kinase 10 (human) in blood serum	PR:O94804	serine/threonine-protein kinase 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040704	level of retinal dehydrogenase 2 (human) in blood serum	PR:O94788	retinal dehydrogenase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040705	level of ubiquitin carboxyl-terminal hydrolase 1 (human) in blood serum	PR:O94782	ubiquitin carboxyl-terminal hydrolase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040706	level of galactosylgalactosylxylosylprotein 3-beta-glucuronosyltransferase 3 (human) in blood serum	PR:O94766	galactosylgalactosylxylosylprotein 3-beta-glucuronosyltransferase 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040707	level of N(G),N(G)-dimethylarginine dimethylaminohydrolase 1 (human) in blood serum	PR:O94760	N(G),N(G)-dimethylarginine dimethylaminohydrolase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040708	level of protein JTB (human) in blood serum	PR:O76095	protein JTB (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040709	level of AN1-type zinc finger protein 5 (human) in blood serum	PR:O76080	AN1-type zinc finger protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040710	level of CCN family member 5 (human) in blood serum	PR:O76076	CCN family member 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040711	level of pantetheine hydrolase VNN2 (human) in blood serum	PR:O95498	pantetheine hydrolase VNN2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040712	level of GDH/6PGL endoplasmic bifunctional protein (human) in blood serum	PR:O95479	GDH/6PGL endoplasmic bifunctional protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040713	level of homeobox protein SIX6 (human) in blood serum	PR:O95475	homeobox protein SIX6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040714	level of xylosyl- and glucuronyltransferase LARGE1 (human) in blood serum	PR:O95461	xylosyl- and glucuronyltransferase LARGE1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040715	level of matrilin-4 (human) in blood serum	PR:O95460	matrilin-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040716	level of activator of 90 kDa heat shock protein ATPase homolog 1 (human) in blood serum	PR:O95433	activator of 90 kDa heat shock protein ATPase homolog 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040717	level of BAG family molecular chaperone regulator 4 (human) in blood serum	PR:O95429	BAG family molecular chaperone regulator 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040718	level of papilin (human) in blood serum	PR:O95428	papilin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040719	level of urotensin-2 (human) in blood serum	PR:O95399	urotensin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040720	level of adenylyltransferase and sulfurtransferase MOCS3 (human) in blood serum	PR:O95396	adenylyltransferase and sulfurtransferase MOCS3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040721	level of tumor necrosis factor alpha-induced protein 8 (human) in blood serum	PR:O95379	tumor necrosis factor alpha-induced protein 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040722	level of zinc finger and BTB domain-containing protein 7A (human) in blood serum	PR:O95365	zinc finger and BTB domain-containing protein 7A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040723	level of phenylalanine--tRNA ligase, mitochondrial (human) in blood serum	PR:O95363	phenylalanine--tRNA ligase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040724	level of 6-phosphogluconolactonase (human) in blood serum	PR:O95336	6-phosphogluconolactonase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040725	level of CUGBP Elav-like family member 2 (human) in blood serum	PR:O95319	CUGBP Elav-like family member 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040726	level of myelin protein zero-like protein 1 (human) in blood serum	PR:O95297	myelin protein zero-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040727	level of SNARE-associated protein Snapin (human) in blood serum	PR:O95295	SNARE-associated protein Snapin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040728	level of vesicle-associated membrane protein-associated protein B/C (human) in blood serum	PR:O95292	vesicle-associated membrane protein-associated protein B/C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040729	level of poly [ADP-ribose] polymerase tankyrase-1 (human) in blood serum	PR:O95271	poly [ADP-ribose] polymerase tankyrase-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040730	level of arginyl-tRNA--protein transferase 1 (human) in blood serum	PR:O95260	arginyl-tRNA--protein transferase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040731	level of interleukin-18 receptor accessory protein (human) in blood serum	PR:O95256	interleukin-18 receptor accessory protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040732	level of ATP-binding cassette sub-family C member 6 (human) in blood serum	PR:O95255	ATP-binding cassette sub-family C member 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040733	level of Golgi SNAP receptor complex member 1 (human) in blood serum	PR:O95249	Golgi SNAP receptor complex member 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040734	level of SAM pointed domain-containing Ets transcription factor (human) in blood serum	PR:O95238	SAM pointed domain-containing Ets transcription factor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040735	level of apolipoprotein L3 (human) in blood serum	PR:O95236	apolipoprotein L3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040736	level of ZW10 interactor (human) in blood serum	PR:O95229	ZW10 interactor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040737	level of protocadherin-8 (human) in blood serum	PR:O95206	protocadherin-8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040738	level of kelch-like protein 2 (human) in blood serum	PR:O95198	kelch-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040739	level of NADH dehydrogenase [ubiquinone] 1 beta subcomplex subunit 8, mitochondrial (human) in blood serum	PR:O95169	NADH dehydrogenase [ubiquinone] 1 beta subcomplex subunit 8, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040740	level of gamma-aminobutyric acid receptor-associated protein (human) in blood serum	PR:O95166	gamma-aminobutyric acid receptor-associated protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040741	level of ubiquitin-like protein 3 (human) in blood serum	PR:O95164	ubiquitin-like protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040742	level of lymphocyte antigen 6 complex locus protein G6c (human) in blood serum	PR:O95867	lymphocyte antigen 6 complex locus protein G6c (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040743	level of 3'(2'),5'-bisphosphate nucleotidase 1 (human) in blood serum	PR:O95861	3'(2'),5'-bisphosphate nucleotidase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040744	level of uridine diphosphate glucose pyrophosphatase NUDT14 (human) in blood serum	PR:O95848	uridine diphosphate glucose pyrophosphatase NUDT14 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040745	level of echinoderm microtubule-associated protein-like 2 (human) in blood serum	PR:O95834	echinoderm microtubule-associated protein-like 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040746	level of chloride intracellular channel protein 3 (human) in blood serum	PR:O95833	chloride intracellular channel protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040747	level of claudin-1 (human) in blood serum	PR:O95832	claudin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040748	level of apoptosis-inducing factor 1, mitochondrial (human) in blood serum	PR:O95831	apoptosis-inducing factor 1, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040749	level of malonyl-CoA decarboxylase, mitochondrial (human) in blood serum	PR:O95822	malonyl-CoA decarboxylase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040750	level of BAG family molecular chaperone regulator 3 (human) in blood serum	PR:O95817	BAG family molecular chaperone regulator 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040751	level of BAG family molecular chaperone regulator 2 (human) in blood serum	PR:O95816	BAG family molecular chaperone regulator 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040752	level of cerberus (human) in blood serum	PR:O95813	cerberus (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040753	level of double-stranded RNA-binding protein Staufen homolog 1 (human) in blood serum	PR:O95793	double-stranded RNA-binding protein Staufen homolog 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040754	level of antiviral innate immune response receptor RIG-I (human) in blood serum	PR:O95786	antiviral innate immune response receptor RIG-I (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040755	level of semaphorin-4F (human) in blood serum	PR:O95754	semaphorin-4F (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040756	level of protein LDOC1 (human) in blood serum	PR:O95751	protein LDOC1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040757	level of geranylgeranyl pyrophosphate synthase (human) in blood serum	PR:O95749	geranylgeranyl pyrophosphate synthase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040758	level of serine/threonine-protein kinase OSR1 (human) in blood serum	PR:O95747	serine/threonine-protein kinase OSR1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040759	level of copine-6 (human) in blood serum	PR:O95741	copine-6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040760	level of synaptosomal-associated protein 29 (human) in blood serum	PR:O95721	synaptosomal-associated protein 29 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040761	level of Ras-related protein Rab-3D (human) in blood serum	PR:O95716	Ras-related protein Rab-3D (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040762	level of C-X-C motif chemokine 14 (human) in blood serum	PR:O95715	C-X-C motif chemokine 14 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040763	level of bromodomain-containing protein 1 (human) in blood serum	PR:O95696	bromodomain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040764	level of centrosomal protein 43 (human) in blood serum	PR:O95684	centrosomal protein 43 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040765	level of endothelin-converting enzyme-like 1 (human) in blood serum	PR:O95672	endothelin-converting enzyme-like 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040766	level of probable bifunctional dTTP/UTP pyrophosphatase/methyltransferase protein (human) in blood serum	PR:O95671	probable bifunctional dTTP/UTP pyrophosphatase/methyltransferase protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040767	level of GTP-binding protein Di-Ras3 (human) in blood serum	PR:O95661	GTP-binding protein Di-Ras3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040768	level of nuclear factor of activated T-cells, cytoplasmic 1 (human) in blood serum	PR:O95644	nuclear factor of activated T-cells, cytoplasmic 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040769	level of STAM-binding protein (human) in blood serum	PR:O95630	STAM-binding protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040770	level of YEATS domain-containing protein 4 (human) in blood serum	PR:O95619	YEATS domain-containing protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040771	level of NAD kinase (human) in blood serum	PR:O95544	NAD kinase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040772	level of neuronal pentraxin receptor (human) in blood serum	PR:O95502	neuronal pentraxin receptor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040773	level of aspartate aminotransferase, mitochondrial (human) in blood serum	PR:P00505	aspartate aminotransferase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040774	level of hypoxanthine-guanine phosphoribosyltransferase (human) in blood serum	PR:P00492	hypoxanthine-guanine phosphoribosyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040775	level of purine nucleoside phosphorylase (human) in blood serum	PR:P00491	purine nucleoside phosphorylase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040776	level of coagulation factor XIII A chain (human) in blood serum	PR:P00488	coagulation factor XIII A chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040777	level of ornithine transcarbamylase, mitochondrial (human) in blood serum	PR:P00480	ornithine transcarbamylase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040778	level of coagulation factor VIII (human) in blood serum	PR:P00451	coagulation factor VIII (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040779	level of ceruloplasmin (human) in blood serum	PR:P00450	ceruloplasmin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040780	level of superoxide dismutase [Cu-Zn] (human) in blood serum	PR:P00441	superoxide dismutase [Cu-Zn] (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040781	level of glutathione reductase, mitochondrial (human) in blood serum	PR:P00390	glutathione reductase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040782	level of NADH-cytochrome b5 reductase 3 (human) in blood serum	PR:P00387	NADH-cytochrome b5 reductase 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040783	level of dihydrofolate reductase (human) in blood serum	PR:P00374	dihydrofolate reductase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040784	level of glutamate dehydrogenase 1, mitochondrial (human) in blood serum	PR:P00367	glutamate dehydrogenase 1, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040785	level of aldehyde dehydrogenase 1A1 (human) in blood serum	PR:P00352	aldehyde dehydrogenase 1A1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040786	level of L-lactate dehydrogenase A chain (human) in blood serum	PR:P00338	L-lactate dehydrogenase A chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040787	level of alcohol dehydrogenase 1C (human) in blood serum	PR:P00326	alcohol dehydrogenase 1C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040788	level of all-trans-retinol dehydrogenase [NAD(+)] ADH1B (human) in blood serum	PR:P00325	all-trans-retinol dehydrogenase [NAD(+)] ADH1B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040789	level of cytochrome b5 (human) in blood serum	PR:P00167	cytochrome b5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040790	level of protein Wnt-11 (human) in blood serum	PR:O96014	protein Wnt-11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040791	level of serine/threonine-protein kinase PAK 4 (human) in blood serum	PR:O96013	serine/threonine-protein kinase PAK 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040792	level of NADH dehydrogenase [ubiquinone] 1 beta subcomplex subunit 10 (human) in blood serum	PR:O96000	NADH dehydrogenase [ubiquinone] 1 beta subcomplex subunit 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040793	level of B-cell lymphoma/leukemia 10 (human) in blood serum	PR:O95999	B-cell lymphoma/leukemia 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040794	level of securin (human) in blood serum	PR:O95997	securin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040795	level of diphosphoinositol polyphosphate phosphohydrolase 1 (human) in blood serum	PR:O95989	diphosphoinositol polyphosphate phosphohydrolase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040796	level of T-cell leukemia/lymphoma protein 1B (human) in blood serum	PR:O95988	T-cell leukemia/lymphoma protein 1B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040797	level of bone morphogenetic protein 15 (human) in blood serum	PR:O95972	bone morphogenetic protein 15 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040798	level of secretoglobin family 1D member 2 (human) in blood serum	PR:O95969	secretoglobin family 1D member 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040799	level of secretoglobin family 1D member 1 (human) in blood serum	PR:O95968	secretoglobin family 1D member 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040800	level of chromobox protein homolog 7 (human) in blood serum	PR:O95931	chromobox protein homolog 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040801	level of pre-mRNA-splicing factor SYF2 (human) in blood serum	PR:O95926	pre-mRNA-splicing factor SYF2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040802	level of noelin-2 (human) in blood serum	PR:O95897	noelin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040803	level of lymphocyte antigen 6 complex locus protein G6d (human) in blood serum	PR:O95868	lymphocyte antigen 6 complex locus protein G6d (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040804	level of hemoglobin subunit zeta (human) in blood serum	PR:P02008	hemoglobin subunit zeta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040805	level of HLA class II histocompatibility antigen, DQ alpha 2 chain (human) in blood serum	PR:P01906	HLA class II histocompatibility antigen, DQ alpha 2 chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040806	level of immunoglobulin heavy constant alpha 2 (human) in blood serum	PR:P01877	immunoglobulin heavy constant alpha 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040807	level of immunoglobulin heavy constant alpha 1 (human) in blood serum	PR:P01876	immunoglobulin heavy constant alpha 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040808	level of immunoglobulin heavy constant gamma 4 (human) in blood serum	PR:P01861	immunoglobulin heavy constant gamma 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040809	level of immunoglobulin heavy constant gamma 2 (human) in blood serum	PR:P01859	immunoglobulin heavy constant gamma 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040810	level of T-cell surface glycoprotein CD8 alpha chain (human) in blood serum	PR:P01732	T-cell surface glycoprotein CD8 alpha chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040811	level of immunoglobulin kappa variable 1-5 (human) in blood serum	PR:P01602	immunoglobulin kappa variable 1-5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040812	level of immunoglobulin J chain (human) in blood serum	PR:P01591	immunoglobulin J chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040813	level of interleukin-1 alpha (human) in blood serum	PR:P01583	interleukin-1 alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040814	level of interferon beta (human) in blood serum	PR:P01574	interferon beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040815	level of interferon alpha-14 (human) in blood serum	PR:P01570	interferon alpha-14 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040816	level of interferon alpha-5 (human) in blood serum	PR:P01569	interferon alpha-5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040817	level of interferon alpha-21 (human) in blood serum	PR:P01568	interferon alpha-21 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040818	level of interferon alpha-1/13 (human) in blood serum	PR:P01562	interferon alpha-1/13 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040819	level of pro-neuropeptide Y (human) in blood serum	PR:P01303	pro-neuropeptide Y (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040820	level of somatoliberin (human) in blood serum	PR:P01286	somatoliberin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040821	level of parathyroid hormone (human) in blood serum	PR:P01270	parathyroid hormone (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040822	level of growth hormone variant (human) in blood serum	PR:P01242	growth hormone variant (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040823	level of lutropin subunit beta (human) in blood serum	PR:P01229	lutropin subunit beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040824	level of follitropin subunit beta (human) in blood serum	PR:P01225	follitropin subunit beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040825	level of glycoprotein hormones alpha chain (human) in blood serum	PR:P01215	glycoprotein hormones alpha chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040826	level of proenkephalin-B (human) in blood serum	PR:P01213	proenkephalin-B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040827	level of proenkephalin-A (human) in blood serum	PR:P01210	proenkephalin-A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040828	level of oxytocin-neurophysin 1 (human) in blood serum	PR:P01178	oxytocin-neurophysin 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040829	level of progonadoliberin-1 (human) in blood serum	PR:P01148	progonadoliberin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040830	level of GTPase HRas (human) in blood serum	PR:P01112	GTPase HRas (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040831	level of GTPase NRas (human) in blood serum	PR:P01111	GTPase NRas (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040832	level of serine protease inhibitor Kazal-type 1 (human) in blood serum	PR:P00995	serine protease inhibitor Kazal-type 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040833	level of haptoglobin (human) in blood serum	PR:P00738	haptoglobin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040834	level of epidermal growth factor receptor (human) in blood serum	PR:P00533	epidermal growth factor receptor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040835	level of Thy-1 membrane glycoprotein (human) in blood serum	PR:P04216	Thy-1 membrane glycoprotein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040836	level of phosphatidylcholine-sterol acyltransferase (human) in blood serum	PR:P04180	phosphatidylcholine-sterol acyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040837	level of superoxide dismutase [Mn], mitochondrial (human) in blood serum	PR:P04179	superoxide dismutase [Mn], mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040838	level of major prion protein (human) in blood serum	PR:P04156	major prion protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040839	level of colipase (human) in blood serum	PR:P04118	colipase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040840	level of platelet-derived growth factor subunit A (human) in blood serum	PR:P04085	platelet-derived growth factor subunit A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040841	level of tissue alpha-L-fucosidase (human) in blood serum	PR:P04066	tissue alpha-L-fucosidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040842	level of lysosomal acid glucosylceramidase (human) in blood serum	PR:P04062	lysosomal acid glucosylceramidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040843	level of phospholipase A2 (human) in blood serum	PR:P04054	phospholipase A2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040844	level of RAF proto-oncogene serine/threonine-protein kinase (human) in blood serum	PR:P04049	RAF proto-oncogene serine/threonine-protein kinase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040845	level of C4b-binding protein alpha chain (human) in blood serum	PR:P04003	C4b-binding protein alpha chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040846	level of coagulation factor XI (human) in blood serum	PR:P03951	coagulation factor XI (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040847	level of statherin (human) in blood serum	PR:P02808	statherin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040848	level of ferritin heavy chain (human) in blood serum	PR:P02794	ferritin heavy chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040849	level of ferritin light chain (human) in blood serum	PR:P02792	ferritin light chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040850	level of platelet basic protein (human) in blood serum	PR:P02775	platelet basic protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040851	level of protein AMBP (human) in blood serum	PR:P02760	protein AMBP (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040852	level of beta-2-glycoprotein 1 (human) in blood serum	PR:P02749	beta-2-glycoprotein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040853	level of apolipoprotein C-III (human) in blood serum	PR:P02656	apolipoprotein C-III (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040854	level of apolipoprotein C-II (human) in blood serum	PR:P02655	apolipoprotein C-II (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040855	level of apolipoprotein C-I (human) in blood serum	PR:P02654	apolipoprotein C-I (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040856	level of apolipoprotein A-II (human) in blood serum	PR:P02652	apolipoprotein A-II (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040857	level of apolipoprotein E (human) in blood serum	PR:P02649	apolipoprotein E (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040858	level of apolipoprotein A-I (human) in blood serum	PR:P02647	apolipoprotein A-I (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040859	level of keratin, type II cytoskeletal 6A (human) in blood serum	PR:P02538	keratin, type II cytoskeletal 6A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040860	level of keratin, type I cytoskeletal 14 (human) in blood serum	PR:P02533	keratin, type I cytoskeletal 14 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040861	level of alpha-crystallin A chain (human) in blood serum	PR:P02489	alpha-crystallin A chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040862	level of collagen alpha-1(III) chain (human) in blood serum	PR:P02461	collagen alpha-1(III) chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040863	level of collagen alpha-1(II) chain (human) in blood serum	PR:P02458	collagen alpha-1(II) chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040864	level of hemoglobin subunit epsilon (human) in blood serum	PR:P02100	hemoglobin subunit epsilon (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040865	level of hemoglobin subunit delta (human) in blood serum	PR:P02042	hemoglobin subunit delta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040866	level of 60S acidic ribosomal protein P2 (human) in blood serum	PR:P05387	60S acidic ribosomal protein P2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040867	level of endothelin-1 (human) in blood serum	PR:P05305	endothelin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040868	level of eukaryotic translation initiation factor 2 subunit 1 (human) in blood serum	PR:P05198	eukaryotic translation initiation factor 2 subunit 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040869	level of alkaline phosphatase, placental type (human) in blood serum	PR:P05187	alkaline phosphatase, placental type (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040870	level of alkaline phosphatase, tissue-nonspecific isozyme (human) in blood serum	PR:P05186	alkaline phosphatase, tissue-nonspecific isozyme (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040871	level of coagulation factor XIII B chain (human) in blood serum	PR:P05160	coagulation factor XIII B chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040872	level of plasminogen activator inhibitor 2 (human) in blood serum	PR:P05120	plasminogen activator inhibitor 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040873	level of interleukin-5 (human) in blood serum	PR:P05113	interleukin-5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040874	level of interleukin-4 (human) in blood serum	PR:P05112	interleukin-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040875	level of inhibin alpha chain (human) in blood serum	PR:P05111	inhibin alpha chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040876	level of protein S100-A8 (human) in blood serum	PR:P05109	protein S100-A8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040877	level of integrin beta-2 (human) in blood serum	PR:P05107	integrin beta-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040878	level of integrin beta-3 (human) in blood serum	PR:P05106	integrin beta-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040879	level of aldehyde dehydrogenase, mitochondrial (human) in blood serum	PR:P05091	aldehyde dehydrogenase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040880	level of fructose-bisphosphate aldolase B (human) in blood serum	PR:P05062	fructose-bisphosphate aldolase B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040881	level of secretogranin-1 (human) in blood serum	PR:P05060	secretogranin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040882	level of insulin-like growth factor I (human) in blood serum	PR:P05019	insulin-like growth factor I (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040883	level of interferon alpha-16 (human) in blood serum	PR:P05015	interferon alpha-16 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040884	level of interferon alpha-4 (human) in blood serum	PR:P05014	interferon alpha-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040885	level of interferon alpha-6 (human) in blood serum	PR:P05013	interferon alpha-6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040886	level of interferon omega-1 (human) in blood serum	PR:P05000	interferon omega-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040887	level of dolichyl-diphosphooligosaccharide--protein glycosyltransferase subunit 2 (human) in blood serum	PR:P04844	dolichyl-diphosphooligosaccharide--protein glycosyltransferase subunit 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040888	level of pancreatic alpha-amylase (human) in blood serum	PR:P04746	pancreatic alpha-amylase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040889	level of alpha-amylase 1 (human) in blood serum	PR:P04745	alpha-amylase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040890	level of cellular tumor antigen p53 (human) in blood serum	PR:P04637	cellular tumor antigen p53 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040891	level of calpain small subunit 1 (human) in blood serum	PR:P04632	calpain small subunit 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040892	level of argininosuccinate lyase (human) in blood serum	PR:P04424	argininosuccinate lyase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040893	level of semenogelin-1 (human) in blood serum	PR:P04279	semenogelin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040894	level of keratin, type II cytoskeletal 1 (human) in blood serum	PR:P04264	keratin, type II cytoskeletal 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040895	level of HLA class II histocompatibility antigen gamma chain (human) in blood serum	PR:P04233	HLA class II histocompatibility antigen gamma chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040896	level of alpha-1B-glycoprotein (human) in blood serum	PR:P04217	alpha-1B-glycoprotein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040897	level of complement component C8 gamma chain (human) in blood serum	PR:P07360	complement component C8 gamma chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040898	level of alcohol dehydrogenase 1A (human) in blood serum	PR:P07327	alcohol dehydrogenase 1A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040899	level of gamma-crystallin D (human) in blood serum	PR:P07320	gamma-crystallin D (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040900	level of gamma-crystallin C (human) in blood serum	PR:P07315	gamma-crystallin C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040901	level of acylphosphatase-1 (human) in blood serum	PR:P07311	acylphosphatase-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040902	level of asialoglycoprotein receptor 2 (human) in blood serum	PR:P07307	asialoglycoprotein receptor 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040903	level of prostate-specific antigen (human) in blood serum	PR:P07288	prostate-specific antigen (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040904	level of phosphoglycerate kinase 2 (human) in blood serum	PR:P07205	phosphoglycerate kinase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040905	level of neurofilament light polypeptide (human) in blood serum	PR:P07196	neurofilament light polypeptide (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040906	level of acyl-CoA-binding protein (human) in blood serum	PR:P07108	acyl-CoA-binding protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040907	level of beta-hexosaminidase subunit alpha (human) in blood serum	PR:P06865	beta-hexosaminidase subunit alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040908	level of lipoprotein lipase (human) in blood serum	PR:P06858	lipoprotein lipase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040909	level of corticoliberin (human) in blood serum	PR:P06850	corticoliberin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040910	level of integrin alpha-V (human) in blood serum	PR:P06756	integrin alpha-V (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040911	level of tropomyosin alpha-3 chain (human) in blood serum	PR:P06753	tropomyosin alpha-3 chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040912	level of nucleophosmin (human) in blood serum	PR:P06748	nucleophosmin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040913	level of DNA polymerase beta (human) in blood serum	PR:P06746	DNA polymerase beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040914	level of glycogen phosphorylase, liver form (human) in blood serum	PR:P06737	glycogen phosphorylase, liver form (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040915	level of eukaryotic translation initiation factor 4E (human) in blood serum	PR:P06730	eukaryotic translation initiation factor 4E (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040916	level of T-cell surface antigen CD2 (human) in blood serum	PR:P06729	T-cell surface antigen CD2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040917	level of protein S100-A9 (human) in blood serum	PR:P06702	protein S100-A9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040918	level of progesterone receptor (human) in blood serum	PR:P06401	progesterone receptor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040919	level of cholecystokinin (human) in blood serum	PR:P06307	cholecystokinin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040920	level of alpha-galactosidase A (human) in blood serum	PR:P06280	alpha-galactosidase A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040921	level of cholinesterase (human) in blood serum	PR:P06276	cholinesterase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040922	level of uroporphyrinogen decarboxylase (human) in blood serum	PR:P06132	uroporphyrinogen decarboxylase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040923	level of T-cell surface glycoprotein CD1a (human) in blood serum	PR:P06126	T-cell surface glycoprotein CD1a (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040924	level of calbindin (human) in blood serum	PR:P05937	calbindin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040925	level of integrin beta-1 (human) in blood serum	PR:P05556	integrin beta-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040926	level of lithostathine-1-alpha (human) in blood serum	PR:P05451	lithostathine-1-alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040927	level of neuroendocrine protein 7B2 (human) in blood serum	PR:P05408	neuroendocrine protein 7B2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040928	level of low affinity immunoglobulin gamma Fc region receptor III-A (human) in blood serum	PR:P08637	low affinity immunoglobulin gamma Fc region receptor III-A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040929	level of myosin light chain 3 (human) in blood serum	PR:P08590	myosin light chain 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040930	level of U2 small nuclear ribonucleoprotein B'' (human) in blood serum	PR:P08579	U2 small nuclear ribonucleoprotein B'' (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040931	level of monocyte differentiation antigen CD14 (human) in blood serum	PR:P08571	monocyte differentiation antigen CD14 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040932	level of pleckstrin (human) in blood serum	PR:P08567	pleckstrin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040933	level of matrix Gla protein (human) in blood serum	PR:P08493	matrix Gla protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040934	level of inhibin beta A chain (human) in blood serum	PR:P08476	inhibin beta A chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040935	level of neprilysin (human) in blood serum	PR:P08473	neprilysin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040936	level of porphobilinogen deaminase (human) in blood serum	PR:P08397	porphobilinogen deaminase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040937	level of all-trans-retinol dehydrogenase [NAD(+)] ADH4 (human) in blood serum	PR:P08319	all-trans-retinol dehydrogenase [NAD(+)] ADH4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040938	level of extracellular superoxide dismutase [Cu-Zn] (human) in blood serum	PR:P08294	extracellular superoxide dismutase [Cu-Zn] (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040939	level of glutathione S-transferase A1 (human) in blood serum	PR:P08263	glutathione S-transferase A1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040940	level of stromelysin-1 (human) in blood serum	PR:P08254	stromelysin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040941	level of ATP-dependent 6-phosphofructokinase, muscle type (human) in blood serum	PR:P08237	ATP-dependent 6-phosphofructokinase, muscle type (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040942	level of beta-glucuronidase (human) in blood serum	PR:P08236	beta-glucuronidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040943	level of chymotrypsin-like elastase family member 2A (human) in blood serum	PR:P08217	chymotrypsin-like elastase family member 2A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040944	level of tumor necrosis factor receptor superfamily member 16 (human) in blood serum	PR:P08138	tumor necrosis factor receptor superfamily member 16 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040945	level of Rho-related GTP-binding protein RhoC (human) in blood serum	PR:P08134	Rho-related GTP-binding protein RhoC (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040946	level of ribonuclease pancreatic (human) in blood serum	PR:P07998	ribonuclease pancreatic (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040947	level of DNA excision repair protein ERCC-1 (human) in blood serum	PR:P07992	DNA excision repair protein ERCC-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040948	level of fumarate hydratase, mitochondrial (human) in blood serum	PR:P07954	fumarate hydratase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040949	level of laminin subunit beta-1 (human) in blood serum	PR:P07942	laminin subunit beta-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040950	level of heterogeneous nuclear ribonucleoproteins C1/C2 (human) in blood serum	PR:P07910	heterogeneous nuclear ribonucleoproteins C1/C2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040951	level of heat shock protein HSP 90-alpha (human) in blood serum	PR:P07900	heat shock protein HSP 90-alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040952	level of L-lactate dehydrogenase C chain (human) in blood serum	PR:P07864	L-lactate dehydrogenase C chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040953	level of T-cell surface glycoprotein CD3 epsilon chain (human) in blood serum	PR:P07766	T-cell surface glycoprotein CD3 epsilon chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040954	level of adenine phosphoribosyltransferase (human) in blood serum	PR:P07741	adenine phosphoribosyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040955	level of bisphosphoglycerate mutase (human) in blood serum	PR:P07738	bisphosphoglycerate mutase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040956	level of profilin-1 (human) in blood serum	PR:P07737	profilin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040957	level of beta-hexosaminidase subunit beta (human) in blood serum	PR:P07686	beta-hexosaminidase subunit beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040958	level of prosaposin (human) in blood serum	PR:P07602	prosaposin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040959	level of heme oxygenase 1 (human) in blood serum	PR:P09601	heme oxygenase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040960	level of T-cell antigen CD7 (human) in blood serum	PR:P09564	T-cell antigen CD7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040961	level of 2',3'-cyclic-nucleotide 3'-phosphodiesterase (human) in blood serum	PR:P09543	2',3'-cyclic-nucleotide 3'-phosphodiesterase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040962	level of inhibin beta B chain (human) in blood serum	PR:P09529	inhibin beta B chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040963	level of annexin A4 (human) in blood serum	PR:P09525	annexin A4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040964	level of clathrin light chain A (human) in blood serum	PR:P09496	clathrin light chain A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040965	level of glutathione S-transferase mu 1 (human) in blood serum	PR:P09488	glutathione S-transferase mu 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040966	level of fructose-1,6-bisphosphatase 1 (human) in blood serum	PR:P09467	fructose-1,6-bisphosphatase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040967	level of glycodelin (human) in blood serum	PR:P09466	glycodelin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040968	level of retinol-binding protein 1 (human) in blood serum	PR:P09455	retinol-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040969	level of dihydropteridine reductase (human) in blood serum	PR:P09417	dihydropteridine reductase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040970	level of villin-1 (human) in blood serum	PR:P09327	villin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040971	level of stromelysin-2 (human) in blood serum	PR:P09238	stromelysin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040972	level of U1 small nuclear ribonucleoprotein C (human) in blood serum	PR:P09234	U1 small nuclear ribonucleoprotein C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040973	level of glutathione S-transferase A2 (human) in blood serum	PR:P09210	glutathione S-transferase A2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040974	level of signal recognition particle 19 kDa protein (human) in blood serum	PR:P09132	signal recognition particle 19 kDa protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040975	level of 3-ketoacyl-CoA thiolase, peroxisomal (human) in blood serum	PR:P09110	3-ketoacyl-CoA thiolase, peroxisomal (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040976	level of hemoglobin subunit theta-1 (human) in blood serum	PR:P09105	hemoglobin subunit theta-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040977	level of homeobox protein Hox-D4 (human) in blood serum	PR:P09016	homeobox protein Hox-D4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040978	level of U1 small nuclear ribonucleoprotein A (human) in blood serum	PR:P09012	U1 small nuclear ribonucleoprotein A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040979	level of neuromedin-B (human) in blood serum	PR:P08949	neuromedin-B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040980	level of proto-oncogene tyrosine-protein kinase ROS (human) in blood serum	PR:P08922	proto-oncogene tyrosine-protein kinase ROS (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040981	level of interleukin-6 receptor subunit alpha (human) in blood serum	PR:P08887	interleukin-6 receptor subunit alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040982	level of chymotrypsin-like elastase family member 3B (human) in blood serum	PR:P08861	chymotrypsin-like elastase family member 3B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040983	level of keratin, type I cytoskeletal 16 (human) in blood serum	PR:P08779	keratin, type I cytoskeletal 16 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040984	level of guanine nucleotide-binding protein G(i) subunit alpha-3 (human) in blood serum	PR:P08754	guanine nucleotide-binding protein G(i) subunit alpha-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040985	level of keratin, type II cytoskeletal 7 (human) in blood serum	PR:P08729	keratin, type II cytoskeletal 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040986	level of keratin, type I cytoskeletal 19 (human) in blood serum	PR:P08727	keratin, type I cytoskeletal 19 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040987	level of coagulation factor VII (human) in blood serum	PR:P08709	coagulation factor VII (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040988	level of vimentin (human) in blood serum	PR:P08670	vimentin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040989	level of integrin alpha-5 (human) in blood serum	PR:P08648	integrin alpha-5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040990	level of pepsin A-4 (human) in blood serum	PR:P0DJD7	pepsin A-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040991	level of small integral membrane protein 13 (human) in blood serum	PR:P0DJ93	small integral membrane protein 13 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040992	level of trafficking protein particle complex subunit 2A (human) in blood serum	PR:P0DI81	trafficking protein particle complex subunit 2A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040993	level of G antigen 12F (human) in blood serum	PR:P0CL80	G antigen 12F (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040994	level of zinc finger CCHC domain-containing protein 18 (human) in blood serum	PR:P0CG32	zinc finger CCHC domain-containing protein 18 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040995	level of glutathione S-transferase theta-2B (human) in blood serum	PR:P0CG30	glutathione S-transferase theta-2B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040996	level of glutathione S-transferase theta-2 (human) in blood serum	PR:P0CG29	glutathione S-transferase theta-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040997	level of chromosome transmission fidelity protein 8 homolog (human) in blood serum	PR:P0CG13	chromosome transmission fidelity protein 8 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040998	level of DNA-directed RNA polymerase II subunit GRINL1A isoforms 1/2/3 (human) in blood serum	PR:P0CAP2	DNA-directed RNA polymerase II subunit GRINL1A isoforms 1/2/3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2040999	level of myocardial zonula adherens protein (human) in blood serum	PR:P0CAP1	myocardial zonula adherens protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041000	level of prostate and testis expressed protein 4 (human) in blood serum	PR:P0C8F1	prostate and testis expressed protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041001	level of complement C1q and tumor necrosis factor-related protein 9A (human) in blood serum	PR:P0C862	complement C1q and tumor necrosis factor-related protein 9A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041002	level of C-type lectin domain family 2 member L (human) in blood serum	PR:P0C7M8	C-type lectin domain family 2 member L (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041003	level of IQ domain-containing protein F3 (human) in blood serum	PR:P0C7M6	IQ domain-containing protein F3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041004	level of serine protease inhibitor Kazal-type 8 (human) in blood serum	PR:P0C7L1	serine protease inhibitor Kazal-type 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041005	level of leucine-rich repeat and immunoglobulin-like domain-containing nogo receptor-interacting protein 3 (human) in blood serum	PR:P0C6S8	leucine-rich repeat and immunoglobulin-like domain-containing nogo receptor-interacting protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041006	level of protein FAM163B (human) in blood serum	PR:P0C2L3	protein FAM163B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041007	level of Wee1-like protein kinase 2 (human) in blood serum	PR:P0C1S8	Wee1-like protein kinase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041008	level of neuropeptide S (human) in blood serum	PR:P0C0P6	neuropeptide S (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041009	level of complement C4-B (human) in blood serum	PR:P0C0L5	complement C4-B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041010	level of complement C4-A (human) in blood serum	PR:P0C0L4	complement C4-A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041011	level of peroxisomal coenzyme A diphosphatase NUDT7 (human) in blood serum	PR:P0C024	peroxisomal coenzyme A diphosphatase NUDT7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041012	level of fructose-bisphosphate aldolase C (human) in blood serum	PR:P09972	fructose-bisphosphate aldolase C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041013	level of intestinal-type alkaline phosphatase (human) in blood serum	PR:P09923	intestinal-type alkaline phosphatase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041014	level of polyunsaturated fatty acid 5-lipoxygenase (human) in blood serum	PR:P09917	polyunsaturated fatty acid 5-lipoxygenase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041015	level of interferon-induced protein with tetratricopeptide repeats 2 (human) in blood serum	PR:P09913	interferon-induced protein with tetratricopeptide repeats 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041016	level of lactase/phlorizin hydrolase (human) in blood serum	PR:P09848	lactase/phlorizin hydrolase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041017	level of T-cell surface glycoprotein CD3 gamma chain (human) in blood serum	PR:P09693	T-cell surface glycoprotein CD3 gamma chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041018	level of gastric inhibitory polypeptide (human) in blood serum	PR:P09681	gastric inhibitory polypeptide (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041019	level of heterogeneous nuclear ribonucleoprotein A1 (human) in blood serum	PR:P09651	heterogeneous nuclear ribonucleoprotein A1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041020	level of dihydrolipoyl dehydrogenase, mitochondrial (human) in blood serum	PR:P09622	dihydrolipoyl dehydrogenase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041021	level of laminin subunit gamma-1 (human) in blood serum	PR:P11047	laminin subunit gamma-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041022	level of islet amyloid polypeptide (human) in blood serum	PR:P10997	islet amyloid polypeptide (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041023	level of T-cell surface glycoprotein CD8 beta chain (human) in blood serum	PR:P10966	T-cell surface glycoprotein CD8 beta chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041024	level of thyroid hormone receptor beta (human) in blood serum	PR:P10828	thyroid hormone receptor beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041025	level of thyroid hormone receptor alpha (human) in blood serum	PR:P10827	thyroid hormone receptor alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041026	level of T-cell-specific surface glycoprotein CD28 (human) in blood serum	PR:P10747	T-cell-specific surface glycoprotein CD28 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041027	level of uroporphyrinogen-III synthase (human) in blood serum	PR:P10746	uroporphyrinogen-III synthase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041028	level of platelet factor 4 variant (human) in blood serum	PR:P10720	platelet factor 4 variant (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041029	level of alkaline phosphatase, germ cell type (human) in blood serum	PR:P10696	alkaline phosphatase, germ cell type (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041030	level of cAMP-dependent protein kinase type I-alpha regulatory subunit (human) in blood serum	PR:P10644	cAMP-dependent protein kinase type I-alpha regulatory subunit (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041031	level of cytochrome c oxidase subunit 5B, mitochondrial (human) in blood serum	PR:P10606	cytochrome c oxidase subunit 5B, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041032	level of thioredoxin (human) in blood serum	PR:P10599	thioredoxin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041033	level of S-arrestin (human) in blood serum	PR:P10523	S-arrestin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041034	level of dihydrolipoyllysine-residue acetyltransferase component of pyruvate dehydrogenase complex, mitochondrial (human) in blood serum	PR:P10515	dihydrolipoyllysine-residue acetyltransferase component of pyruvate dehydrogenase complex, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041035	level of serine/threonine-protein kinase A-Raf (human) in blood serum	PR:P10398	serine/threonine-protein kinase A-Raf (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041036	level of HLA class I histocompatibility antigen, C alpha chain (human) in blood serum	PR:P10321	HLA class I histocompatibility antigen, C alpha chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041037	level of Ras-related protein R-Ras (human) in blood serum	PR:P10301	Ras-related protein R-Ras (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041038	level of transcriptional activator Myb (human) in blood serum	PR:P10242	transcriptional activator Myb (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041039	level of non-secretory ribonuclease (human) in blood serum	PR:P10153	non-secretory ribonuclease (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041040	level of serglycin (human) in blood serum	PR:P10124	serglycin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041041	level of Ras-related protein Rap-2a (human) in blood serum	PR:P10114	Ras-related protein Rap-2a (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041042	level of calcitonin gene-related peptide 2 (human) in blood serum	PR:P10092	calcitonin gene-related peptide 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041043	level of UDP-glucuronosyltransferase 2A1 (human) in blood serum	PR:P0DTE4	UDP-glucuronosyltransferase 2A1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041044	level of glutamine amidotransferase-like class 1 domain-containing protein 3, mitochondrial (human) in blood serum	PR:P0DPI2	glutamine amidotransferase-like class 1 domain-containing protein 3, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041045	level of V-set and immunoglobulin domain-containing protein 8 (human) in blood serum	PR:P0DPA2	V-set and immunoglobulin domain-containing protein 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041046	level of transmembrane protein 225B (human) in blood serum	PR:P0DP42	transmembrane protein 225B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041047	level of choriogonadotropin subunit beta 3 (human) in blood serum	PR:P0DN86	choriogonadotropin subunit beta 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041048	level of heat shock 70 kDa protein 1B (human) in blood serum	PR:P0DMV9	heat shock 70 kDa protein 1B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041049	level of sulfotransferase 1A3 (human) in blood serum	PR:P0DMM9	sulfotransferase 1A3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041050	level of GTPase IMAP family member GIMD1 (human) in blood serum	PR:P0DJR0	GTPase IMAP family member GIMD1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041051	level of serum amyloid A-2 protein (human) in blood serum	PR:P0DJI9	serum amyloid A-2 protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041052	level of high affinity immunoglobulin epsilon receptor subunit alpha (human) in blood serum	PR:P12319	high affinity immunoglobulin epsilon receptor subunit alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041053	level of prolactin-inducible protein (human) in blood serum	PR:P12273	prolactin-inducible protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041054	level of retinaldehyde-binding protein 1 (human) in blood serum	PR:P12271	retinaldehyde-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041055	level of collagen alpha-2(VI) chain (human) in blood serum	PR:P12110	collagen alpha-2(VI) chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041056	level of collagen alpha-1(VI) chain (human) in blood serum	PR:P12109	collagen alpha-1(VI) chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041057	level of fatty acid-binding protein, intestinal (human) in blood serum	PR:P12104	fatty acid-binding protein, intestinal (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041058	level of histidine--tRNA ligase, cytoplasmic (human) in blood serum	PR:P12081	histidine--tRNA ligase, cytoplasmic (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041059	level of neurofilament heavy polypeptide (human) in blood serum	PR:P12036	neurofilament heavy polypeptide (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041060	level of ornithine decarboxylase (human) in blood serum	PR:P11926	ornithine decarboxylase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041061	level of B-cell antigen receptor complex-associated protein alpha chain (human) in blood serum	PR:P11912	B-cell antigen receptor complex-associated protein alpha chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041062	level of ribose-phosphate pyrophosphokinase 2 (human) in blood serum	PR:P11908	ribose-phosphate pyrophosphokinase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041063	level of gamma-crystallin A (human) in blood serum	PR:P11844	gamma-crystallin A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041064	level of alcohol dehydrogenase class-3 (human) in blood serum	PR:P11766	alcohol dehydrogenase class-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041065	level of C-1-tetrahydrofolate synthase, cytoplasmic (human) in blood serum	PR:P11586	C-1-tetrahydrofolate synthase, cytoplasmic (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041066	level of pyruvate carboxylase, mitochondrial (human) in blood serum	PR:P11498	pyruvate carboxylase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041067	level of fibroblast growth factor 3 (human) in blood serum	PR:P11487	fibroblast growth factor 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041068	level of steroid hormone receptor ERR1 (human) in blood serum	PR:P11474	steroid hormone receptor ERR1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041069	level of vitamin D3 receptor (human) in blood serum	PR:P11473	vitamin D3 receptor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041070	level of pregnancy-specific beta-1-glycoprotein 2 (human) in blood serum	PR:P11465	pregnancy-specific beta-1-glycoprotein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041071	level of pregnancy-specific beta-1-glycoprotein 1 (human) in blood serum	PR:P11464	pregnancy-specific beta-1-glycoprotein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041072	level of ubiquitin-like protein 4A (human) in blood serum	PR:P11441	ubiquitin-like protein 4A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041073	level of glucose-6-phosphate 1-dehydrogenase (human) in blood serum	PR:P11413	glucose-6-phosphate 1-dehydrogenase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041074	level of medium-chain specific acyl-CoA dehydrogenase, mitochondrial (human) in blood serum	PR:P11310	medium-chain specific acyl-CoA dehydrogenase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041075	level of lysosome-associated membrane glycoprotein 1 (human) in blood serum	PR:P11279	lysosome-associated membrane glycoprotein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041076	level of Ras-related protein Ral-A (human) in blood serum	PR:P11233	Ras-related protein Ral-A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041077	level of integrin alpha-M (human) in blood serum	PR:P11215	integrin alpha-M (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041078	level of lipoamide acyltransferase component of branched-chain alpha-keto acid dehydrogenase complex, mitochondrial (human) in blood serum	PR:P11182	lipoamide acyltransferase component of branched-chain alpha-keto acid dehydrogenase complex, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041079	level of pyruvate dehydrogenase E1 component subunit beta, mitochondrial (human) in blood serum	PR:P11177	pyruvate dehydrogenase E1 component subunit beta, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041080	level of protein 4.1 (human) in blood serum	PR:P11171	protein 4.1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041081	level of phenylethanolamine N-methyltransferase (human) in blood serum	PR:P11086	phenylethanolamine N-methyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041082	level of leukocyte antigen CD37 (human) in blood serum	PR:P11049	leukocyte antigen CD37 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041083	level of bifunctional methylenetetrahydrofolate dehydrogenase/cyclohydrolase, mitochondrial (human) in blood serum	PR:P13995	bifunctional methylenetetrahydrofolate dehydrogenase/cyclohydrolase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041084	level of general transcription factor IIF subunit 2 (human) in blood serum	PR:P13984	general transcription factor IIF subunit 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041085	level of collagen alpha-2(XI) chain (human) in blood serum	PR:P13942	collagen alpha-2(XI) chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041086	level of beta-enolase (human) in blood serum	PR:P13929	beta-enolase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041087	level of annexin A8 (human) in blood serum	PR:P13928	annexin A8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041088	level of cAMP-dependent protein kinase type II-alpha regulatory subunit (human) in blood serum	PR:P13861	cAMP-dependent protein kinase type II-alpha regulatory subunit (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041089	level of electron transfer flavoprotein subunit alpha, mitochondrial (human) in blood serum	PR:P13804	electron transfer flavoprotein subunit alpha, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041090	level of plastin-3 (human) in blood serum	PR:P13797	plastin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041091	level of plastin-2 (human) in blood serum	PR:P13796	plastin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041092	level of HLA class I histocompatibility antigen, alpha chain E (human) in blood serum	PR:P13747	HLA class I histocompatibility antigen, alpha chain E (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041093	level of bone marrow proteoglycan (human) in blood serum	PR:P13727	bone marrow proteoglycan (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041094	level of delta-aminolevulinic acid dehydratase (human) in blood serum	PR:P13716	delta-aminolevulinic acid dehydratase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041095	level of prolyl 4-hydroxylase subunit alpha-1 (human) in blood serum	PR:P13674	prolyl 4-hydroxylase subunit alpha-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041096	level of protein disulfide-isomerase A4 (human) in blood serum	PR:P13667	protein disulfide-isomerase A4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041097	level of keratin, type II cytoskeletal 5 (human) in blood serum	PR:P13647	keratin, type II cytoskeletal 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041098	level of integrin alpha-4 (human) in blood serum	PR:P13612	integrin alpha-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041099	level of versican core protein (human) in blood serum	PR:P13611	versican core protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041100	level of neural cell adhesion molecule 1 (human) in blood serum	PR:P13591	neural cell adhesion molecule 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041101	level of cystic fibrosis transmembrane conductance regulator (human) in blood serum	PR:P13569	cystic fibrosis transmembrane conductance regulator (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041102	level of interleukin-7 (human) in blood serum	PR:P13232	interleukin-7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041103	level of platelet glycoprotein Ib beta chain (human) in blood serum	PR:P13224	platelet glycoprotein Ib beta chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041104	level of uracil-DNA glycosylase (human) in blood serum	PR:P13051	uracil-DNA glycosylase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041105	level of promotilin (human) in blood serum	PR:P12872	promotilin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041106	level of myosin light chain 4 (human) in blood serum	PR:P12829	myosin light chain 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041107	level of alpha-actinin-1 (human) in blood serum	PR:P12814	alpha-actinin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041108	level of ski-like protein (human) in blood serum	PR:P12757	ski-like protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041109	level of bone morphogenetic protein 3 (human) in blood serum	PR:P12645	bone morphogenetic protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041110	level of bone morphogenetic protein 4 (human) in blood serum	PR:P12644	bone morphogenetic protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041111	level of bone morphogenetic protein 2 (human) in blood serum	PR:P12643	bone morphogenetic protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041112	level of creatine kinase U-type, mitochondrial (human) in blood serum	PR:P12532	creatine kinase U-type, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041113	level of annexin A3 (human) in blood serum	PR:P12429	annexin A3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041114	level of carboxypeptidase N catalytic chain (human) in blood serum	PR:P15169	carboxypeptidase N catalytic chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041115	level of poliovirus receptor (human) in blood serum	PR:P15151	poliovirus receptor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041116	level of aldo-keto reductase family 1 member B1 (human) in blood serum	PR:P15121	aldo-keto reductase family 1 member B1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041117	level of glutamine synthetase (human) in blood serum	PR:P15104	glutamine synthetase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041118	level of carboxypeptidase B (human) in blood serum	PR:P15086	carboxypeptidase B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041119	level of carboxypeptidase A1 (human) in blood serum	PR:P15085	carboxypeptidase A1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041120	level of serine/threonine-protein kinase B-raf (human) in blood serum	PR:P15056	serine/threonine-protein kinase B-raf (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041121	level of protein C-ets-2 (human) in blood serum	PR:P15036	protein C-ets-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041122	level of leukemia inhibitory factor (human) in blood serum	PR:P15018	leukemia inhibitory factor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041123	level of cytochrome b-c1 complex subunit 7 (human) in blood serum	PR:P14927	cytochrome b-c1 complex subunit 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041124	level of junction plakoglobin (human) in blood serum	PR:P14923	junction plakoglobin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041125	level of D-amino-acid oxidase (human) in blood serum	PR:P14920	D-amino-acid oxidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041126	level of indoleamine 2,3-dioxygenase 1 (human) in blood serum	PR:P14902	indoleamine 2,3-dioxygenase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041127	level of aspartate--tRNA ligase, cytoplasmic (human) in blood serum	PR:P14868	aspartate--tRNA ligase, cytoplasmic (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041128	level of POU domain, class 2, transcription factor 1 (human) in blood serum	PR:P14859	POU domain, class 2, transcription factor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041129	level of interleukin-2 receptor subunit beta (human) in blood serum	PR:P14784	interleukin-2 receptor subunit beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041130	level of myosin light chain 6B (human) in blood serum	PR:P14649	myosin light chain 6B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041131	level of endoplasmin (human) in blood serum	PR:P14625	endoplasmin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041132	level of acylphosphatase-2 (human) in blood serum	PR:P14621	acylphosphatase-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041133	level of insulin receptor-related protein (human) in blood serum	PR:P14616	insulin receptor-related protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041134	level of neutrophil cytosol factor 1 (human) in blood serum	PR:P14598	neutrophil cytosol factor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041135	level of aldo-keto reductase family 1 member A1 (human) in blood serum	PR:P14550	aldo-keto reductase family 1 member A1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041136	level of sodium/potassium-transporting ATPase subunit beta-2 (human) in blood serum	PR:P14415	sodium/potassium-transporting ATPase subunit beta-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041137	level of carboxypeptidase M (human) in blood serum	PR:P14384	carboxypeptidase M (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041138	level of zinc finger protein RFP (human) in blood serum	PR:P14373	zinc finger protein RFP (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041139	level of farnesyl pyrophosphate synthase (human) in blood serum	PR:P14324	farnesyl pyrophosphate synthase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041140	level of hematopoietic lineage cell-specific protein (human) in blood serum	PR:P14317	hematopoietic lineage cell-specific protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041141	level of interferon regulatory factor 2 (human) in blood serum	PR:P14316	interferon regulatory factor 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041142	level of glucosidase 2 subunit beta (human) in blood serum	PR:P14314	glucosidase 2 subunit beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041143	level of folate receptor beta (human) in blood serum	PR:P14207	folate receptor beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041144	level of endothelin-3 (human) in blood serum	PR:P14138	endothelin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041145	level of thyrotropin receptor (human) in blood serum	PR:P16473	thyrotropin receptor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041146	level of methylated-DNA--protein-cysteine methyltransferase (human) in blood serum	PR:P16455	methylated-DNA--protein-cysteine methyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041147	level of dipeptidase 1 (human) in blood serum	PR:P16444	dipeptidase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041148	level of histo-blood group ABO system transferase (human) in blood serum	PR:P16442	histo-blood group ABO system transferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041149	level of pancreatic triacylglycerol lipase (human) in blood serum	PR:P16233	pancreatic triacylglycerol lipase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041150	level of cyclic AMP-responsive element-binding protein 1 (human) in blood serum	PR:P16220	cyclic AMP-responsive element-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041151	level of short-chain specific acyl-CoA dehydrogenase, mitochondrial (human) in blood serum	PR:P16219	short-chain specific acyl-CoA dehydrogenase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041152	level of carbonyl reductase [NADPH] 1 (human) in blood serum	PR:P16152	carbonyl reductase [NADPH] 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041153	level of leukosialin (human) in blood serum	PR:P16150	leukosialin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041154	level of 6-phosphofructo-2-kinase/fructose-2,6-bisphosphatase 1 (human) in blood serum	PR:P16118	6-phosphofructo-2-kinase/fructose-2,6-bisphosphatase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041155	level of ribosyldihydronicotinamide dehydrogenase [quinone] (human) in blood serum	PR:P16083	ribosyldihydronicotinamide dehydrogenase [quinone] (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041156	level of CD44 antigen (human) in blood serum	PR:P16070	CD44 antigen (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041157	level of replication protein A 32 kDa subunit (human) in blood serum	PR:P15927	replication protein A 32 kDa subunit (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041158	level of V(D)J recombination-activating protein 1 (human) in blood serum	PR:P15918	V(D)J recombination-activating protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041159	level of beta-galactoside alpha-2,6-sialyltransferase 1 (human) in blood serum	PR:P15907	beta-galactoside alpha-2,6-sialyltransferase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041160	level of transcription factor 4 (human) in blood serum	PR:P15884	transcription factor 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041161	level of N-chimaerin (human) in blood serum	PR:P15882	N-chimaerin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041162	level of immunoglobulin lambda-like polypeptide 1 (human) in blood serum	PR:P15814	immunoglobulin lambda-like polypeptide 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041163	level of antigen-presenting glycoprotein CD1d (human) in blood serum	PR:P15813	antigen-presenting glycoprotein CD1d (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041164	level of vascular endothelial growth factor A (human) in blood serum	PR:P15692	vascular endothelial growth factor A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041165	level of NAD(P)H dehydrogenase [quinone] 1 (human) in blood serum	PR:P15559	NAD(P)H dehydrogenase [quinone] 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041166	level of membrane cofactor protein (human) in blood serum	PR:P15529	membrane cofactor protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041167	level of histatin-3 (human) in blood serum	PR:P15516	histatin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041168	level of histatin-1 (human) in blood serum	PR:P15515	histatin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041169	level of granulocyte-macrophage colony-stimulating factor receptor subunit alpha (human) in blood serum	PR:P15509	granulocyte-macrophage colony-stimulating factor receptor subunit alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041170	level of 15-hydroxyprostaglandin dehydrogenase [NAD(+)] (human) in blood serum	PR:P15428	15-hydroxyprostaglandin dehydrogenase [NAD(+)] (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041171	level of Fos-related antigen 2 (human) in blood serum	PR:P15408	Fos-related antigen 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041172	level of folate receptor alpha (human) in blood serum	PR:P15328	folate receptor alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041173	level of ezrin (human) in blood serum	PR:P15311	ezrin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041174	level of prostatic acid phosphatase (human) in blood serum	PR:P15309	prostatic acid phosphatase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041175	level of beta-1,4-galactosyltransferase 1 (human) in blood serum	PR:P15291	beta-1,4-galactosyltransferase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041176	level of vascular endothelial growth factor receptor 1 (human) in blood serum	PR:P17948	vascular endothelial growth factor receptor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041177	level of transcription factor PU.1 (human) in blood serum	PR:P17947	transcription factor PU.1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041178	level of insulin-like growth factor-binding protein 3 (human) in blood serum	PR:P17936	insulin-like growth factor-binding protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041179	level of complement receptor type 1 (human) in blood serum	PR:P17927	complement receptor type 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041180	level of ganglioside GM2 activator (human) in blood serum	PR:P17900	ganglioside GM2 activator (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041181	level of X-box-binding protein 1 (human) in blood serum	PR:P17861	X-box-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041182	level of CTP synthase 1 (human) in blood serum	PR:P17812	CTP synthase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041183	level of tryptophan 5-hydroxylase 1 (human) in blood serum	PR:P17752	tryptophan 5-hydroxylase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041184	level of tyrosine aminotransferase (human) in blood serum	PR:P17735	tyrosine aminotransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041185	level of HLA class I histocompatibility antigen, alpha chain G (human) in blood serum	PR:P17693	HLA class I histocompatibility antigen, alpha chain G (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041186	level of neuromodulin (human) in blood serum	PR:P17677	neuromodulin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041187	level of desmin (human) in blood serum	PR:P17661	desmin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041188	level of calpain-2 catalytic subunit (human) in blood serum	PR:P17655	calpain-2 catalytic subunit (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041189	level of 5,6-dihydroxyindole-2-carboxylic acid oxidase (human) in blood serum	PR:P17643	5,6-dihydroxyindole-2-carboxylic acid oxidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041190	level of creatine kinase S-type, mitochondrial (human) in blood serum	PR:P17540	creatine kinase S-type, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041191	level of chymotrypsinogen B (human) in blood serum	PR:P17538	chymotrypsinogen B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041192	level of transcription factor JunD (human) in blood serum	PR:P17535	transcription factor JunD (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041193	level of aldo-keto reductase family 1 member C4 (human) in blood serum	PR:P17516	aldo-keto reductase family 1 member C4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041194	level of sphingomyelin phosphodiesterase (human) in blood serum	PR:P17405	sphingomyelin phosphodiesterase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041195	level of gap junction alpha-1 protein (human) in blood serum	PR:P17302	gap junction alpha-1 protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041196	level of integrin alpha-2 (human) in blood serum	PR:P17301	integrin alpha-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041197	level of high mobility group protein HMG-I/HMG-Y (human) in blood serum	PR:P17096	high mobility group protein HMG-I/HMG-Y (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041198	level of Rho-related GTP-binding protein RhoQ (human) in blood serum	PR:P17081	Rho-related GTP-binding protein RhoQ (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041199	level of heat shock 70 kDa protein 6 (human) in blood serum	PR:P17066	heat shock 70 kDa protein 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041200	level of zinc finger protein 23 (human) in blood serum	PR:P17027	zinc finger protein 23 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041201	level of zinc finger protein 18 (human) in blood serum	PR:P17022	zinc finger protein 18 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041202	level of stathmin (human) in blood serum	PR:P16949	stathmin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041203	level of fumarylacetoacetase (human) in blood serum	PR:P16930	fumarylacetoacetase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041204	level of 1-phosphatidylinositol 4,5-bisphosphate phosphodiesterase gamma-2 (human) in blood serum	PR:P16885	1-phosphatidylinositol 4,5-bisphosphate phosphodiesterase gamma-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041205	level of cysteine-rich secretory protein 2 (human) in blood serum	PR:P16562	cysteine-rich secretory protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041206	level of neuroendocrine convertase 2 (human) in blood serum	PR:P16519	neuroendocrine convertase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041207	level of inter-alpha-trypsin inhibitor heavy chain H1 (human) in blood serum	PR:P19827	inter-alpha-trypsin inhibitor heavy chain H1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041208	level of inter-alpha-trypsin inhibitor heavy chain H2 (human) in blood serum	PR:P19823	inter-alpha-trypsin inhibitor heavy chain H2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041209	level of amiloride-sensitive amine oxidase [copper-containing] (human) in blood serum	PR:P19801	amiloride-sensitive amine oxidase [copper-containing] (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041210	level of retinoic acid receptor RXR-alpha (human) in blood serum	PR:P19793	retinoic acid receptor RXR-alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041211	level of spermidine synthase (human) in blood serum	PR:P19623	spermidine synthase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041212	level of E3 ubiquitin-protein ligase TRIM21 (human) in blood serum	PR:P19474	E3 ubiquitin-protein ligase TRIM21 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041213	level of tumor necrosis factor receptor superfamily member 1A (human) in blood serum	PR:P19438	tumor necrosis factor receptor superfamily member 1A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041214	level of ETS domain-containing protein Elk-1 (human) in blood serum	PR:P19419	ETS domain-containing protein Elk-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041215	level of NADH dehydrogenase [ubiquinone] flavoprotein 2, mitochondrial (human) in blood serum	PR:P19404	NADH dehydrogenase [ubiquinone] flavoprotein 2, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041216	level of DNA-directed RNA polymerases I, II, and III subunit RPABC1 (human) in blood serum	PR:P19388	DNA-directed RNA polymerases I, II, and III subunit RPABC1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041217	level of DNA-directed RNA polymerase II subunit RPB3 (human) in blood serum	PR:P19387	DNA-directed RNA polymerase II subunit RPB3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041218	level of nucleolin (human) in blood serum	PR:P19338	nucleolin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041219	level of lymphocyte function-associated antigen 3 (human) in blood serum	PR:P19256	lymphocyte function-associated antigen 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041220	level of UDP-glucuronosyltransferase 1-6 (human) in blood serum	PR:P19224	UDP-glucuronosyltransferase 1-6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041221	level of myosin regulatory light chain 12A (human) in blood serum	PR:P19105	myosin regulatory light chain 12A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041222	level of peptidyl-glycine alpha-amidating monooxygenase (human) in blood serum	PR:P19021	peptidyl-glycine alpha-amidating monooxygenase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041223	level of DNA repair protein XRCC1 (human) in blood serum	PR:P18887	DNA repair protein XRCC1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041224	level of ATP synthase-coupling factor 6, mitochondrial (human) in blood serum	PR:P18859	ATP synthase-coupling factor 6, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041225	level of cyclic AMP-dependent transcription factor ATF-6 alpha (human) in blood serum	PR:P18850	cyclic AMP-dependent transcription factor ATF-6 alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041226	level of cyclic AMP-dependent transcription factor ATF-3 (human) in blood serum	PR:P18847	cyclic AMP-dependent transcription factor ATF-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041227	level of cyclic AMP-dependent transcription factor ATF-1 (human) in blood serum	PR:P18846	cyclic AMP-dependent transcription factor ATF-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041228	level of negative elongation factor E (human) in blood serum	PR:P18615	negative elongation factor E (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041229	level of integrin beta-6 (human) in blood serum	PR:P18564	integrin beta-6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041230	level of pituitary adenylate cyclase-activating polypeptide (human) in blood serum	PR:P18509	pituitary adenylate cyclase-activating polypeptide (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041231	level of arylamine N-acetyltransferase 1 (human) in blood serum	PR:P18440	arylamine N-acetyltransferase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041232	level of glutathione peroxidase 2 (human) in blood serum	PR:P18283	glutathione peroxidase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041233	level of vinculin (human) in blood serum	PR:P18206	vinculin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041234	level of ADP-ribosylation factor 4 (human) in blood serum	PR:P18085	ADP-ribosylation factor 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041235	level of integrin beta-5 (human) in blood serum	PR:P18084	integrin beta-5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041236	level of T-complex protein 1 subunit alpha (human) in blood serum	PR:P17987	T-complex protein 1 subunit alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041237	level of 26S proteasome regulatory subunit 6A (human) in blood serum	PR:P17980	26S proteasome regulatory subunit 6A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041238	level of hepatocyte nuclear factor 1-alpha (human) in blood serum	PR:P20823	hepatocyte nuclear factor 1-alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041239	level of calpain-3 (human) in blood serum	PR:P20807	calpain-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041240	level of endothelin-2 (human) in blood serum	PR:P20800	endothelin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041241	level of mimecan (human) in blood serum	PR:P20774	mimecan (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041242	level of pregnancy zone protein (human) in blood serum	PR:P20742	pregnancy zone protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041243	level of homeobox protein Hox-A5 (human) in blood serum	PR:P20719	homeobox protein Hox-A5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041244	level of integrin alpha-L (human) in blood serum	PR:P20701	integrin alpha-L (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041245	level of cytochrome c oxidase subunit 5A, mitochondrial (human) in blood serum	PR:P20674	cytochrome c oxidase subunit 5A, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041246	level of proteasome subunit beta type-1 (human) in blood serum	PR:P20618	proteasome subunit beta type-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041247	level of interferon-induced GTP-binding protein Mx1 (human) in blood serum	PR:P20591	interferon-induced GTP-binding protein Mx1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041248	level of pro-thyrotropin-releasing hormone (human) in blood serum	PR:P20396	pro-thyrotropin-releasing hormone (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041249	level of protachykinin-1 (human) in blood serum	PR:P20366	protachykinin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041250	level of Ras-related protein Rab-6A (human) in blood serum	PR:P20340	Ras-related protein Rab-6A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041251	level of Ras-related protein Rab-5A (human) in blood serum	PR:P20339	Ras-related protein Rab-5A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041252	level of Ras-related protein Rab-4A (human) in blood serum	PR:P20338	Ras-related protein Rab-4A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041253	level of Ras-related protein Rab-3B (human) in blood serum	PR:P20337	Ras-related protein Rab-3B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041254	level of Ras-related protein Rab-3A (human) in blood serum	PR:P20336	Ras-related protein Rab-3A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041255	level of cyclin-A2 (human) in blood serum	PR:P20248	cyclin-A2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041256	level of serine protease inhibitor Kazal-type 2 (human) in blood serum	PR:P20155	serine protease inhibitor Kazal-type 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041257	level of annexin A7 (human) in blood serum	PR:P20073	annexin A7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041258	level of transcobalamin-2 (human) in blood serum	PR:P20062	transcobalamin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041259	level of transcobalamin-1 (human) in blood serum	PR:P20061	transcobalamin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041260	level of eukaryotic translation initiation factor 2 subunit 2 (human) in blood serum	PR:P20042	eukaryotic translation initiation factor 2 subunit 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041261	level of complement receptor type 2 (human) in blood serum	PR:P20023	complement receptor type 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041262	level of thymidine phosphorylase (human) in blood serum	PR:P19971	thymidine phosphorylase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041263	level of alpha-amylase 2B (human) in blood serum	PR:P19961	alpha-amylase 2B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041264	level of neutrophil cytosol factor 2 (human) in blood serum	PR:P19878	neutrophil cytosol factor 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041265	level of C-X-C motif chemokine 3 (human) in blood serum	PR:P19876	C-X-C motif chemokine 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041266	level of C-X-C motif chemokine 2 (human) in blood serum	PR:P19875	C-X-C motif chemokine 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041267	level of nuclear factor NF-kappa-B p105 subunit (human) in blood serum	PR:P19838	nuclear factor NF-kappa-B p105 subunit (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041268	level of bile salt-activated lipase (human) in blood serum	PR:P19835	bile salt-activated lipase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041269	level of upstream stimulatory factor 1 (human) in blood serum	PR:P22415	upstream stimulatory factor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041270	level of glutathione peroxidase 3 (human) in blood serum	PR:P22352	glutathione peroxidase 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041271	level of ubiquitin-like modifier-activating enzyme 1 (human) in blood serum	PR:P22314	ubiquitin-like modifier-activating enzyme 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041272	level of UDP-glucuronosyltransferase 1A1 (human) in blood serum	PR:P22309	UDP-glucuronosyltransferase 1A1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041273	level of acetylcholinesterase (human) in blood serum	PR:P22303	acetylcholinesterase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041274	level of bifunctional phosphoribosylaminoimidazole carboxylase/phosphoribosylaminoimidazole succinocarboxamide synthetase (human) in blood serum	PR:P22234	bifunctional phosphoribosylaminoimidazole carboxylase/phosphoribosylaminoimidazole succinocarboxamide synthetase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041275	level of tenascin-X (human) in blood serum	PR:P22105	tenascin-X (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041276	level of oxysterol-binding protein 1 (human) in blood serum	PR:P22059	oxysterol-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041277	level of bone morphogenetic protein 5 (human) in blood serum	PR:P22003	bone morphogenetic protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041278	level of protein-glutamine gamma-glutamyltransferase 2 (human) in blood serum	PR:P21980	protein-glutamine gamma-glutamyltransferase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041279	level of catechol O-methyltransferase (human) in blood serum	PR:P21964	catechol O-methyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041280	level of CD9 antigen (human) in blood serum	PR:P21926	CD9 antigen (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041281	level of succinate dehydrogenase [ubiquinone] iron-sulfur subunit, mitochondrial (human) in blood serum	PR:P21912	succinate dehydrogenase [ubiquinone] iron-sulfur subunit, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041282	level of B-cell differentiation antigen CD72 (human) in blood serum	PR:P21854	B-cell differentiation antigen CD72 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041283	level of glycerol-3-phosphate dehydrogenase [NAD(+)], cytoplasmic (human) in blood serum	PR:P21695	glycerol-3-phosphate dehydrogenase [NAD(+)], cytoplasmic (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041284	level of diamine acetyltransferase 1 (human) in blood serum	PR:P21673	diamine acetyltransferase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041285	level of 5'-nucleotidase (human) in blood serum	PR:P21589	5'-nucleotidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041286	level of tumor necrosis factor alpha-induced protein 3 (human) in blood serum	PR:P21580	tumor necrosis factor alpha-induced protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041287	level of synaptotagmin-1 (human) in blood serum	PR:P21579	synaptotagmin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041288	level of alanine--glyoxylate aminotransferase (human) in blood serum	PR:P21549	alanine--glyoxylate aminotransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041289	level of zinc finger protein 10 (human) in blood serum	PR:P21506	zinc finger protein 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041290	level of cytoplasmic aconitate hydratase (human) in blood serum	PR:P21399	cytoplasmic aconitate hydratase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041291	level of V-type proton ATPase subunit C 1 (human) in blood serum	PR:P21283	V-type proton ATPase subunit C 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041292	level of glutathione S-transferase mu 3 (human) in blood serum	PR:P21266	glutathione S-transferase mu 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041293	level of uridylate-specific endoribonuclease (human) in blood serum	PR:P21128	uridylate-specific endoribonuclease (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041294	level of T-cell surface glycoprotein CD3 (human) in blood serum	PR:P20963	T-cell surface glycoprotein CD3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041295	level of N(4)-(beta-N-acetylglucosaminyl)-L-asparaginase (human) in blood serum	PR:P20933	N(4)-(beta-N-acetylglucosaminyl)-L-asparaginase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041296	level of myelin-associated glycoprotein (human) in blood serum	PR:P20916	myelin-associated glycoprotein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041297	level of collagen alpha-1(V) chain (human) in blood serum	PR:P20908	collagen alpha-1(V) chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041298	level of collagen alpha-1(IX) chain (human) in blood serum	PR:P20849	collagen alpha-1(IX) chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041299	level of ephrin-A1 (human) in blood serum	PR:P20827	ephrin-A1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041300	level of laminin subunit alpha-2 (human) in blood serum	PR:P24043	laminin subunit alpha-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041301	level of interleukin-32 (human) in blood serum	PR:P24001	interleukin-32 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041302	level of ribonucleoside-diphosphate reductase large subunit (human) in blood serum	PR:P23921	ribonucleoside-diphosphate reductase large subunit (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041303	level of thymidylate kinase (human) in blood serum	PR:P23919	thymidylate kinase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041304	level of vesicle-associated membrane protein 1 (human) in blood serum	PR:P23763	vesicle-associated membrane protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041305	level of paired box protein Pax-3 (human) in blood serum	PR:P23760	paired box protein Pax-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041306	level of inositol-trisphosphate 3-kinase A (human) in blood serum	PR:P23677	inositol-trisphosphate 3-kinase A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041307	level of eukaryotic translation initiation factor 4B (human) in blood serum	PR:P23588	eukaryotic translation initiation factor 4B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041308	level of C-type natriuretic peptide (human) in blood serum	PR:P23582	C-type natriuretic peptide (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041309	level of oligodendrocyte-myelin glycoprotein (human) in blood serum	PR:P23515	oligodendrocyte-myelin glycoprotein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041310	level of nuclear transcription factor Y subunit alpha (human) in blood serum	PR:P23511	nuclear transcription factor Y subunit alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041311	level of receptor-type tyrosine-protein phosphatase delta (human) in blood serum	PR:P23468	receptor-type tyrosine-protein phosphatase delta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041312	level of ribosomal protein S6 kinase beta-1 (human) in blood serum	PR:P23443	ribosomal protein S6 kinase beta-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041313	level of cerebellin-1 (human) in blood serum	PR:P23435	cerebellin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041314	level of glycine cleavage system H protein, mitochondrial (human) in blood serum	PR:P23434	glycine cleavage system H protein, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041315	level of tryptophan--tRNA ligase, cytoplasmic (human) in blood serum	PR:P23381	tryptophan--tRNA ligase, cytoplasmic (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041316	level of NAD-dependent malic enzyme, mitochondrial (human) in blood serum	PR:P23368	NAD-dependent malic enzyme, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041317	level of anosmin-1 (human) in blood serum	PR:P23352	anosmin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041318	level of sarcoplasmic reticulum histidine-rich calcium-binding protein (human) in blood serum	PR:P23327	sarcoplasmic reticulum histidine-rich calcium-binding protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041319	level of kell blood group glycoprotein (human) in blood serum	PR:P23276	kell blood group glycoprotein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041320	level of integrin alpha-6 (human) in blood serum	PR:P23229	integrin alpha-6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041321	level of transcription elongation factor A protein 1 (human) in blood serum	PR:P23193	transcription elongation factor A protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041322	level of fibulin-1 (human) in blood serum	PR:P23142	fibulin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041323	level of liver carboxylesterase 1 (human) in blood serum	PR:P23141	liver carboxylesterase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041324	level of gamma-crystallin S (human) in blood serum	PR:P22914	gamma-crystallin S (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041325	level of lutropin-choriogonadotropic hormone receptor (human) in blood serum	PR:P22888	lutropin-choriogonadotropic hormone receptor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041326	level of carboxypeptidase N subunit 2 (human) in blood serum	PR:P22792	carboxypeptidase N subunit 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041327	level of nuclear receptor subfamily 4 group A member 1 (human) in blood serum	PR:P22736	nuclear receptor subfamily 4 group A member 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041328	level of protein-glutamine gamma-glutamyltransferase K (human) in blood serum	PR:P22735	protein-glutamine gamma-glutamyltransferase K (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041329	level of E3 ubiquitin-protein ligase CBL (human) in blood serum	PR:P22681	E3 ubiquitin-protein ligase CBL (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041330	level of calretinin (human) in blood serum	PR:P22676	calretinin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041331	level of beta-crystallin B3 (human) in blood serum	PR:P26998	beta-crystallin B3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041332	level of NKG2-A/NKG2-B type II integral membrane protein (human) in blood serum	PR:P26715	NKG2-A/NKG2-B type II integral membrane protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041333	level of mRNA decay activator protein ZFP36 (human) in blood serum	PR:P26651	mRNA decay activator protein ZFP36 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041334	level of elongation factor 1-gamma (human) in blood serum	PR:P26641	elongation factor 1-gamma (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041335	level of valine--tRNA ligase (human) in blood serum	PR:P26640	valine--tRNA ligase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041336	level of threonine--tRNA ligase 1, cytoplasmic (human) in blood serum	PR:P26639	threonine--tRNA ligase 1, cytoplasmic (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041337	level of high mobility group protein B2 (human) in blood serum	PR:P26583	high mobility group protein B2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041338	level of alpha-1,3-mannosyl-glycoprotein 2-beta-N-acetylglucosaminyltransferase (human) in blood serum	PR:P26572	alpha-1,3-mannosyl-glycoprotein 2-beta-N-acetylglucosaminyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041339	level of isovaleryl-CoA dehydrogenase, mitochondrial (human) in blood serum	PR:P26440	isovaleryl-CoA dehydrogenase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041340	level of acrosomal protein SP-10 (human) in blood serum	PR:P26436	acrosomal protein SP-10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041341	level of splicing factor U2AF 65 kDa subunit (human) in blood serum	PR:P26368	splicing factor U2AF 65 kDa subunit (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041342	level of catenin alpha-2 (human) in blood serum	PR:P26232	catenin alpha-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041343	level of probable ATP-dependent RNA helicase DDX6 (human) in blood serum	PR:P26196	probable ATP-dependent RNA helicase DDX6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041344	level of integrin beta-8 (human) in blood serum	PR:P26012	integrin beta-8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041345	level of integrin beta-7 (human) in blood serum	PR:P26010	integrin beta-7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041346	level of NF-kappa-B inhibitor alpha (human) in blood serum	PR:P25963	NF-kappa-B inhibitor alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041347	level of protein S100-P (human) in blood serum	PR:P25815	protein S100-P (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041348	level of proteasome subunit alpha type-4 (human) in blood serum	PR:P25789	proteasome subunit alpha type-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041349	level of proteasome subunit alpha type-3 (human) in blood serum	PR:P25788	proteasome subunit alpha type-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041350	level of DnaJ homolog subfamily B member 2 (human) in blood serum	PR:P25686	DnaJ homolog subfamily B member 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041351	level of transcriptional repressor protein YY1 (human) in blood serum	PR:P25490	transcriptional repressor protein YY1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041352	level of bromodomain-containing protein 2 (human) in blood serum	PR:P25440	bromodomain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041353	level of 40S ribosomal protein S12 (human) in blood serum	PR:P25398	40S ribosomal protein S12 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041354	level of 3-mercaptopyruvate sulfurtransferase (human) in blood serum	PR:P25325	3-mercaptopyruvate sulfurtransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041355	level of zinc-alpha-2-glycoprotein (human) in blood serum	PR:P25311	zinc-alpha-2-glycoprotein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041356	level of myelin protein P0 (human) in blood serum	PR:P25189	myelin protein P0 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041357	level of cyclin-dependent kinase 2 (human) in blood serum	PR:P24941	cyclin-dependent kinase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041358	level of thromboxane-A synthase (human) in blood serum	PR:P24557	thromboxane-A synthase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041359	level of ATP synthase F(0) complex subunit B1, mitochondrial (human) in blood serum	PR:P24539	ATP synthase F(0) complex subunit B1, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041360	level of corticotropin-releasing factor-binding protein (human) in blood serum	PR:P24387	corticotropin-releasing factor-binding protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041361	level of cytochrome c oxidase subunit 7A1, mitochondrial (human) in blood serum	PR:P24310	cytochrome c oxidase subunit 7A1, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041362	level of protein S100-A2 (human) in blood serum	PR:P29034	protein S100-A2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041363	level of hematopoietic progenitor cell antigen CD34 (human) in blood serum	PR:P28906	hematopoietic progenitor cell antigen CD34 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041364	level of 11-beta-hydroxysteroid dehydrogenase 1 (human) in blood serum	PR:P28845	11-beta-hydroxysteroid dehydrogenase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041365	level of cytosol aminopeptidase (human) in blood serum	PR:P28838	cytosol aminopeptidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041366	level of retinoblastoma-like protein 1 (human) in blood serum	PR:P28749	retinoblastoma-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041367	level of myeloid zinc finger 1 (human) in blood serum	PR:P28698	myeloid zinc finger 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041368	level of grancalcin (human) in blood serum	PR:P28676	grancalcin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041369	level of alcohol dehydrogenase 6 (human) in blood serum	PR:P28332	alcohol dehydrogenase 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041370	level of long-chain specific acyl-CoA dehydrogenase, mitochondrial (human) in blood serum	PR:P28330	long-chain specific acyl-CoA dehydrogenase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041371	level of ETS domain-containing protein Elk-4 (human) in blood serum	PR:P28324	ETS domain-containing protein Elk-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041372	level of tropomodulin-1 (human) in blood serum	PR:P28289	tropomodulin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041373	level of 5-hydroxytryptamine receptor 2A (human) in blood serum	PR:P28223	5-hydroxytryptamine receptor 2A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041374	level of proteasome subunit beta type-5 (human) in blood serum	PR:P28074	proteasome subunit beta type-5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041375	level of proteasome subunit beta type-6 (human) in blood serum	PR:P28072	proteasome subunit beta type-6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041376	level of proteasome subunit beta type-4 (human) in blood serum	PR:P28070	proteasome subunit beta type-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041377	level of proteasome subunit alpha type-5 (human) in blood serum	PR:P28066	proteasome subunit alpha type-5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041378	level of proteasome subunit beta type-9 (human) in blood serum	PR:P28065	proteasome subunit beta type-9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041379	level of phosphatidylinositol 3-kinase regulatory subunit alpha (human) in blood serum	PR:P27986	phosphatidylinositol 3-kinase regulatory subunit alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041380	level of calnexin (human) in blood serum	PR:P27824	calnexin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041381	level of cAMP-specific 3',5'-cyclic phosphodiesterase 4A (human) in blood serum	PR:P27815	cAMP-specific 3',5'-cyclic phosphodiesterase 4A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041382	level of deoxycytidine kinase (human) in blood serum	PR:P27707	deoxycytidine kinase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041383	level of CD82 antigen (human) in blood serum	PR:P27701	CD82 antigen (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041384	level of aryl hydrocarbon receptor nuclear translocator (human) in blood serum	PR:P27540	aryl hydrocarbon receptor nuclear translocator (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041385	level of dipeptidyl peptidase 4 (human) in blood serum	PR:P27487	dipeptidyl peptidase 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041386	level of G0/G1 switch protein 2 (human) in blood serum	PR:P27469	G0/G1 switch protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041387	level of MAP/microtubule affinity-regulating kinase 3 (human) in blood serum	PR:P27448	MAP/microtubule affinity-regulating kinase 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041388	level of cobalamin binding intrinsic factor (human) in blood serum	PR:P27352	cobalamin binding intrinsic factor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041389	level of annexin A13 (human) in blood serum	PR:P27216	annexin A13 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041390	level of adenylate kinase 4, mitochondrial (human) in blood serum	PR:P27144	adenylate kinase 4, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041391	level of stomatin (human) in blood serum	PR:P27105	stomatin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041392	level of activin receptor type-2A (human) in blood serum	PR:P27037	activin receptor type-2A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041393	level of leukocyte elastase inhibitor (human) in blood serum	PR:P30740	leukocyte elastase inhibitor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041394	level of glutathione S-transferase theta-1 (human) in blood serum	PR:P30711	glutathione S-transferase theta-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041395	level of sorcin (human) in blood serum	PR:P30626	sorcin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041396	level of pyruvate kinase PKLR (human) in blood serum	PR:P30613	pyruvate kinase PKLR (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041397	level of neuronal acetylcholine receptor subunit alpha-5 (human) in blood serum	PR:P30532	neuronal acetylcholine receptor subunit alpha-5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041398	level of M-phase inducer phosphatase 2 (human) in blood serum	PR:P30305	M-phase inducer phosphatase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041399	level of M-phase inducer phosphatase 1 (human) in blood serum	PR:P30304	M-phase inducer phosphatase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041400	level of serine/threonine-protein phosphatase 2A 65 kDa regulatory subunit A alpha isoform (human) in blood serum	PR:P30153	serine/threonine-protein phosphatase 2A 65 kDa regulatory subunit A alpha isoform (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041401	level of enoyl-CoA hydratase, mitochondrial (human) in blood serum	PR:P30084	enoyl-CoA hydratase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041402	level of 60S ribosomal protein L12 (human) in blood serum	PR:P30050	60S ribosomal protein L12 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041403	level of thioredoxin-dependent peroxide reductase, mitochondrial (human) in blood serum	PR:P30048	thioredoxin-dependent peroxide reductase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041404	level of GTP cyclohydrolase 1 feedback regulatory protein (human) in blood serum	PR:P30047	GTP cyclohydrolase 1 feedback regulatory protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041405	level of D-dopachrome decarboxylase (human) in blood serum	PR:P30046	D-dopachrome decarboxylase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041406	level of flavin reductase (NADPH) (human) in blood serum	PR:P30043	flavin reductase (NADPH) (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041407	level of elongation factor 1-delta (human) in blood serum	PR:P29692	elongation factor 1-delta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041408	level of protein PML (human) in blood serum	PR:P29590	protein PML (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041409	level of RNA-binding motif, single-stranded-interacting protein 1 (human) in blood serum	PR:P29558	RNA-binding motif, single-stranded-interacting protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041410	level of leiomodin-1 (human) in blood serum	PR:P29536	leiomodin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041411	level of serpin B3 (human) in blood serum	PR:P29508	serpin B3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041412	level of nitric oxide synthase, endothelial (human) in blood serum	PR:P29474	nitric oxide synthase, endothelial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041413	level of interleukin-12 subunit beta (human) in blood serum	PR:P29460	interleukin-12 subunit beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041414	level of interleukin-12 subunit alpha (human) in blood serum	PR:P29459	interleukin-12 subunit alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041415	level of leukocyte tyrosine kinase receptor (human) in blood serum	PR:P29376	leukocyte tyrosine kinase receptor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041416	level of DNA-3-methyladenine glycosylase (human) in blood serum	PR:P29372	DNA-3-methyladenine glycosylase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041417	level of ephrin type-A receptor 8 (human) in blood serum	PR:P29322	ephrin type-A receptor 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041418	level of inositol monophosphatase 1 (human) in blood serum	PR:P29218	inositol monophosphatase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041419	level of tripeptidyl-peptidase 2 (human) in blood serum	PR:P29144	tripeptidyl-peptidase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041420	level of neuroendocrine convertase 1 (human) in blood serum	PR:P29120	neuroendocrine convertase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041421	level of transcription initiation factor IIE subunit beta (human) in blood serum	PR:P29084	transcription initiation factor IIE subunit beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041422	level of general transcription factor IIE subunit 1 (human) in blood serum	PR:P29083	general transcription factor IIE subunit 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041423	level of tyrosine-protein phosphatase non-receptor type 4 (human) in blood serum	PR:P29074	tyrosine-protein phosphatase non-receptor type 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041424	level of lymphocyte-specific protein 1 (human) in blood serum	PR:P33241	lymphocyte-specific protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041425	level of cystathionine gamma-lyase (human) in blood serum	PR:P32929	cystathionine gamma-lyase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041426	level of desmoglein-3 (human) in blood serum	PR:P32926	desmoglein-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041427	level of interferon alpha-8 (human) in blood serum	PR:P32881	interferon alpha-8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041428	level of syntaxin-2 (human) in blood serum	PR:P32856	syntaxin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041429	level of 4-hydroxyphenylpyruvate dioxygenase (human) in blood serum	PR:P32754	4-hydroxyphenylpyruvate dioxygenase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041430	level of guanylate-binding protein 2 (human) in blood serum	PR:P32456	guanylate-binding protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041431	level of guanylate-binding protein 1 (human) in blood serum	PR:P32455	guanylate-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041432	level of pyrroline-5-carboxylate reductase 1, mitochondrial (human) in blood serum	PR:P32322	pyrroline-5-carboxylate reductase 1, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041433	level of deoxycytidylate deaminase (human) in blood serum	PR:P32321	deoxycytidylate deaminase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041434	level of homeobox protein OTX2 (human) in blood serum	PR:P32243	homeobox protein OTX2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041435	level of homeobox protein OTX1 (human) in blood serum	PR:P32242	homeobox protein OTX1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041436	level of carcinoembryonic antigen-related cell adhesion molecule 8 (human) in blood serum	PR:P31997	carcinoembryonic antigen-related cell adhesion molecule 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041437	level of protein S100-A11 (human) in blood serum	PR:P31949	protein S100-A11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041438	level of heterogeneous nuclear ribonucleoprotein H (human) in blood serum	PR:P31943	heterogeneous nuclear ribonucleoprotein H (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041439	level of bifunctional purine biosynthesis protein ATIC (human) in blood serum	PR:P31939	bifunctional purine biosynthesis protein ATIC (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041440	level of RAC-alpha serine/threonine-protein kinase (human) in blood serum	PR:P31749	RAC-alpha serine/threonine-protein kinase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041441	level of flavin-containing monooxygenase 3 (human) in blood serum	PR:P31513	flavin-containing monooxygenase 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041442	level of cytotoxic granule associated RNA binding protein TIA1 (human) in blood serum	PR:P31483	cytotoxic granule associated RNA binding protein TIA1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041443	level of calsequestrin-1 (human) in blood serum	PR:P31415	calsequestrin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041444	level of ribonucleoside-diphosphate reductase subunit M2 (human) in blood serum	PR:P31350	ribonucleoside-diphosphate reductase subunit M2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041445	level of cAMP-dependent protein kinase type II-beta regulatory subunit (human) in blood serum	PR:P31323	cAMP-dependent protein kinase type II-beta regulatory subunit (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041446	level of cAMP-dependent protein kinase type I-beta regulatory subunit (human) in blood serum	PR:P31321	cAMP-dependent protein kinase type I-beta regulatory subunit (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041447	level of Rab GDP dissociation inhibitor alpha (human) in blood serum	PR:P31150	Rab GDP dissociation inhibitor alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041448	level of lipocalin-1 (human) in blood serum	PR:P31025	lipocalin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041449	level of neurotensin/neuromedin N (human) in blood serum	PR:P30990	neurotensin/neuromedin N (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041450	level of calcitonin receptor (human) in blood serum	PR:P30988	calcitonin receptor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041451	level of somatostatin receptor type 1 (human) in blood serum	PR:P30872	somatostatin receptor type 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041452	level of aldehyde dehydrogenase, dimeric NADP-preferring (human) in blood serum	PR:P30838	aldehyde dehydrogenase, dimeric NADP-preferring (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041453	level of aldehyde dehydrogenase X, mitochondrial (human) in blood serum	PR:P30837	aldehyde dehydrogenase X, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041454	level of GTP cyclohydrolase 1 (human) in blood serum	PR:P30793	GTP cyclohydrolase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041455	level of phosphoenolpyruvate carboxykinase, cytosolic [GTP] (human) in blood serum	PR:P35558	phosphoenolpyruvate carboxykinase, cytosolic [GTP] (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041456	level of hexokinase-4 (human) in blood serum	PR:P35557	hexokinase-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041457	level of homeobox protein MSX-2 (human) in blood serum	PR:P35548	homeobox protein MSX-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041458	level of serum amyloid A-4 protein (human) in blood serum	PR:P35542	serum amyloid A-4 protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041459	level of cystathionine beta-synthase (human) in blood serum	PR:P35520	cystathionine beta-synthase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041460	level of sepiapterin reductase (human) in blood serum	PR:P35270	sepiapterin reductase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041461	level of recoverin (human) in blood serum	PR:P35243	recoverin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041462	level of radixin (human) in blood serum	PR:P35241	radixin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041463	level of tyrosine-protein phosphatase non-receptor type 7 (human) in blood serum	PR:P35236	tyrosine-protein phosphatase non-receptor type 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041464	level of Polycomb complex protein BMI-1 (human) in blood serum	PR:P35226	Polycomb complex protein BMI-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041465	level of interleukin-13 (human) in blood serum	PR:P35225	interleukin-13 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041466	level of catenin beta-1 (human) in blood serum	PR:P35222	catenin beta-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041467	level of catenin alpha-1 (human) in blood serum	PR:P35221	catenin alpha-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041468	level of carbonic anhydrase-related protein (human) in blood serum	PR:P35219	carbonic anhydrase-related protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041469	level of carbonic anhydrase 5A, mitochondrial (human) in blood serum	PR:P35218	carbonic anhydrase 5A, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041470	level of profilin-2 (human) in blood serum	PR:P35080	profilin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041471	level of glypican-1 (human) in blood serum	PR:P35052	glypican-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041472	level of 5-hydroxytryptamine receptor 7 (human) in blood serum	PR:P34969	5-hydroxytryptamine receptor 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041473	level of mannose-6-phosphate isomerase (human) in blood serum	PR:P34949	mannose-6-phosphate isomerase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041474	level of G protein-coupled receptor kinase 5 (human) in blood serum	PR:P34947	G protein-coupled receptor kinase 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041475	level of tyrosine-protein kinase RYK (human) in blood serum	PR:P34925	tyrosine-protein kinase RYK (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041476	level of bifunctional epoxide hydrolase 2 (human) in blood serum	PR:P34913	bifunctional epoxide hydrolase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041477	level of serine hydroxymethyltransferase, mitochondrial (human) in blood serum	PR:P34897	serine hydroxymethyltransferase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041478	level of serine hydroxymethyltransferase, cytosolic (human) in blood serum	PR:P34896	serine hydroxymethyltransferase, cytosolic (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041479	level of bone morphogenetic protein 8B (human) in blood serum	PR:P34820	bone morphogenetic protein 8B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041480	level of macrosialin (human) in blood serum	PR:P34810	macrosialin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041481	level of ribonuclease 4 (human) in blood serum	PR:P34096	ribonuclease 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041482	level of N-acetylgalactosamine-6-sulfatase (human) in blood serum	PR:P34059	N-acetylgalactosamine-6-sulfatase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041483	level of protein S100-A5 (human) in blood serum	PR:P33763	protein S100-A5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041484	level of deoxyuridine 5'-triphosphate nucleotidohydrolase, mitochondrial (human) in blood serum	PR:P33316	deoxyuridine 5'-triphosphate nucleotidohydrolase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041485	level of cytochrome P450 2C19 (human) in blood serum	PR:P33261	cytochrome P450 2C19 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041486	level of 40S ribosomal protein S19 (human) in blood serum	PR:P39019	40S ribosomal protein S19 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041487	level of cyclin-dependent kinase inhibitor 1 (human) in blood serum	PR:P38936	cyclin-dependent kinase inhibitor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041488	level of stress-70 protein, mitochondrial (human) in blood serum	PR:P38646	stress-70 protein, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041489	level of transaldolase (human) in blood serum	PR:P37837	transaldolase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041490	level of hippocalcin-like protein 1 (human) in blood serum	PR:P37235	hippocalcin-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041491	level of peroxisome proliferator-activated receptor gamma (human) in blood serum	PR:P37231	peroxisome proliferator-activated receptor gamma (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041492	level of signal recognition particle 14 kDa protein (human) in blood serum	PR:P37108	signal recognition particle 14 kDa protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041493	level of GMP reductase 1 (human) in blood serum	PR:P36959	GMP reductase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041494	level of dihydrolipoyllysine-residue succinyltransferase component of 2-oxoglutarate dehydrogenase complex, mitochondrial (human) in blood serum	PR:P36957	dihydrolipoyllysine-residue succinyltransferase component of 2-oxoglutarate dehydrogenase complex, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041495	level of DNA-directed RNA polymerase II subunit RPB9 (human) in blood serum	PR:P36954	DNA-directed RNA polymerase II subunit RPB9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041496	level of serpin B5 (human) in blood serum	PR:P36952	serpin B5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041497	level of TGF-beta receptor type-1 (human) in blood serum	PR:P36897	TGF-beta receptor type-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041498	level of serine/threonine-protein phosphatase PP1-gamma catalytic subunit (human) in blood serum	PR:P36873	serine/threonine-protein phosphatase PP1-gamma catalytic subunit (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041499	level of Lon protease homolog, mitochondrial (human) in blood serum	PR:P36776	Lon protease homolog, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041500	level of oxidized purine nucleoside triphosphate hydrolase (human) in blood serum	PR:P36639	oxidized purine nucleoside triphosphate hydrolase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041501	level of oxygen-dependent coproporphyrinogen-III oxidase, mitochondrial (human) in blood serum	PR:P36551	oxygen-dependent coproporphyrinogen-III oxidase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041502	level of ADP-ribosylation factor-like protein 3 (human) in blood serum	PR:P36405	ADP-ribosylation factor-like protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041503	level of ADP-ribosylation factor-like protein 2 (human) in blood serum	PR:P36404	ADP-ribosylation factor-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041504	level of glutathione hydrolase 5 proenzyme (human) in blood serum	PR:P36269	glutathione hydrolase 5 proenzyme (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041505	level of inactive glutathione hydrolase 2 (human) in blood serum	PR:P36268	inactive glutathione hydrolase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041506	level of chitinase-3-like protein 1 (human) in blood serum	PR:P36222	chitinase-3-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041507	level of hydroxymethylglutaryl-CoA lyase, mitochondrial (human) in blood serum	PR:P35914	hydroxymethylglutaryl-CoA lyase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041508	level of keratin, type I cytoskeletal 20 (human) in blood serum	PR:P35900	keratin, type I cytoskeletal 20 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041509	level of insulin-like growth factor-binding protein complex acid labile subunit (human) in blood serum	PR:P35858	insulin-like growth factor-binding protein complex acid labile subunit (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041510	level of protein phosphatase 1A (human) in blood serum	PR:P35813	protein phosphatase 1A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041511	level of glutaredoxin-1 (human) in blood serum	PR:P35754	glutaredoxin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041512	level of transcription factor SOX-6 (human) in blood serum	PR:P35712	transcription factor SOX-6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041513	level of DNA damage-inducible transcript 3 protein (human) in blood serum	PR:P35638	DNA damage-inducible transcript 3 protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041514	level of beta-adducin (human) in blood serum	PR:P35612	beta-adducin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041515	level of alpha-actinin-2 (human) in blood serum	PR:P35609	alpha-actinin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041516	level of coatomer subunit beta' (human) in blood serum	PR:P35606	coatomer subunit beta' (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041517	level of glycine--tRNA ligase (human) in blood serum	PR:P41250	glycine--tRNA ligase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041518	level of protein phosphatase inhibitor 2 (human) in blood serum	PR:P41236	protein phosphatase inhibitor 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041519	level of hepatocyte nuclear factor 4-alpha (human) in blood serum	PR:P41235	hepatocyte nuclear factor 4-alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041520	level of N-alpha-acetyltransferase 10 (human) in blood serum	PR:P41227	N-alpha-acetyltransferase 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041521	level of ubiquitin-like modifier-activating enzyme 7 (human) in blood serum	PR:P41226	ubiquitin-like modifier-activating enzyme 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041522	level of protein BUD31 homolog (human) in blood serum	PR:P41223	protein BUD31 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041523	level of prostaglandin-H2 D-isomerase (human) in blood serum	PR:P41222	prostaglandin-H2 D-isomerase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041524	level of protein Wnt-5a (human) in blood serum	PR:P41221	protein Wnt-5a (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041525	level of centrin-2 (human) in blood serum	PR:P41208	centrin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041526	level of DNA-binding protein inhibitor ID-1 (human) in blood serum	PR:P41134	DNA-binding protein inhibitor ID-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041527	level of melanocyte protein PMEL (human) in blood serum	PR:P40967	melanocyte protein PMEL (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041528	level of interleukin-15 (human) in blood serum	PR:P40933	interleukin-15 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041529	level of malate dehydrogenase, mitochondrial (human) in blood serum	PR:P40926	malate dehydrogenase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041530	level of ubiquitin carboxyl-terminal hydrolase 8 (human) in blood serum	PR:P40818	ubiquitin carboxyl-terminal hydrolase 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041531	level of ADP-ribosylation factor-like protein 1 (human) in blood serum	PR:P40616	ADP-ribosylation factor-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041532	level of all-trans-retinol dehydrogenase [NAD(+)] ADH7 (human) in blood serum	PR:P40394	all-trans-retinol dehydrogenase [NAD(+)] ADH7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041533	level of von Hippel-Lindau disease tumor suppressor (human) in blood serum	PR:P40337	von Hippel-Lindau disease tumor suppressor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041534	level of chymotrypsin-like protease CTRL-1 (human) in blood serum	PR:P40313	chymotrypsin-like protease CTRL-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041535	level of proteasome subunit beta type-10 (human) in blood serum	PR:P40306	proteasome subunit beta type-10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041536	level of nicotinamide N-methyltransferase (human) in blood serum	PR:P40261	nicotinamide N-methyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041537	level of B-cell antigen receptor complex-associated protein beta chain (human) in blood serum	PR:P40259	B-cell antigen receptor complex-associated protein beta chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041538	level of alpha-taxilin (human) in blood serum	PR:P40222	alpha-taxilin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041539	level of T-cell surface protein tactile (human) in blood serum	PR:P40200	T-cell surface protein tactile (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041540	level of carcinoembryonic antigen-related cell adhesion molecule 3 (human) in blood serum	PR:P40198	carcinoembryonic antigen-related cell adhesion molecule 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041541	level of platelet glycoprotein V (human) in blood serum	PR:P40197	platelet glycoprotein V (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041542	level of interleukin-6 receptor subunit beta (human) in blood serum	PR:P40189	interleukin-6 receptor subunit beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041543	level of L-dopachrome tautomerase (human) in blood serum	PR:P40126	L-dopachrome tautomerase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041544	level of flap endonuclease 1 (human) in blood serum	PR:P39748	flap endonuclease 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041545	level of acidic leucine-rich nuclear phosphoprotein 32 family member A (human) in blood serum	PR:P39687	acidic leucine-rich nuclear phosphoprotein 32 family member A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041546	level of dolichyl-diphosphooligosaccharide--protein glycosyltransferase 48 kDa subunit (human) in blood serum	PR:P39656	dolichyl-diphosphooligosaccharide--protein glycosyltransferase 48 kDa subunit (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041547	level of collagen alpha-1(XV) chain (human) in blood serum	PR:P39059	collagen alpha-1(XV) chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041548	level of putative melanoma-associated antigen 5P (human) in blood serum	PR:P43359	putative melanoma-associated antigen 5P (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041549	level of melanoma-associated antigen 4 (human) in blood serum	PR:P43358	melanoma-associated antigen 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041550	level of melanoma-associated antigen 3 (human) in blood serum	PR:P43357	melanoma-associated antigen 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041551	level of aldehyde dehydrogenase family 3 member B1 (human) in blood serum	PR:P43353	aldehyde dehydrogenase family 3 member B1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041552	level of beta-crystallin B2 (human) in blood serum	PR:P43320	beta-crystallin B2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041553	level of translocon-associated protein subunit beta (human) in blood serum	PR:P43308	translocon-associated protein subunit beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041554	level of translocon-associated protein subunit alpha (human) in blood serum	PR:P43307	translocon-associated protein subunit alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041555	level of biotinidase (human) in blood serum	PR:P43251	biotinidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041556	level of DNA mismatch repair protein Msh2 (human) in blood serum	PR:P43246	DNA mismatch repair protein Msh2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041557	level of cathepsin K (human) in blood serum	PR:P43235	cathepsin K (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041558	level of cathepsin O (human) in blood serum	PR:P43234	cathepsin O (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041559	level of carnitine O-acetyltransferase (human) in blood serum	PR:P43155	carnitine O-acetyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041560	level of netrin receptor DCC (human) in blood serum	PR:P43146	netrin receptor DCC (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041561	level of cell surface glycoprotein MUC18 (human) in blood serum	PR:P43121	cell surface glycoprotein MUC18 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041562	level of guanylyl cyclase-activating protein 1 (human) in blood serum	PR:P43080	guanylyl cyclase-activating protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041563	level of lysosomal Pro-X carboxypeptidase (human) in blood serum	PR:P42785	lysosomal Pro-X carboxypeptidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041564	level of cyclin-dependent kinase 4 inhibitor C (human) in blood serum	PR:P42773	cyclin-dependent kinase 4 inhibitor C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041565	level of cyclin-dependent kinase 4 inhibitor B (human) in blood serum	PR:P42772	cyclin-dependent kinase 4 inhibitor B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041566	level of actin nucleation-promoting factor WAS (human) in blood serum	PR:P42768	actin nucleation-promoting factor WAS (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041567	level of dipeptidyl aminopeptidase-like protein 6 (human) in blood serum	PR:P42658	dipeptidyl aminopeptidase-like protein 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041568	level of Rho GTPase-activating protein 25 (human) in blood serum	PR:P42331	Rho GTPase-activating protein 25 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041569	level of aldo-keto reductase family 1 member C3 (human) in blood serum	PR:P42330	aldo-keto reductase family 1 member C3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041570	level of signal transducer and activator of transcription 5A (human) in blood serum	PR:P42229	signal transducer and activator of transcription 5A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041571	level of lamina-associated polypeptide 2 isoforms beta/gamma/zeta (human) in blood serum	PR:P42167	lamina-associated polypeptide 2 isoforms beta/gamma/zeta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041572	level of agouti-signaling protein (human) in blood serum	PR:P42127	agouti-signaling protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041573	level of enoyl-CoA Delta isomerase 1, mitochondrial (human) in blood serum	PR:P42126	enoyl-CoA Delta isomerase 1, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041574	level of ETS domain-containing protein Elk-3 (human) in blood serum	PR:P41970	ETS domain-containing protein Elk-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041575	level of pituitary adenylate cyclase-activating polypeptide type I receptor (human) in blood serum	PR:P41586	pituitary adenylate cyclase-activating polypeptide type I receptor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041576	level of eukaryotic translation initiation factor 1 (human) in blood serum	PR:P41567	eukaryotic translation initiation factor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041577	level of folate receptor gamma (human) in blood serum	PR:P41439	folate receptor gamma (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041578	level of isoleucine--tRNA ligase, cytoplasmic (human) in blood serum	PR:P41252	isoleucine--tRNA ligase, cytoplasmic (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041579	level of F-actin-capping protein subunit beta (human) in blood serum	PR:P47756	F-actin-capping protein subunit beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041580	level of Rap1 GTPase-activating protein 1 (human) in blood serum	PR:P47736	Rap1 GTPase-activating protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041581	level of cytosolic phospholipase A2 (human) in blood serum	PR:P47712	cytosolic phospholipase A2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041582	level of transcriptional coactivator YAP1 (human) in blood serum	PR:P46937	transcriptional coactivator YAP1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041583	level of glucosamine-6-phosphate isomerase 1 (human) in blood serum	PR:P46926	glucosamine-6-phosphate isomerase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041584	level of 40S ribosomal protein S5 (human) in blood serum	PR:P46782	40S ribosomal protein S5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041585	level of 60S ribosomal protein L5 (human) in blood serum	PR:P46777	60S ribosomal protein L5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041586	level of radiation-inducible immediate-early gene IEX-1 (human) in blood serum	PR:P46695	radiation-inducible immediate-early gene IEX-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041587	level of vesicle-fusing ATPase (human) in blood serum	PR:P46459	vesicle-fusing ATPase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041588	level of glutathione S-transferase mu 5 (human) in blood serum	PR:P46439	glutathione S-transferase mu 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041589	level of large proline-rich protein BAG6 (human) in blood serum	PR:P46379	large proline-rich protein BAG6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041590	level of Crk-like protein (human) in blood serum	PR:P46109	Crk-like protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041591	level of ATP-dependent DNA helicase Q1 (human) in blood serum	PR:P46063	ATP-dependent DNA helicase Q1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041592	level of Ran GTPase-activating protein 1 (human) in blood serum	PR:P46060	Ran GTPase-activating protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041593	level of phosphorylase b kinase regulatory subunit alpha, skeletal muscle isoform (human) in blood serum	PR:P46020	phosphorylase b kinase regulatory subunit alpha, skeletal muscle isoform (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041594	level of ubiquitin carboxyl-terminal hydrolase 5 (human) in blood serum	PR:P45974	ubiquitin carboxyl-terminal hydrolase 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041595	level of short/branched chain specific acyl-CoA dehydrogenase, mitochondrial (human) in blood serum	PR:P45954	short/branched chain specific acyl-CoA dehydrogenase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041596	level of peptidyl-prolyl cis-trans isomerase C (human) in blood serum	PR:P45877	peptidyl-prolyl cis-trans isomerase C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041597	level of aspartoacylase (human) in blood serum	PR:P45381	aspartoacylase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041598	level of troponin T, cardiac muscle (human) in blood serum	PR:P45379	troponin T, cardiac muscle (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041599	level of killer cell immunoglobulin-like receptor 2DS4 (human) in blood serum	PR:P43632	killer cell immunoglobulin-like receptor 2DS4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041600	level of killer cell immunoglobulin-like receptor 2DS2 (human) in blood serum	PR:P43631	killer cell immunoglobulin-like receptor 2DS2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041601	level of killer cell immunoglobulin-like receptor 3DL1 (human) in blood serum	PR:P43629	killer cell immunoglobulin-like receptor 3DL1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041602	level of killer cell immunoglobulin-like receptor 2DL3 (human) in blood serum	PR:P43628	killer cell immunoglobulin-like receptor 2DL3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041603	level of killer cell immunoglobulin-like receptor 2DL2 (human) in blood serum	PR:P43627	killer cell immunoglobulin-like receptor 2DL2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041604	level of killer cell immunoglobulin-like receptor 2DL1 (human) in blood serum	PR:P43626	killer cell immunoglobulin-like receptor 2DL1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041605	level of Ran-specific GTPase-activating protein (human) in blood serum	PR:P43487	Ran-specific GTPase-activating protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041606	level of tyrosine-protein phosphatase non-receptor type 9 (human) in blood serum	PR:P43378	tyrosine-protein phosphatase non-receptor type 9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041607	level of melanoma-associated antigen 10 (human) in blood serum	PR:P43363	melanoma-associated antigen 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041608	level of melanoma-associated antigen 8 (human) in blood serum	PR:P43361	melanoma-associated antigen 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041609	level of melanoma-associated antigen 6 (human) in blood serum	PR:P43360	melanoma-associated antigen 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041610	level of guided entry of tail-anchored proteins factor CAMLG (human) in blood serum	PR:P49069	guided entry of tail-anchored proteins factor CAMLG (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041611	level of MARCKS-related protein (human) in blood serum	PR:P49006	MARCKS-related protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041612	level of tryptophan 2,3-dioxygenase (human) in blood serum	PR:P48775	tryptophan 2,3-dioxygenase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041613	level of phosphatidylinositol transfer protein beta isoform (human) in blood serum	PR:P48739	phosphatidylinositol transfer protein beta isoform (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041614	level of casein kinase I isoform delta (human) in blood serum	PR:P48730	casein kinase I isoform delta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041615	level of aminomethyltransferase, mitochondrial (human) in blood serum	PR:P48728	aminomethyltransferase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041616	level of heat shock 70 kDa protein 13 (human) in blood serum	PR:P48723	heat shock 70 kDa protein 13 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041617	level of neuromedin-U (human) in blood serum	PR:P48645	neuromedin-U (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041618	level of glutathione synthetase (human) in blood serum	PR:P48637	glutathione synthetase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041619	level of serpin B4 (human) in blood serum	PR:P48594	serpin B4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041620	level of glutamate--cysteine ligase regulatory subunit (human) in blood serum	PR:P48507	glutamate--cysteine ligase regulatory subunit (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041621	level of transcription factor SOX-9 (human) in blood serum	PR:P48436	transcription factor SOX-9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041622	level of transcription factor SOX-2 (human) in blood serum	PR:P48431	transcription factor SOX-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041623	level of phosphatidylinositol 5-phosphate 4-kinase type-2 alpha (human) in blood serum	PR:P48426	phosphatidylinositol 5-phosphate 4-kinase type-2 alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041624	level of DNA-binding protein RFX5 (human) in blood serum	PR:P48382	DNA-binding protein RFX5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041625	level of tissue factor pathway inhibitor 2 (human) in blood serum	PR:P48307	tissue factor pathway inhibitor 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041626	level of lithostathine-1-beta (human) in blood serum	PR:P48304	lithostathine-1-beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041627	level of gap junction alpha-8 protein (human) in blood serum	PR:P48165	gap junction alpha-8 protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041628	level of NADP-dependent malic enzyme (human) in blood serum	PR:P48163	NADP-dependent malic enzyme (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041629	level of prolyl endopeptidase (human) in blood serum	PR:P48147	prolyl endopeptidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041630	level of sodium- and chloride-dependent glycine transporter 1 (human) in blood serum	PR:P48067	sodium- and chloride-dependent glycine transporter 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041631	level of glioma pathogenesis-related protein 1 (human) in blood serum	PR:P48060	glioma pathogenesis-related protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041632	level of glutamate receptor 4 (human) in blood serum	PR:P48058	glutamate receptor 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041633	level of carboxypeptidase A2 (human) in blood serum	PR:P48052	carboxypeptidase A2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041634	level of ATP synthase subunit O, mitochondrial (human) in blood serum	PR:P48047	ATP synthase subunit O, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041635	level of xanthine dehydrogenase/oxidase (human) in blood serum	PR:P47989	xanthine dehydrogenase/oxidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041636	level of neuronal pentraxin-2 (human) in blood serum	PR:P47972	neuronal pentraxin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041637	level of homeobox protein CDX-1 (human) in blood serum	PR:P47902	homeobox protein CDX-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041638	level of aldehyde dehydrogenase family 1 member A3 (human) in blood serum	PR:P47895	aldehyde dehydrogenase family 1 member A3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041639	level of olfactory marker protein (human) in blood serum	PR:P47874	olfactory marker protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041640	level of eukaryotic translation initiation factor 1A, X-chromosomal (human) in blood serum	PR:P47813	eukaryotic translation initiation factor 1A, X-chromosomal (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041641	level of retinoic acid receptor responder protein 1 (human) in blood serum	PR:P49788	retinoic acid receptor responder protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041642	level of vascular endothelial growth factor B (human) in blood serum	PR:P49765	vascular endothelial growth factor B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041643	level of dual specificity protein kinase CLK2 (human) in blood serum	PR:P49760	dual specificity protein kinase CLK2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041644	level of protein numb homolog (human) in blood serum	PR:P49757	protein numb homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041645	level of transmembrane emp24 domain-containing protein 10 (human) in blood serum	PR:P49755	transmembrane emp24 domain-containing protein 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041646	level of very long-chain specific acyl-CoA dehydrogenase, mitochondrial (human) in blood serum	PR:P49748	very long-chain specific acyl-CoA dehydrogenase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041647	level of cartilage oligomeric matrix protein (human) in blood serum	PR:P49747	cartilage oligomeric matrix protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041648	level of thrombospondin-3 (human) in blood serum	PR:P49746	thrombospondin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041649	level of proteasome subunit beta type-2 (human) in blood serum	PR:P49721	proteasome subunit beta type-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041650	level of proteasome subunit beta type-3 (human) in blood serum	PR:P49720	proteasome subunit beta type-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041651	level of CCAAT/enhancer-binding protein alpha (human) in blood serum	PR:P49715	CCAAT/enhancer-binding protein alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041652	level of transcriptional repressor CTCF (human) in blood serum	PR:P49711	transcriptional repressor CTCF (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041653	level of ADP-ribosylation factor-like protein 4D (human) in blood serum	PR:P49703	ADP-ribosylation factor-like protein 4D (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041654	level of steroidogenic acute regulatory protein, mitochondrial (human) in blood serum	PR:P49675	steroidogenic acute regulatory protein, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041655	level of caspase-4 (human) in blood serum	PR:P49662	caspase-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041656	level of DNA primase small subunit (human) in blood serum	PR:P49642	DNA primase small subunit (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041657	level of protein phosphatase 1F (human) in blood serum	PR:P49593	protein phosphatase 1F (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041658	level of serine--tRNA ligase, cytoplasmic (human) in blood serum	PR:P49591	serine--tRNA ligase, cytoplasmic (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041659	level of cysteine--tRNA ligase, cytoplasmic (human) in blood serum	PR:P49589	cysteine--tRNA ligase, cytoplasmic (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041660	level of alanine--tRNA ligase, cytoplasmic (human) in blood serum	PR:P49588	alanine--tRNA ligase, cytoplasmic (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041661	level of ubiquitin-conjugating enzyme E2 A (human) in blood serum	PR:P49459	ubiquitin-conjugating enzyme E2 A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041662	level of ubiquitin-conjugating enzyme E2 R1 (human) in blood serum	PR:P49427	ubiquitin-conjugating enzyme E2 R1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041663	level of alpha-aminoadipic semialdehyde dehydrogenase (human) in blood serum	PR:P49419	alpha-aminoadipic semialdehyde dehydrogenase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041664	level of amphiphysin (human) in blood serum	PR:P49418	amphiphysin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041665	level of beta-arrestin-1 (human) in blood serum	PR:P49407	beta-arrestin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041666	level of protein farnesyltransferase/geranylgeranyltransferase type-1 subunit alpha (human) in blood serum	PR:P49354	protein farnesyltransferase/geranylgeranyltransferase type-1 subunit alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041667	level of fatty acid synthase (human) in blood serum	PR:P49327	fatty acid synthase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041668	level of protein ERGIC-53 (human) in blood serum	PR:P49257	protein ERGIC-53 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041669	level of ribose-5-phosphate isomerase (human) in blood serum	PR:P49247	ribose-5-phosphate isomerase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041670	level of Kunitz-type protease inhibitor 3 (human) in blood serum	PR:P49223	Kunitz-type protease inhibitor 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041671	level of protein-glutamine gamma-glutamyltransferase 4 (human) in blood serum	PR:P49221	protein-glutamine gamma-glutamyltransferase 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041672	level of dynamin-2 (human) in blood serum	PR:P50570	dynamin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041673	level of vasodilator-stimulated phosphoprotein (human) in blood serum	PR:P50552	vasodilator-stimulated phosphoprotein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041674	level of max-interacting protein 1 (human) in blood serum	PR:P50539	max-interacting protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041675	level of Hsc70-interacting protein (human) in blood serum	PR:P50502	Hsc70-interacting protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041676	level of PDZ and LIM domain protein 4 (human) in blood serum	PR:P50479	PDZ and LIM domain protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041677	level of serpin H1 (human) in blood serum	PR:P50454	serpin H1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041678	level of serpin B9 (human) in blood serum	PR:P50453	serpin B9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041679	level of serpin B8 (human) in blood serum	PR:P50452	serpin B8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041680	level of glycine amidinotransferase, mitochondrial (human) in blood serum	PR:P50440	glycine amidinotransferase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041681	level of 5-hydroxytryptamine receptor 6 (human) in blood serum	PR:P50406	5-hydroxytryptamine receptor 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041682	level of cysteine-rich protein 1 (human) in blood serum	PR:P50238	cysteine-rich protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041683	level of sulfotransferase 1A1 (human) in blood serum	PR:P50225	sulfotransferase 1A1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041684	level of homeobox protein MOX-2 (human) in blood serum	PR:P50222	homeobox protein MOX-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041685	level of homeobox protein MOX-1 (human) in blood serum	PR:P50221	homeobox protein MOX-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041686	level of motor neuron and pancreas homeobox protein 1 (human) in blood serum	PR:P50219	motor neuron and pancreas homeobox protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041687	level of guanine nucleotide-binding protein G(q) subunit alpha (human) in blood serum	PR:P50148	guanine nucleotide-binding protein G(q) subunit alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041688	level of histamine N-methyltransferase (human) in blood serum	PR:P50135	histamine N-methyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041689	level of retinol-binding protein 2 (human) in blood serum	PR:P50120	retinol-binding protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041690	level of ketohexokinase (human) in blood serum	PR:P50053	ketohexokinase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041691	level of double-strand break repair protein MRE11 (human) in blood serum	PR:P49959	double-strand break repair protein MRE11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041692	level of 5-formyltetrahydrofolate cyclo-ligase (human) in blood serum	PR:P49914	5-formyltetrahydrofolate cyclo-ligase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041693	level of cathelicidin antimicrobial peptide (human) in blood serum	PR:P49913	cathelicidin antimicrobial peptide (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041694	level of selenide, water dikinase 1 (human) in blood serum	PR:P49903	selenide, water dikinase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041695	level of cytosolic purine 5'-nucleotidase (human) in blood serum	PR:P49902	cytosolic purine 5'-nucleotidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041696	level of sulfotransferase 1E1 (human) in blood serum	PR:P49888	sulfotransferase 1E1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041697	level of granzyme K (human) in blood serum	PR:P49863	granzyme K (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041698	level of glycogen synthase kinase-3 beta (human) in blood serum	PR:P49841	glycogen synthase kinase-3 beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041699	level of regulator of G-protein signaling 4 (human) in blood serum	PR:P49798	regulator of G-protein signaling 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041700	level of regulator of G-protein signaling 3 (human) in blood serum	PR:P49796	regulator of G-protein signaling 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041701	level of regulator of G-protein signaling 19 (human) in blood serum	PR:P49795	regulator of G-protein signaling 19 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041702	level of bis(5'-adenosyl)-triphosphatase (human) in blood serum	PR:P49789	bis(5'-adenosyl)-triphosphatase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041703	level of zinc finger protein 41 (human) in blood serum	PR:P51814	zinc finger protein 41 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041704	level of vesicle-associated membrane protein 7 (human) in blood serum	PR:P51809	vesicle-associated membrane protein 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041705	level of dynein light chain Tctex-type 3 (human) in blood serum	PR:P51808	dynein light chain Tctex-type 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041706	level of ubiquitin carboxyl-terminal hydrolase 11 (human) in blood serum	PR:P51784	ubiquitin carboxyl-terminal hydrolase 11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041707	level of amyloid beta precursor like protein 1 (human) in blood serum	PR:P51693	amyloid beta precursor like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041708	level of signal transducer and activator of transcription 5B (human) in blood serum	PR:P51692	signal transducer and activator of transcription 5B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041709	level of N-sulphoglucosamine sulphohydrolase (human) in blood serum	PR:P51688	N-sulphoglucosamine sulphohydrolase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041710	level of sulfite oxidase, mitochondrial (human) in blood serum	PR:P51687	sulfite oxidase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041711	level of ubiquitin-conjugating enzyme E2 D1 (human) in blood serum	PR:P51668	ubiquitin-conjugating enzyme E2 D1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041712	level of succinate-semialdehyde dehydrogenase, mitochondrial (human) in blood serum	PR:P51649	succinate-semialdehyde dehydrogenase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041713	level of caveolin-2 (human) in blood serum	PR:P51636	caveolin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041714	level of methyl-CpG-binding protein 2 (human) in blood serum	PR:P51608	methyl-CpG-binding protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041715	level of thiopurine S-methyltransferase (human) in blood serum	PR:P51580	thiopurine S-methyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041716	level of galactokinase (human) in blood serum	PR:P51570	galactokinase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041717	level of isocitrate dehydrogenase [NAD] subunit gamma, mitochondrial (human) in blood serum	PR:P51553	isocitrate dehydrogenase [NAD] subunit gamma, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041718	level of RNA-binding protein Nova-1 (human) in blood serum	PR:P51513	RNA-binding protein Nova-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041719	level of insulin-like 3 (human) in blood serum	PR:P51460	insulin-like 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041720	level of tyrosine-protein kinase Blk (human) in blood serum	PR:P51451	tyrosine-protein kinase Blk (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041721	level of nuclear receptor ROR-gamma (human) in blood serum	PR:P51449	nuclear receptor ROR-gamma (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041722	level of death-associated protein 1 (human) in blood serum	PR:P51397	death-associated protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041723	level of 1-phosphatidylinositol 4,5-bisphosphate phosphodiesterase delta-1 (human) in blood serum	PR:P51178	1-phosphatidylinositol 4,5-bisphosphate phosphodiesterase delta-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041724	level of gastrotropin (human) in blood serum	PR:P51161	gastrotropin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041725	level of Ras-related protein Rab-27A (human) in blood serum	PR:P51159	Ras-related protein Rab-27A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041726	level of Ras-related protein Rab-13 (human) in blood serum	PR:P51153	Ras-related protein Rab-13 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041727	level of Ras-related protein Rab-7a (human) in blood serum	PR:P51149	Ras-related protein Rab-7a (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041728	level of Ras-related protein Rab-5C (human) in blood serum	PR:P51148	Ras-related protein Rab-5C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041729	level of RNA-binding protein FXR1 (human) in blood serum	PR:P51114	RNA-binding protein FXR1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041730	level of annexin A11 (human) in blood serum	PR:P50995	annexin A11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041731	level of palmitoyl-protein thioesterase 1 (human) in blood serum	PR:P50897	palmitoyl-protein thioesterase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041732	level of Ras association domain-containing protein 2 (human) in blood serum	PR:P50749	Ras association domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041733	level of bis(5'-nucleosyl)-tetraphosphatase [asymmetrical] (human) in blood serum	PR:P50583	bis(5'-nucleosyl)-tetraphosphatase [asymmetrical] (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041734	level of death-associated protein kinase 1 (human) in blood serum	PR:P53355	death-associated protein kinase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041735	level of tricarboxylate transport protein, mitochondrial (human) in blood serum	PR:P53007	tricarboxylate transport protein, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041736	level of biliverdin reductase A (human) in blood serum	PR:P53004	biliverdin reductase A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041737	level of nuclear pore complex protein Nup98-Nup96 (human) in blood serum	PR:P52948	nuclear pore complex protein Nup98-Nup96 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041738	level of cysteine-rich protein 2 (human) in blood serum	PR:P52943	cysteine-rich protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041739	level of high mobility group protein HMGI-C (human) in blood serum	PR:P52926	high mobility group protein HMGI-C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041740	level of aldo-keto reductase family 1 member C2 (human) in blood serum	PR:P52895	aldo-keto reductase family 1 member C2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041741	level of thimet oligopeptidase (human) in blood serum	PR:P52888	thimet oligopeptidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041742	level of bifunctional heparan sulfate N-deacetylase/N-sulfotransferase 1 (human) in blood serum	PR:P52848	bifunctional heparan sulfate N-deacetylase/N-sulfotransferase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041743	level of 39S ribosomal protein L12, mitochondrial (human) in blood serum	PR:P52815	39S ribosomal protein L12, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041744	level of spermine synthase (human) in blood serum	PR:P52788	spermine synthase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041745	level of 2-iminobutanoate/2-iminopropanoate deaminase (human) in blood serum	PR:P52758	2-iminobutanoate/2-iminopropanoate deaminase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041746	level of zinc finger protein 134 (human) in blood serum	PR:P52741	zinc finger protein 134 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041747	level of transcription initiation factor IIA subunit 2 (human) in blood serum	PR:P52657	transcription initiation factor IIA subunit 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041748	level of heterogeneous nuclear ribonucleoprotein F (human) in blood serum	PR:P52597	heterogeneous nuclear ribonucleoprotein F (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041749	level of Arf-GAP domain and FG repeat-containing protein 1 (human) in blood serum	PR:P52594	Arf-GAP domain and FG repeat-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041750	level of Rho GDP-dissociation inhibitor 2 (human) in blood serum	PR:P52566	Rho GDP-dissociation inhibitor 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041751	level of dual specificity mitogen-activated protein kinase kinase 6 (human) in blood serum	PR:P52564	dual specificity mitogen-activated protein kinase kinase 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041752	level of DNA-directed RNA polymerase II subunit RPB11-a (human) in blood serum	PR:P52435	DNA-directed RNA polymerase II subunit RPB11-a (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041753	level of Rap1 GTPase-GDP dissociation stimulator 1 (human) in blood serum	PR:P52306	Rap1 GTPase-GDP dissociation stimulator 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041754	level of nuclear cap-binding protein subunit 2 (human) in blood serum	PR:P52298	nuclear cap-binding protein subunit 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041755	level of importin subunit alpha-5 (human) in blood serum	PR:P52294	importin subunit alpha-5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041756	level of heterogeneous nuclear ribonucleoprotein M (human) in blood serum	PR:P52272	heterogeneous nuclear ribonucleoprotein M (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041757	level of ubiquitin-conjugating enzyme E2 E1 (human) in blood serum	PR:P51965	ubiquitin-conjugating enzyme E2 E1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041758	level of CDK-activating kinase assembly factor MAT1 (human) in blood serum	PR:P51948	CDK-activating kinase assembly factor MAT1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041759	level of cyclin-H (human) in blood serum	PR:P51946	cyclin-H (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041760	level of calponin-1 (human) in blood serum	PR:P51911	calponin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041761	level of caspase-5 (human) in blood serum	PR:P51878	caspase-5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041762	level of hepatoma-derived growth factor (human) in blood serum	PR:P51858	hepatoma-derived growth factor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041763	level of aldo-keto reductase family 1 member D1 (human) in blood serum	PR:P51857	aldo-keto reductase family 1 member D1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041764	level of zinc finger protein 75D (human) in blood serum	PR:P51815	zinc finger protein 75D (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041765	level of ephrin type-B receptor 1 (human) in blood serum	PR:P54762	ephrin type-B receptor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041766	level of ephrin type-B receptor 3 (human) in blood serum	PR:P54753	ephrin type-B receptor 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041767	level of UV excision repair protein RAD23 homolog B (human) in blood serum	PR:P54727	UV excision repair protein RAD23 homolog B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041768	level of UV excision repair protein RAD23 homolog A (human) in blood serum	PR:P54725	UV excision repair protein RAD23 homolog A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041769	level of sodium/potassium-transporting ATPase subunit gamma (human) in blood serum	PR:P54710	sodium/potassium-transporting ATPase subunit gamma (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041770	level of heat shock-related 70 kDa protein 2 (human) in blood serum	PR:P54652	heat shock-related 70 kDa protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041771	level of ubiquitin carboxyl-terminal hydrolase 14 (human) in blood serum	PR:P54578	ubiquitin carboxyl-terminal hydrolase 14 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041772	level of ornithine decarboxylase antizyme 1 (human) in blood serum	PR:P54368	ornithine decarboxylase antizyme 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041773	level of pancreatic lipase-related protein 2 (human) in blood serum	PR:P54317	pancreatic lipase-related protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041774	level of inactive pancreatic lipase-related protein 1 (human) in blood serum	PR:P54315	inactive pancreatic lipase-related protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041775	level of myomesin-2 (human) in blood serum	PR:P54296	myomesin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041776	level of voltage-dependent L-type calcium channel subunit beta-3 (human) in blood serum	PR:P54284	voltage-dependent L-type calcium channel subunit beta-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041777	level of mismatch repair endonuclease PMS2 (human) in blood serum	PR:P54278	mismatch repair endonuclease PMS2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041778	level of telomeric repeat-binding factor 1 (human) in blood serum	PR:P54274	telomeric repeat-binding factor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041779	level of ataxin-3 (human) in blood serum	PR:P54252	ataxin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041780	level of activated RNA polymerase II transcriptional coactivator p15 (human) in blood serum	PR:P53999	activated RNA polymerase II transcriptional coactivator p15 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041781	level of IST1 homolog (human) in blood serum	PR:P53990	IST1 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041782	level of phospholipase A and acyltransferase 3 (human) in blood serum	PR:P53816	phospholipase A and acyltransferase 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041783	level of smoothelin (human) in blood serum	PR:P53814	smoothelin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041784	level of calcipressin-1 (human) in blood serum	PR:P53805	calcipressin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041785	level of DNA-directed RNA polymerases I, II, and III subunit RPABC4 (human) in blood serum	PR:P53803	DNA-directed RNA polymerases I, II, and III subunit RPABC4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041786	level of mitogen-activated protein kinase 10 (human) in blood serum	PR:P53779	mitogen-activated protein kinase 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041787	level of holocytochrome c-type synthase (human) in blood serum	PR:P53701	holocytochrome c-type synthase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041788	level of beta-crystallin B1 (human) in blood serum	PR:P53674	beta-crystallin B1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041789	level of LIM domain kinase 1 (human) in blood serum	PR:P53667	LIM domain kinase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041790	level of diphosphomevalonate decarboxylase (human) in blood serum	PR:P53602	diphosphomevalonate decarboxylase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041791	level of CCAAT/enhancer-binding protein gamma (human) in blood serum	PR:P53567	CCAAT/enhancer-binding protein gamma (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041792	level of ATP-citrate synthase (human) in blood serum	PR:P53396	ATP-citrate synthase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041793	level of cytosolic Fe-S cluster assembly factor NUBP1 (human) in blood serum	PR:P53384	cytosolic Fe-S cluster assembly factor NUBP1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041794	level of arfaptin-1 (human) in blood serum	PR:P53367	arfaptin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041795	level of arfaptin-2 (human) in blood serum	PR:P53365	arfaptin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041796	level of FAD-linked sulfhydryl oxidase ALR (human) in blood serum	PR:P55789	FAD-linked sulfhydryl oxidase ALR (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041797	level of NHP2-like protein 1 (human) in blood serum	PR:P55769	NHP2-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041798	level of protein SEC13 homolog (human) in blood serum	PR:P55735	protein SEC13 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041799	level of cadherin-13 (human) in blood serum	PR:P55290	cadherin-13 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041800	level of cadherin-4 (human) in blood serum	PR:P55283	cadherin-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041801	level of cyclin-dependent kinase 4 inhibitor D (human) in blood serum	PR:P55273	cyclin-dependent kinase 4 inhibitor D (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041802	level of adenosine kinase (human) in blood serum	PR:P55263	adenosine kinase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041803	level of caspase-7 (human) in blood serum	PR:P55210	caspase-7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041804	level of nucleosome assembly protein 1-like 1 (human) in blood serum	PR:P55209	nucleosome assembly protein 1-like 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041805	level of peregrin (human) in blood serum	PR:P55201	peregrin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041806	level of RNA polymerase II elongation factor ELL (human) in blood serum	PR:P55199	RNA polymerase II elongation factor ELL (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041807	level of mesencephalic astrocyte-derived neurotrophic factor (human) in blood serum	PR:P55145	mesencephalic astrocyte-derived neurotrophic factor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041808	level of growth/differentiation factor 10 (human) in blood serum	PR:P55107	growth/differentiation factor 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041809	level of inhibin beta C chain (human) in blood serum	PR:P55103	inhibin beta C chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041810	level of aquaporin-4 (human) in blood serum	PR:P55087	aquaporin-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041811	level of microfibril-associated glycoprotein 3 (human) in blood serum	PR:P55082	microfibril-associated glycoprotein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041812	level of microfibrillar-associated protein 1 (human) in blood serum	PR:P55081	microfibrillar-associated protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041813	level of fibroblast growth factor 8 (human) in blood serum	PR:P55075	fibroblast growth factor 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041814	level of transitional endoplasmic reticulum ATPase (human) in blood serum	PR:P55072	transitional endoplasmic reticulum ATPase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041815	level of phospholipid transfer protein (human) in blood serum	PR:P55058	phospholipid transfer protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041816	level of oxysterols receptor LXR-beta (human) in blood serum	PR:P55055	oxysterols receptor LXR-beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041817	level of GTP-binding protein RAD (human) in blood serum	PR:P55042	GTP-binding protein RAD (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041818	level of GTP-binding protein GEM (human) in blood serum	PR:P55040	GTP-binding protein GEM (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041819	level of 26S proteasome non-ATPase regulatory subunit 4 (human) in blood serum	PR:P55036	26S proteasome non-ATPase regulatory subunit 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041820	level of microfibrillar-associated protein 2 (human) in blood serum	PR:P55001	microfibrillar-associated protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041821	level of ADP-ribosylhydrolase ARH1 (human) in blood serum	PR:P54922	ADP-ribosylhydrolase ARH1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041822	level of hydroxymethylglutaryl-CoA synthase, mitochondrial (human) in blood serum	PR:P54868	hydroxymethylglutaryl-CoA synthase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041823	level of UDP-glucuronosyltransferase 2B15 (human) in blood serum	PR:P54855	UDP-glucuronosyltransferase 2B15 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041824	level of paired mesoderm homeobox protein 1 (human) in blood serum	PR:P54821	paired mesoderm homeobox protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041825	level of alpha-N-acetylglucosaminidase (human) in blood serum	PR:P54802	alpha-N-acetylglucosaminidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041826	level of ephrin type-A receptor 4 (human) in blood serum	PR:P54764	ephrin type-A receptor 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041827	level of anthrax toxin receptor 2 (human) in blood serum	PR:P58335	anthrax toxin receptor 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041828	level of lysyl oxidase homolog 3 (human) in blood serum	PR:P58215	lysyl oxidase homolog 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041829	level of serine protease inhibitor Kazal-type 7 (human) in blood serum	PR:P58062	serine protease inhibitor Kazal-type 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041830	level of forkhead box protein L2 (human) in blood serum	PR:P58012	forkhead box protein L2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041831	level of regulator of G-protein signaling 8 (human) in blood serum	PR:P57771	regulator of G-protein signaling 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041832	level of sorting nexin-16 (human) in blood serum	PR:P57768	sorting nexin-16 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041833	level of caspase recruitment domain-containing protein 18 (human) in blood serum	PR:P57730	caspase recruitment domain-containing protein 18 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041834	level of Ras-related protein Rab-38 (human) in blood serum	PR:P57729	Ras-related protein Rab-38 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041835	level of synaptojanin-2-binding protein (human) in blood serum	PR:P57105	synaptojanin-2-binding protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041836	level of SCAN domain-containing protein 1 (human) in blood serum	PR:P57086	SCAN domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041837	level of cilia- and flagella-associated protein 298 (human) in blood serum	PR:P57076	cilia- and flagella-associated protein 298 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041838	level of ubiquitin-associated and SH3 domain-containing protein A (human) in blood serum	PR:P57075	ubiquitin-associated and SH3 domain-containing protein A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041839	level of protein ripply3 (human) in blood serum	PR:P57055	protein ripply3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041840	level of pro-neuregulin-3, membrane-bound isoform (human) in blood serum	PR:P56975	pro-neuregulin-3, membrane-bound isoform (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041841	level of syntaxin-17 (human) in blood serum	PR:P56962	syntaxin-17 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041842	level of epididymal secretory protein E3-beta (human) in blood serum	PR:P56851	epididymal secretory protein E3-beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041843	level of transcription factor SOX-10 (human) in blood serum	PR:P56693	transcription factor SOX-10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041844	level of caveolin-3 (human) in blood serum	PR:P56539	caveolin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041845	level of histone deacetylase 4 (human) in blood serum	PR:P56524	histone deacetylase 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041846	level of AP-1 complex subunit sigma-2 (human) in blood serum	PR:P56377	AP-1 complex subunit sigma-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041847	level of DNA polymerase epsilon subunit 2 (human) in blood serum	PR:P56282	DNA polymerase epsilon subunit 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041848	level of T-cell leukemia/lymphoma protein 1A (human) in blood serum	PR:P56279	T-cell leukemia/lymphoma protein 1A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041849	level of protein p13 MTCP-1 (human) in blood serum	PR:P56278	protein p13 MTCP-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041850	level of Cx9C motif-containing protein 4 (human) in blood serum	PR:P56277	Cx9C motif-containing protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041851	level of Myc-associated zinc finger protein (human) in blood serum	PR:P56270	Myc-associated zinc finger protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041852	level of methionine--tRNA ligase, cytoplasmic (human) in blood serum	PR:P56192	methionine--tRNA ligase, cytoplasmic (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041853	level of ATP synthase subunit f, mitochondrial (human) in blood serum	PR:P56134	ATP synthase subunit f, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041854	level of IgG receptor FcRn large subunit p51 (human) in blood serum	PR:P55899	IgG receptor FcRn large subunit p51 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041855	level of eukaryotic translation initiation factor 3 subunit B (human) in blood serum	PR:P55884	eukaryotic translation initiation factor 3 subunit B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041856	level of succinyl-CoA:3-ketoacid coenzyme A transferase 1, mitochondrial (human) in blood serum	PR:P55809	succinyl-CoA:3-ketoacid coenzyme A transferase 1, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041857	level of glycoprotein Xg (human) in blood serum	PR:P55808	glycoprotein Xg (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041858	level of ubiquitin-conjugating enzyme E2 N (human) in blood serum	PR:P61088	ubiquitin-conjugating enzyme E2 N (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041859	level of ubiquitin-conjugating enzyme E2 K (human) in blood serum	PR:P61086	ubiquitin-conjugating enzyme E2 K (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041860	level of NEDD8-conjugating enzyme Ubc12 (human) in blood serum	PR:P61081	NEDD8-conjugating enzyme Ubc12 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041861	level of ubiquitin-conjugating enzyme E2 D3 (human) in blood serum	PR:P61077	ubiquitin-conjugating enzyme E2 D3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041862	level of cyclin-dependent kinases regulatory subunit 1 (human) in blood serum	PR:P61024	cyclin-dependent kinases regulatory subunit 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041863	level of Ras-related protein Rab-5B (human) in blood serum	PR:P61020	Ras-related protein Rab-5B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041864	level of Ras-related protein Rab-2A (human) in blood serum	PR:P61019	Ras-related protein Rab-2A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041865	level of Ras-related protein Rab-4B (human) in blood serum	PR:P61018	Ras-related protein Rab-4B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041866	level of destrin (human) in blood serum	PR:P60981	destrin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041867	level of cell division control protein 42 homolog (human) in blood serum	PR:P60953	cell division control protein 42 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041868	level of protein S100-A10 (human) in blood serum	PR:P60903	protein S100-A10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041869	level of ribose-phosphate pyrophosphokinase 1 (human) in blood serum	PR:P60891	ribose-phosphate pyrophosphokinase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041870	level of 40S ribosomal protein S20 (human) in blood serum	PR:P60866	40S ribosomal protein S20 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041871	level of myosin light polypeptide 6 (human) in blood serum	PR:P60660	myosin light polypeptide 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041872	level of interleukin-2 (human) in blood serum	PR:P60568	interleukin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041873	level of gamma-aminobutyric acid receptor-associated protein-like 2 (human) in blood serum	PR:P60520	gamma-aminobutyric acid receptor-associated protein-like 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041874	level of serine/threonine-protein phosphatase 4 catalytic subunit (human) in blood serum	PR:P60510	serine/threonine-protein phosphatase 4 catalytic subunit (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041875	level of protein transport protein Sec61 subunit beta (human) in blood serum	PR:P60468	protein transport protein Sec61 subunit beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041876	level of protein transport protein Sec61 subunit gamma (human) in blood serum	PR:P60059	protein transport protein Sec61 subunit gamma (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041877	level of CD81 antigen (human) in blood serum	PR:P60033	CD81 antigen (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041878	level of beta-defensin 1 (human) in blood serum	PR:P60022	beta-defensin 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041879	level of mitochondrial coiled-coil domain protein 1 (human) in blood serum	PR:P59942	mitochondrial coiled-coil domain protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041880	level of DnaJ homolog subfamily B member 13 (human) in blood serum	PR:P59910	DnaJ homolog subfamily B member 13 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041881	level of leukocyte immunoglobulin-like receptor subfamily A member 4 (human) in blood serum	PR:P59901	leukocyte immunoglobulin-like receptor subfamily A member 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041882	level of neutrophil defensin 3 (human) in blood serum	PR:P59666	neutrophil defensin 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041883	level of neutrophil defensin 1 (human) in blood serum	PR:P59665	neutrophil defensin 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041884	level of tubulin polymerization-promoting protein family member 2 (human) in blood serum	PR:P59282	tubulin polymerization-promoting protein family member 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041885	level of Toll/interleukin-1 receptor domain-containing adapter protein (human) in blood serum	PR:P58753	Toll/interleukin-1 receptor domain-containing adapter protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041886	level of prestin (human) in blood serum	PR:P58743	prestin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041887	level of neurexin-2-beta (human) in blood serum	PR:P58401	neurexin-2-beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041888	level of myeloid leukemia factor 1 (human) in blood serum	PR:P58340	myeloid leukemia factor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041889	level of small nuclear ribonucleoprotein E (human) in blood serum	PR:P62304	small nuclear ribonucleoprotein E (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041890	level of 40S ribosomal protein S14 (human) in blood serum	PR:P62263	40S ribosomal protein S14 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041891	level of ubiquitin-conjugating enzyme E2 H (human) in blood serum	PR:P62256	ubiquitin-conjugating enzyme E2 H (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041892	level of ubiquitin-conjugating enzyme E2 G1 (human) in blood serum	PR:P62253	ubiquitin-conjugating enzyme E2 G1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041893	level of mitochondrial import inner membrane translocase subunit Tim10 (human) in blood serum	PR:P62072	mitochondrial import inner membrane translocase subunit Tim10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041894	level of Ras-related protein R-Ras2 (human) in blood serum	PR:P62070	Ras-related protein R-Ras2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041895	level of ubiquitin carboxyl-terminal hydrolase 46 (human) in blood serum	PR:P62068	ubiquitin carboxyl-terminal hydrolase 46 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041896	level of 14-3-3 protein gamma (human) in blood serum	PR:P61981	14-3-3 protein gamma (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041897	level of nuclear transport factor 2 (human) in blood serum	PR:P61970	nuclear transport factor 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041898	level of LIM domain transcription factor LMO4 (human) in blood serum	PR:P61968	LIM domain transcription factor LMO4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041899	level of WD repeat-containing protein 5 (human) in blood serum	PR:P61964	WD repeat-containing protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041900	level of small ubiquitin-related modifier 2 (human) in blood serum	PR:P61956	small ubiquitin-related modifier 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041901	level of guanine nucleotide-binding protein G(I)/G(S)/G(O) subunit gamma-11 (human) in blood serum	PR:P61952	guanine nucleotide-binding protein G(I)/G(S)/G(O) subunit gamma-11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041902	level of prefoldin subunit 3 (human) in blood serum	PR:P61758	prefoldin subunit 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041903	level of alpha-2,8-sialyltransferase 8F (human) in blood serum	PR:P61647	alpha-2,8-sialyltransferase 8F (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041904	level of 10 kDa heat shock protein, mitochondrial (human) in blood serum	PR:P61604	10 kDa heat shock protein, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041905	level of neurocalcin-delta (human) in blood serum	PR:P61601	neurocalcin-delta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041906	level of N-alpha-acetyltransferase 20 (human) in blood serum	PR:P61599	N-alpha-acetyltransferase 20 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041907	level of Rho-related GTP-binding protein RhoE (human) in blood serum	PR:P61587	Rho-related GTP-binding protein RhoE (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041908	level of transforming protein RhoA (human) in blood serum	PR:P61586	transforming protein RhoA (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041909	level of pterin-4-alpha-carbinolamine dehydratase (human) in blood serum	PR:P61457	pterin-4-alpha-carbinolamine dehydratase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041910	level of insulin gene enhancer protein ISL-1 (human) in blood serum	PR:P61371	insulin gene enhancer protein ISL-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041911	level of osteocrin (human) in blood serum	PR:P61366	osteocrin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041912	level of protein mago nashi homolog (human) in blood serum	PR:P61326	protein mago nashi homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041913	level of syntaxin-1B (human) in blood serum	PR:P61266	syntaxin-1B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041914	level of 40S ribosomal protein S3a (human) in blood serum	PR:P61247	40S ribosomal protein S3a (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041915	level of protein max (human) in blood serum	PR:P61244	protein max (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041916	level of DNA-directed RNA polymerases I, II, and III subunit RPABC2 (human) in blood serum	PR:P61218	DNA-directed RNA polymerases I, II, and III subunit RPABC2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041917	level of ADP-ribosylation factor 3 (human) in blood serum	PR:P61204	ADP-ribosylation factor 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041918	level of COP9 signalosome complex subunit 2 (human) in blood serum	PR:P61201	COP9 signalosome complex subunit 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041919	level of Ras-related protein Rab-14 (human) in blood serum	PR:P61106	Ras-related protein Rab-14 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041920	level of hemoglobin subunit beta (human) in blood serum	PR:P68871	hemoglobin subunit beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041921	level of peptidyl-prolyl cis-trans isomerase FKBP1B (human) in blood serum	PR:P68106	peptidyl-prolyl cis-trans isomerase FKBP1B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041922	level of elongation factor 1-alpha 1 (human) in blood serum	PR:P68104	elongation factor 1-alpha 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041923	level of casein kinase II subunit beta (human) in blood serum	PR:P67870	casein kinase II subunit beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041924	level of Y-box-binding protein 1 (human) in blood serum	PR:P67809	Y-box-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041925	level of selenoprotein W (human) in blood serum	PR:P63302	selenoprotein W (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041926	level of receptor of activated protein C kinase 1 (human) in blood serum	PR:P63244	receptor of activated protein C kinase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041927	level of 60S ribosomal protein L38 (human) in blood serum	PR:P63173	60S ribosomal protein L38 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041928	level of dynein light chain Tctex-type 1 (human) in blood serum	PR:P63172	dynein light chain Tctex-type 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041929	level of ubiquitin-conjugating enzyme E2 B (human) in blood serum	PR:P63146	ubiquitin-conjugating enzyme E2 B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041930	level of guanine nucleotide-binding protein G(i) subunit alpha-1 (human) in blood serum	PR:P63096	guanine nucleotide-binding protein G(i) subunit alpha-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041931	level of guanine nucleotide-binding protein G(s) subunit alpha isoforms Gnas-1/Gnas-2/3/4 (human) in blood serum	PR:P63092	guanine nucleotide-binding protein G(s) subunit alpha isoforms Gnas-1/Gnas-2/3/4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041932	level of vesicle-associated membrane protein 2 (human) in blood serum	PR:P63027	vesicle-associated membrane protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041933	level of AP-2 complex subunit beta (human) in blood serum	PR:P63010	AP-2 complex subunit beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041934	level of transformer-2 protein homolog beta (human) in blood serum	PR:P62995	transformer-2 protein homolog beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041935	level of peptidyl-prolyl cis-trans isomerase FKBP1A (human) in blood serum	PR:P62942	peptidyl-prolyl cis-trans isomerase FKBP1A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041936	level of 60S ribosomal protein L11 (human) in blood serum	PR:P62913	60S ribosomal protein L11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041937	level of 60S ribosomal protein L30 (human) in blood serum	PR:P62888	60S ribosomal protein L30 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041938	level of 40S ribosomal protein S25 (human) in blood serum	PR:P62851	40S ribosomal protein S25 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041939	level of ubiquitin-conjugating enzyme E2 D2 (human) in blood serum	PR:P62837	ubiquitin-conjugating enzyme E2 D2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041940	level of Ras-related protein Rab-1A (human) in blood serum	PR:P62820	Ras-related protein Rab-1A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041941	level of visinin-like protein 1 (human) in blood serum	PR:P62760	visinin-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041942	level of Rho-related GTP-binding protein RhoB (human) in blood serum	PR:P62745	Rho-related GTP-binding protein RhoB (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041943	level of 40S ribosomal protein S4, X isoform (human) in blood serum	PR:P62701	40S ribosomal protein S4, X isoform (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041944	level of TATA box-binding protein-like 1 (human) in blood serum	PR:P62380	TATA box-binding protein-like 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041945	level of ADP-ribosylation factor 6 (human) in blood serum	PR:P62330	ADP-ribosylation factor 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041946	level of protein BTG1 (human) in blood serum	PR:P62324	protein BTG1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041947	level of small nuclear ribonucleoprotein Sm D3 (human) in blood serum	PR:P62318	small nuclear ribonucleoprotein Sm D3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041948	level of small nuclear ribonucleoprotein Sm D2 (human) in blood serum	PR:P62316	small nuclear ribonucleoprotein Sm D2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041949	level of U6 snRNA-associated Sm-like protein LSm3 (human) in blood serum	PR:P62310	U6 snRNA-associated Sm-like protein LSm3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041950	level of small nuclear ribonucleoprotein G (human) in blood serum	PR:P62308	small nuclear ribonucleoprotein G (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041951	level of orexigenic neuropeptide QRFP (human) in blood serum	PR:P83859	orexigenic neuropeptide QRFP (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041952	level of retinol-binding protein 5 (human) in blood serum	PR:P82980	retinol-binding protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041953	level of beta-defensin 103 (human) in blood serum	PR:P81534	beta-defensin 103 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041954	level of prolactin-releasing peptide (human) in blood serum	PR:P81277	prolactin-releasing peptide (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041955	level of brain acid soluble protein 1 (human) in blood serum	PR:P80723	brain acid soluble protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041956	level of protein delta homolog 1 (human) in blood serum	PR:P80370	protein delta homolog 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041957	level of nucleobindin-2 (human) in blood serum	PR:P80303	nucleobindin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041958	level of HLA class II histocompatibility antigen, DR beta 3 chain (human) in blood serum	PR:P79483	HLA class II histocompatibility antigen, DR beta 3 chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041959	level of phosphate-regulating neutral endopeptidase PHEX (human) in blood serum	PR:P78562	phosphate-regulating neutral endopeptidase PHEX (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041960	level of death domain-containing protein CRADD (human) in blood serum	PR:P78560	death domain-containing protein CRADD (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041961	level of protein BTG2 (human) in blood serum	PR:P78543	protein BTG2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041962	level of arginase-2, mitochondrial (human) in blood serum	PR:P78540	arginase-2, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041963	level of biogenesis of lysosome-related organelles complex 1 subunit 1 (human) in blood serum	PR:P78537	biogenesis of lysosome-related organelles complex 1 subunit 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041964	level of reelin (human) in blood serum	PR:P78509	reelin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041965	level of glutathione S-transferase omega-1 (human) in blood serum	PR:P78417	glutathione S-transferase omega-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041966	level of butyrophilin subfamily 3 member A2 (human) in blood serum	PR:P78410	butyrophilin subfamily 3 member A2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041967	level of cyclin-A1 (human) in blood serum	PR:P78396	cyclin-A1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041968	level of melanoma antigen preferentially expressed in tumors (human) in blood serum	PR:P78395	melanoma antigen preferentially expressed in tumors (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041969	level of casein kinase I isoform gamma-2 (human) in blood serum	PR:P78368	casein kinase I isoform gamma-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041970	level of SRSF protein kinase 2 (human) in blood serum	PR:P78362	SRSF protein kinase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041971	level of cancer/testis antigen 1 (human) in blood serum	PR:P78358	cancer/testis antigen 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041972	level of phosphatidylinositol 5-phosphate 4-kinase type-2 beta (human) in blood serum	PR:P78356	phosphatidylinositol 5-phosphate 4-kinase type-2 beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041973	level of disks large homolog 4 (human) in blood serum	PR:P78352	disks large homolog 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041974	level of general transcription factor II-I (human) in blood serum	PR:P78347	general transcription factor II-I (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041975	level of ribonuclease P protein subunit p30 (human) in blood serum	PR:P78346	ribonuclease P protein subunit p30 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041976	level of phosphoserine phosphatase (human) in blood serum	PR:P78330	phosphoserine phosphatase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041977	level of disintegrin and metalloproteinase domain-containing protein 8 (human) in blood serum	PR:P78325	disintegrin and metalloproteinase domain-containing protein 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041978	level of tyrosine-protein phosphatase non-receptor type substrate 1 (human) in blood serum	PR:P78324	tyrosine-protein phosphatase non-receptor type substrate 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041979	level of immunoglobulin-binding protein 1 (human) in blood serum	PR:P78318	immunoglobulin-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041980	level of coxsackievirus and adenovirus receptor (human) in blood serum	PR:P78310	coxsackievirus and adenovirus receptor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041981	level of hemoglobin subunit gamma-2 (human) in blood serum	PR:P69892	hemoglobin subunit gamma-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041982	level of beta-1,4 N-acetylgalactosaminyltransferase 1 (human) in blood serum	PR:Q00973	beta-1,4 N-acetylgalactosaminyltransferase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041983	level of pregnancy-specific beta-1-glycoprotein 6 (human) in blood serum	PR:Q00889	pregnancy-specific beta-1-glycoprotein 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041984	level of pregnancy-specific beta-1-glycoprotein 4 (human) in blood serum	PR:Q00888	pregnancy-specific beta-1-glycoprotein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041985	level of myosin-binding protein C, slow-type (human) in blood serum	PR:Q00872	myosin-binding protein C, slow-type (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041986	level of sorbitol dehydrogenase (human) in blood serum	PR:Q00796	sorbitol dehydrogenase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041987	level of peptidyl-prolyl cis-trans isomerase FKBP3 (human) in blood serum	PR:Q00688	peptidyl-prolyl cis-trans isomerase FKBP3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041988	level of clathrin heavy chain 1 (human) in blood serum	PR:Q00610	clathrin heavy chain 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041989	level of norrin (human) in blood serum	PR:Q00604	norrin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041990	level of transcriptional activator protein Pur-alpha (human) in blood serum	PR:Q00577	transcriptional activator protein Pur-alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041991	level of cyclin-dependent kinase 16 (human) in blood serum	PR:Q00536	cyclin-dependent kinase 16 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041992	level of transcription initiation factor IIB (human) in blood serum	PR:Q00403	transcription initiation factor IIB (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041993	level of vigilin (human) in blood serum	PR:Q00341	vigilin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041994	level of S-adenosylmethionine synthase isoform type-1 (human) in blood serum	PR:Q00266	S-adenosylmethionine synthase isoform type-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041995	level of phosphatidylinositol transfer protein alpha isoform (human) in blood serum	PR:Q00169	phosphatidylinositol transfer protein alpha isoform (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041996	level of transcription factor A, mitochondrial (human) in blood serum	PR:Q00059	transcription factor A, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041997	level of RNA-binding protein 3 (human) in blood serum	PR:P98179	RNA-binding protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041998	level of forkhead box protein O4 (human) in blood serum	PR:P98177	forkhead box protein O4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2041999	level of protein FAM3A (human) in blood serum	PR:P98173	protein FAM3A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042000	level of low-density lipoprotein receptor-related protein 2 (human) in blood serum	PR:P98164	low-density lipoprotein receptor-related protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042001	level of basement membrane-specific heparan sulfate proteoglycan core protein (human) in blood serum	PR:P98160	basement membrane-specific heparan sulfate proteoglycan core protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042002	level of very low-density lipoprotein receptor (human) in blood serum	PR:P98155	very low-density lipoprotein receptor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042003	level of integral membrane protein DGCR2/IDD (human) in blood serum	PR:P98153	integral membrane protein DGCR2/IDD (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042004	level of disabled homolog 2 (human) in blood serum	PR:P98082	disabled homolog 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042005	level of SHC-transforming protein 2 (human) in blood serum	PR:P98077	SHC-transforming protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042006	level of matrix-remodeling-associated protein 7 (human) in blood serum	PR:P84157	matrix-remodeling-associated protein 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042007	level of small EDRK-rich factor 2 (human) in blood serum	PR:P84101	small EDRK-rich factor 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042008	level of Rho-related GTP-binding protein RhoG (human) in blood serum	PR:P84095	Rho-related GTP-binding protein RhoG (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042009	level of ADP-ribosylation factor 5 (human) in blood serum	PR:P84085	ADP-ribosylation factor 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042010	level of ADP-ribosylation factor 1 (human) in blood serum	PR:P84077	ADP-ribosylation factor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042011	level of chromobox protein homolog 1 (human) in blood serum	PR:P83916	chromobox protein homolog 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042012	level of thioredoxin-like protein 4A (human) in blood serum	PR:P83876	thioredoxin-like protein 4A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042013	level of cAMP-responsive element modulator (human) in blood serum	PR:Q03060	cAMP-responsive element modulator (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042014	level of hematopoietically-expressed homeobox protein HHEX (human) in blood serum	PR:Q03014	hematopoietically-expressed homeobox protein HHEX (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042015	level of glutathione S-transferase mu 4 (human) in blood serum	PR:Q03013	glutathione S-transferase mu 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042016	level of nucleobindin-1 (human) in blood serum	PR:Q02818	nucleobindin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042017	level of mitogen-activated protein kinase kinase kinase 10 (human) in blood serum	PR:Q02779	mitogen-activated protein kinase kinase kinase 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042018	level of beta-1,3-galactosyl-O-glycosyl-glycoprotein beta-1,6-N-acetylglucosaminyltransferase (human) in blood serum	PR:Q02742	beta-1,3-galactosyl-O-glycosyl-glycoprotein beta-1,6-N-acetylglucosaminyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042019	level of interferon regulatory factor 8 (human) in blood serum	PR:Q02556	interferon regulatory factor 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042020	level of DNA-binding protein inhibitor ID-2 (human) in blood serum	PR:Q02363	DNA-binding protein inhibitor ID-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042021	level of pro-neuregulin-1, membrane-bound isoform (human) in blood serum	PR:Q02297	pro-neuregulin-1, membrane-bound isoform (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042022	level of methylmalonate-semialdehyde dehydrogenase [acylating], mitochondrial (human) in blood serum	PR:Q02252	methylmalonate-semialdehyde dehydrogenase [acylating], mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042023	level of dihydroorotate dehydrogenase (quinone), mitochondrial (human) in blood serum	PR:Q02127	dihydroorotate dehydrogenase (quinone), mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042024	level of myosin light chain 5 (human) in blood serum	PR:Q02045	myosin light chain 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042025	level of transgelin (human) in blood serum	PR:Q01995	transgelin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042026	level of tyrosine-protein kinase transmembrane receptor ROR2 (human) in blood serum	PR:Q01974	tyrosine-protein kinase transmembrane receptor ROR2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042027	level of inactive tyrosine-protein kinase transmembrane receptor ROR1 (human) in blood serum	PR:Q01973	inactive tyrosine-protein kinase transmembrane receptor ROR1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042028	level of inositol polyphosphate 5-phosphatase OCRL (human) in blood serum	PR:Q01968	inositol polyphosphate 5-phosphatase OCRL (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042029	level of RNA-binding protein EWS (human) in blood serum	PR:Q01844	RNA-binding protein EWS (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042030	level of DNA-binding protein SATB1 (human) in blood serum	PR:Q01826	DNA-binding protein SATB1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042031	level of protein Dr1 (human) in blood serum	PR:Q01658	protein Dr1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042032	level of interleukin-1 receptor-like 1 (human) in blood serum	PR:Q01638	interleukin-1 receptor-like 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042033	level of hydroxymethylglutaryl-CoA synthase, cytoplasmic (human) in blood serum	PR:Q01581	hydroxymethylglutaryl-CoA synthase, cytoplasmic (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042034	level of Friend leukemia integration 1 transcription factor (human) in blood serum	PR:Q01543	Friend leukemia integration 1 transcription factor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042035	level of defensin alpha 5 (human) in blood serum	PR:Q01523	defensin alpha 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042036	level of myosin regulatory light chain 2, atrial isoform (human) in blood serum	PR:Q01449	myosin regulatory light chain 2, atrial isoform (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042037	level of AMP deaminase 2 (human) in blood serum	PR:Q01433	AMP deaminase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042038	level of N-acetylgalactosamine kinase (human) in blood serum	PR:Q01415	N-acetylgalactosamine kinase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042039	level of interleukin-5 receptor subunit alpha (human) in blood serum	PR:Q01344	interleukin-5 receptor subunit alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042040	level of transcription factor RelB (human) in blood serum	PR:Q01201	transcription factor RelB (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042041	level of nucleolysin TIAR (human) in blood serum	PR:Q01085	nucleolysin TIAR (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042042	level of dual specificity calcium/calmodulin-dependent 3',5'-cyclic nucleotide phosphodiesterase 1B (human) in blood serum	PR:Q01064	dual specificity calcium/calmodulin-dependent 3',5'-cyclic nucleotide phosphodiesterase 1B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042043	level of interferon regulatory factor 9 (human) in blood serum	PR:Q00978	interferon regulatory factor 9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042044	level of early activation antigen CD69 (human) in blood serum	PR:Q07108	early activation antigen CD69 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042045	level of glutamyl aminopeptidase (human) in blood serum	PR:Q07075	glutamyl aminopeptidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042046	level of cytoskeleton-associated protein 4 (human) in blood serum	PR:Q07065	cytoskeleton-associated protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042047	level of fibromodulin (human) in blood serum	PR:Q06828	fibromodulin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042048	level of fragile X messenger ribonucleoprotein 1 (human) in blood serum	PR:Q06787	fragile X messenger ribonucleoprotein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042049	level of paired box protein Pax-8 (human) in blood serum	PR:Q06710	paired box protein Pax-8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042050	level of GA-binding protein subunit beta-1 (human) in blood serum	PR:Q06547	GA-binding protein subunit beta-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042051	level of sulfotransferase 2A1 (human) in blood serum	PR:Q06520	sulfotransferase 2A1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042052	level of amyloid beta precursor like protein 2 (human) in blood serum	PR:Q06481	amyloid beta precursor like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042053	level of myocyte-specific enhancer factor 2C (human) in blood serum	PR:Q06413	myocyte-specific enhancer factor 2C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042054	level of glutamine--fructose-6-phosphate aminotransferase [isomerizing] 1 (human) in blood serum	PR:Q06210	glutamine--fructose-6-phosphate aminotransferase [isomerizing] 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042055	level of serine/threonine-protein phosphatase 2A regulatory subunit B'' subunit alpha (human) in blood serum	PR:Q06190	serine/threonine-protein phosphatase 2A regulatory subunit B'' subunit alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042056	level of regenerating islet-derived protein 3-alpha (human) in blood serum	PR:Q06141	regenerating islet-derived protein 3-alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042057	level of inter-alpha-trypsin inhibitor heavy chain H3 (human) in blood serum	PR:Q06033	inter-alpha-trypsin inhibitor heavy chain H3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042058	level of neuronal acetylcholine receptor subunit beta-3 (human) in blood serum	PR:Q05901	neuronal acetylcholine receptor subunit beta-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042059	level of caldesmon (human) in blood serum	PR:Q05682	caldesmon (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042060	level of zinc finger and BTB domain-containing protein 16 (human) in blood serum	PR:Q05516	zinc finger and BTB domain-containing protein 16 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042061	level of dynamin-1 (human) in blood serum	PR:Q05193	dynamin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042062	level of ubiquitin-protein ligase E3A (human) in blood serum	PR:Q05086	ubiquitin-protein ligase E3A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042063	level of sex-determining region Y protein (human) in blood serum	PR:Q05066	sex-determining region Y protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042064	level of cleavage stimulation factor subunit 1 (human) in blood serum	PR:Q05048	cleavage stimulation factor subunit 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042065	level of 14-3-3 protein eta (human) in blood serum	PR:Q04917	14-3-3 protein eta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042066	level of single-stranded DNA-binding protein, mitochondrial (human) in blood serum	PR:Q04837	single-stranded DNA-binding protein, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042067	level of aldo-keto reductase family 1 member C1 (human) in blood serum	PR:Q04828	aldo-keto reductase family 1 member C1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042068	level of lactoylglutathione lyase (human) in blood serum	PR:Q04760	lactoylglutathione lyase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042069	level of keratin, type I cytoskeletal 17 (human) in blood serum	PR:Q04695	keratin, type I cytoskeletal 17 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042070	level of eukaryotic translation initiation factor 4 gamma 1 (human) in blood serum	PR:Q04637	eukaryotic translation initiation factor 4 gamma 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042071	level of collagen alpha-1(X) chain (human) in blood serum	PR:Q03692	collagen alpha-1(X) chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042072	level of parathyroid hormone/parathyroid hormone-related peptide receptor (human) in blood serum	PR:Q03431	parathyroid hormone/parathyroid hormone-related peptide receptor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042073	level of 6-pyruvoyl tetrahydrobiopterin synthase (human) in blood serum	PR:Q03393	6-pyruvoyl tetrahydrobiopterin synthase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042074	level of lamin-B2 (human) in blood serum	PR:Q03252	lamin-B2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042075	level of polypeptide N-acetylgalactosaminyltransferase 2 (human) in blood serum	PR:Q10471	polypeptide N-acetylgalactosaminyltransferase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042076	level of alpha-1,6-mannosyl-glycoprotein 2-beta-N-acetylglucosaminyltransferase (human) in blood serum	PR:Q10469	alpha-1,6-mannosyl-glycoprotein 2-beta-N-acetylglucosaminyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042077	level of fatty acid-binding protein 9 (human) in blood serum	PR:Q0Z7S8	fatty acid-binding protein 9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042078	level of secernin-3 (human) in blood serum	PR:Q0VDG4	secernin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042079	level of leucine-rich repeat-containing protein 74A (human) in blood serum	PR:Q0VAA2	leucine-rich repeat-containing protein 74A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042080	level of divergent protein kinase domain 1C (human) in blood serum	PR:Q0P6D2	divergent protein kinase domain 1C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042081	level of uncharacterized protein C17orf67 (human) in blood serum	PR:Q0P5P2	uncharacterized protein C17orf67 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042082	level of protein ripply1 (human) in blood serum	PR:Q0D2K3	protein ripply1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042083	level of magnesium transporter NIPA4 (human) in blood serum	PR:Q0D2K0	magnesium transporter NIPA4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042084	level of zinc finger protein 415 (human) in blood serum	PR:Q09FC8	zinc finger protein 415 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042085	level of alpha-1,6-mannosylglycoprotein 6-beta-N-acetylglucosaminyltransferase A (human) in blood serum	PR:Q09328	alpha-1,6-mannosylglycoprotein 6-beta-N-acetylglucosaminyltransferase A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042086	level of beta-1,4-mannosyl-glycoprotein 4-beta-N-acetylglucosaminyltransferase (human) in blood serum	PR:Q09327	beta-1,4-mannosyl-glycoprotein 4-beta-N-acetylglucosaminyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042087	level of nuclear cap-binding protein subunit 1 (human) in blood serum	PR:Q09161	nuclear cap-binding protein subunit 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042088	level of protein VAC14 homolog (human) in blood serum	PR:Q08AM6	protein VAC14 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042089	level of retinoblastoma-like protein 2 (human) in blood serum	PR:Q08999	retinoblastoma-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042090	level of sperm-associated antigen 11B (human) in blood serum	PR:Q08648	sperm-associated antigen 11B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042091	level of pseudouridine-5'-phosphatase (human) in blood serum	PR:Q08623	pseudouridine-5'-phosphatase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042092	level of desmocollin-1 (human) in blood serum	PR:Q08554	desmocollin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042093	level of dematin (human) in blood serum	PR:Q08495	dematin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042094	level of cAMP-specific 3',5'-cyclic phosphodiesterase 4C (human) in blood serum	PR:Q08493	cAMP-specific 3',5'-cyclic phosphodiesterase 4C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042095	level of ATP-dependent RNA helicase A (human) in blood serum	PR:Q08211	ATP-dependent RNA helicase A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042096	level of TLE family member 5 (human) in blood serum	PR:Q08117	TLE family member 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042097	level of regulator of G-protein signaling 1 (human) in blood serum	PR:Q08116	regulator of G-protein signaling 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042098	level of forkhead box protein M1 (human) in blood serum	PR:Q08050	forkhead box protein M1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042099	level of prolow-density lipoprotein receptor-related protein 1 (human) in blood serum	PR:Q07954	prolow-density lipoprotein receptor-related protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042100	level of son of sevenless homolog 1 (human) in blood serum	PR:Q07889	son of sevenless homolog 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042101	level of peroxisome proliferator-activated receptor alpha (human) in blood serum	PR:Q07869	peroxisome proliferator-activated receptor alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042102	level of kinesin light chain 1 (human) in blood serum	PR:Q07866	kinesin light chain 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042103	level of neutral and basic amino acid transport protein rBAT (human) in blood serum	PR:Q07837	neutral and basic amino acid transport protein rBAT (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042104	level of homeobox protein DLX-2 (human) in blood serum	PR:Q07687	homeobox protein DLX-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042105	level of tight junction protein ZO-1 (human) in blood serum	PR:Q07157	tight junction protein ZO-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042106	level of active breakpoint cluster region-related protein (human) in blood serum	PR:Q12979	active breakpoint cluster region-related protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042107	level of protein tyrosine phosphatase type IVA 2 (human) in blood serum	PR:Q12974	protein tyrosine phosphatase type IVA 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042108	level of nuclear inhibitor of protein phosphatase 1 (human) in blood serum	PR:Q12972	nuclear inhibitor of protein phosphatase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042109	level of transcription initiation factor TFIID subunit 10 (human) in blood serum	PR:Q12962	transcription initiation factor TFIID subunit 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042110	level of ELAV-like protein 2 (human) in blood serum	PR:Q12926	ELAV-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042111	level of tyrosine-protein phosphatase non-receptor type 13 (human) in blood serum	PR:Q12923	tyrosine-protein phosphatase non-receptor type 13 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042112	level of killer cell lectin-like receptor subfamily B member 1 (human) in blood serum	PR:Q12918	killer cell lectin-like receptor subfamily B member 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042113	level of receptor-type tyrosine-protein phosphatase eta (human) in blood serum	PR:Q12913	receptor-type tyrosine-protein phosphatase eta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042114	level of inositol 1,4,5-triphosphate receptor associated 2 (human) in blood serum	PR:Q12912	inositol 1,4,5-triphosphate receptor associated 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042115	level of interleukin enhancer-binding factor 3 (human) in blood serum	PR:Q12906	interleukin enhancer-binding factor 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042116	level of interleukin enhancer-binding factor 2 (human) in blood serum	PR:Q12905	interleukin enhancer-binding factor 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042117	level of tyrosine-protein kinase Mer (human) in blood serum	PR:Q12866	tyrosine-protein kinase Mer (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042118	level of cadherin-17 (human) in blood serum	PR:Q12864	cadherin-17 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042119	level of nuclear factor 1 A-type (human) in blood serum	PR:Q12857	nuclear factor 1 A-type (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042120	level of syntaxin-4 (human) in blood serum	PR:Q12846	syntaxin-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042121	level of zona pellucida sperm-binding protein 4 (human) in blood serum	PR:Q12836	zona pellucida sperm-binding protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042122	level of nucleosome-remodeling factor subunit BPTF (human) in blood serum	PR:Q12830	nucleosome-remodeling factor subunit BPTF (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042123	level of obsolete putative T-complex protein 10A homolog (human) in blood serum	PR:Q12799	obsolete putative T-complex protein 10A homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042124	level of centrin-1 (human) in blood serum	PR:Q12798	centrin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042125	level of aspartyl/asparaginyl beta-hydroxylase (human) in blood serum	PR:Q12797	aspartyl/asparaginyl beta-hydroxylase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042126	level of hyaluronidase-1 (human) in blood serum	PR:Q12794	hyaluronidase-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042127	level of twinfilin-1 (human) in blood serum	PR:Q12792	twinfilin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042128	level of forkhead box protein O1 (human) in blood serum	PR:Q12778	forkhead box protein O1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042129	level of CMP-N-acetylneuraminate-beta-galactosamide-alpha-2,3-sialyltransferase 1 (human) in blood serum	PR:Q11201	CMP-N-acetylneuraminate-beta-galactosamide-alpha-2,3-sialyltransferase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042130	level of alpha-(1,3)-fucosyltransferase 7 (human) in blood serum	PR:Q11130	alpha-(1,3)-fucosyltransferase 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042131	level of galactoside alpha-(1,2)-fucosyltransferase 2 (human) in blood serum	PR:Q10981	galactoside alpha-(1,2)-fucosyltransferase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042132	level of mitochondrial-processing peptidase subunit alpha (human) in blood serum	PR:Q10713	mitochondrial-processing peptidase subunit alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042133	level of bone marrow stromal antigen 2 (human) in blood serum	PR:Q10589	bone marrow stromal antigen 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042134	level of thyrotroph embryonic factor (human) in blood serum	PR:Q10587	thyrotroph embryonic factor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042135	level of AP-1 complex subunit beta-1 (human) in blood serum	PR:Q10567	AP-1 complex subunit beta-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042136	level of polypeptide N-acetylgalactosaminyltransferase 1 (human) in blood serum	PR:Q10472	polypeptide N-acetylgalactosaminyltransferase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042137	level of transcription intermediary factor 1-beta (human) in blood serum	PR:Q13263	transcription intermediary factor 1-beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042138	level of interleukin-15 receptor subunit alpha (human) in blood serum	PR:Q13261	interleukin-15 receptor subunit alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042139	level of mitotic spindle assembly checkpoint protein MAD2A (human) in blood serum	PR:Q13257	mitotic spindle assembly checkpoint protein MAD2A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042140	level of serine/arginine-rich splicing factor 6 (human) in blood serum	PR:Q13247	serine/arginine-rich splicing factor 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042141	level of methanethiol oxidase (human) in blood serum	PR:Q13228	methanethiol oxidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042142	level of semaphorin-3B (human) in blood serum	PR:Q13214	semaphorin-3B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042143	level of myosin-binding protein H (human) in blood serum	PR:Q13203	myosin-binding protein H (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042144	level of chromobox protein homolog 3 (human) in blood serum	PR:Q13185	chromobox protein homolog 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042145	level of dual specificity mitogen-activated protein kinase kinase 5 (human) in blood serum	PR:Q13163	dual specificity mitogen-activated protein kinase kinase 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042146	level of peroxiredoxin-4 (human) in blood serum	PR:Q13162	peroxiredoxin-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042147	level of FAS-associated death domain protein (human) in blood serum	PR:Q13158	FAS-associated death domain protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042148	level of TAR DNA-binding protein 43 (human) in blood serum	PR:Q13148	TAR DNA-binding protein 43 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042149	level of calcium-binding and coiled-coil domain-containing protein 2 (human) in blood serum	PR:Q13137	calcium-binding and coiled-coil domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042150	level of liprin-alpha-1 (human) in blood serum	PR:Q13136	liprin-alpha-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042151	level of S-methyl-5'-thioadenosine phosphorylase (human) in blood serum	PR:Q13126	S-methyl-5'-thioadenosine phosphorylase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042152	level of protein Red (human) in blood serum	PR:Q13123	protein Red (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042153	level of dual specificity protein phosphatase 4 (human) in blood serum	PR:Q13115	dual specificity protein phosphatase 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042154	level of ubiquitin carboxyl-terminal hydrolase 4 (human) in blood serum	PR:Q13107	ubiquitin carboxyl-terminal hydrolase 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042155	level of 39S ribosomal protein L28, mitochondrial (human) in blood serum	PR:Q13084	39S ribosomal protein L28, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042156	level of G antigen 2B/2C (human) in blood serum	PR:Q13066	G antigen 2B/2C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042157	level of bifunctional coenzyme A synthase (human) in blood serum	PR:Q13057	bifunctional coenzyme A synthase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042158	level of pregnancy-specific beta-1-glycoprotein 7 (human) in blood serum	PR:Q13046	pregnancy-specific beta-1-glycoprotein 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042159	level of protein flightless-1 homolog (human) in blood serum	PR:Q13045	protein flightless-1 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042160	level of serine/threonine-protein kinase 4 (human) in blood serum	PR:Q13043	serine/threonine-protein kinase 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042161	level of secretory phospholipase A2 receptor (human) in blood serum	PR:Q13018	secretory phospholipase A2 receptor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042162	level of Rho GTPase-activating protein 5 (human) in blood serum	PR:Q13017	Rho GTPase-activating protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042163	level of Delta(3,5)-Delta(2,4)-dienoyl-CoA isomerase, mitochondrial (human) in blood serum	PR:Q13011	Delta(3,5)-Delta(2,4)-dienoyl-CoA isomerase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042164	level of Rho guanine nucleotide exchange factor TIAM1 (human) in blood serum	PR:Q13009	Rho guanine nucleotide exchange factor TIAM1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042165	level of glutamate receptor ionotropic, kainate 2 (human) in blood serum	PR:Q13002	glutamate receptor ionotropic, kainate 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042166	level of heat shock protein beta-3 (human) in blood serum	PR:Q12988	heat shock protein beta-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042167	level of BCL2/adenovirus E1B 19 kDa protein-interacting protein 3 (human) in blood serum	PR:Q12983	BCL2/adenovirus E1B 19 kDa protein-interacting protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042168	level of prepronociceptin (human) in blood serum	PR:Q13519	prepronociceptin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042169	level of acid ceramidase (human) in blood serum	PR:Q13510	acid ceramidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042170	level of ecto-ADP-ribosyltransferase 3 (human) in blood serum	PR:Q13508	ecto-ADP-ribosyltransferase 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042171	level of sequestosome-1 (human) in blood serum	PR:Q13501	sequestosome-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042172	level of baculoviral IAP repeat-containing protein 2 (human) in blood serum	PR:Q13490	baculoviral IAP repeat-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042173	level of mothers against decapentaplegic homolog 4 (human) in blood serum	PR:Q13485	mothers against decapentaplegic homolog 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042174	level of GRB2-associated-binding protein 1 (human) in blood serum	PR:Q13480	GRB2-associated-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042175	level of interleukin-18 receptor 1 (human) in blood serum	PR:Q13478	interleukin-18 receptor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042176	level of mucosal addressin cell adhesion molecule 1 (human) in blood serum	PR:Q13477	mucosal addressin cell adhesion molecule 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042177	level of frizzled-5 (human) in blood serum	PR:Q13467	frizzled-5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042178	level of peptidyl-prolyl cis-trans isomerase FKBP5 (human) in blood serum	PR:Q13451	peptidyl-prolyl cis-trans isomerase FKBP5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042179	level of 28 kDa heat- and acid-stable phosphoprotein (human) in blood serum	PR:Q13442	28 kDa heat- and acid-stable phosphoprotein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042180	level of peptidyl-prolyl cis-trans isomerase G (human) in blood serum	PR:Q13427	peptidyl-prolyl cis-trans isomerase G (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042181	level of DNA repair protein XRCC4 (human) in blood serum	PR:Q13426	DNA repair protein XRCC4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042182	level of alpha-1-syntrophin (human) in blood serum	PR:Q13424	alpha-1-syntrophin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042183	level of butyrophilin subfamily 1 member A1 (human) in blood serum	PR:Q13410	butyrophilin subfamily 1 member A1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042184	level of ubiquitin-conjugating enzyme E2 variant 1 (human) in blood serum	PR:Q13404	ubiquitin-conjugating enzyme E2 variant 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042185	level of phosducin-like protein (human) in blood serum	PR:Q13371	phosducin-like protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042186	level of microfibrillar-associated protein 5 (human) in blood serum	PR:Q13361	microfibrillar-associated protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042187	level of RING-type E3 ubiquitin-protein ligase PPIL2 (human) in blood serum	PR:Q13356	RING-type E3 ubiquitin-protein ligase PPIL2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042188	level of urea transporter 1 (human) in blood serum	PR:Q13336	urea transporter 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042189	level of receptor-type tyrosine-protein phosphatase S (human) in blood serum	PR:Q13332	receptor-type tyrosine-protein phosphatase S (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042190	level of growth factor receptor-bound protein 10 (human) in blood serum	PR:Q13322	growth factor receptor-bound protein 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042191	level of polyadenylate-binding protein 4 (human) in blood serum	PR:Q13310	polyadenylate-binding protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042192	level of S-phase kinase-associated protein 2 (human) in blood serum	PR:Q13309	S-phase kinase-associated protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042193	level of inactive tyrosine-protein kinase 7 (human) in blood serum	PR:Q13308	inactive tyrosine-protein kinase 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042194	level of voltage-gated potassium channel subunit beta-2 (human) in blood serum	PR:Q13303	voltage-gated potassium channel subunit beta-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042195	level of signaling lymphocytic activation molecule (human) in blood serum	PR:Q13291	signaling lymphocytic activation molecule (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042196	level of N-myc-interactor (human) in blood serum	PR:Q13287	N-myc-interactor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042197	level of Ras GTPase-activating protein-binding protein 1 (human) in blood serum	PR:Q13283	Ras GTPase-activating protein-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042198	level of syntaxin-3 (human) in blood serum	PR:Q13277	syntaxin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042199	level of calcyphosin (human) in blood serum	PR:Q13938	calcyphosin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042200	level of isopentenyl-diphosphate Delta-isomerase 1 (human) in blood serum	PR:Q13907	isopentenyl-diphosphate Delta-isomerase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042201	level of Rap guanine nucleotide exchange factor 1 (human) in blood serum	PR:Q13905	Rap guanine nucleotide exchange factor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042202	level of nuclear nucleic acid-binding protein C1D (human) in blood serum	PR:Q13901	nuclear nucleic acid-binding protein C1D (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042203	level of krueppel-like factor 9 (human) in blood serum	PR:Q13886	krueppel-like factor 9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042204	level of beta-1-syntrophin (human) in blood serum	PR:Q13884	beta-1-syntrophin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042205	level of bleomycin hydrolase (human) in blood serum	PR:Q13867	bleomycin hydrolase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042206	level of spliceosome RNA helicase DDX39B (human) in blood serum	PR:Q13838	spliceosome RNA helicase DDX39B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042207	level of BTB/POZ domain-containing adapter for CUL3-mediated RhoA degradation protein 2 (human) in blood serum	PR:Q13829	BTB/POZ domain-containing adapter for CUL3-mediated RhoA degradation protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042208	level of methylglutaconyl-CoA hydratase, mitochondrial (human) in blood serum	PR:Q13825	methylglutaconyl-CoA hydratase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042209	level of ectonucleotide pyrophosphatase/phosphodiesterase family member 2 (human) in blood serum	PR:Q13822	ectonucleotide pyrophosphatase/phosphodiesterase family member 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042210	level of apolipoprotein F (human) in blood serum	PR:Q13790	apolipoprotein F (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042211	level of runt-related transcription factor 3 (human) in blood serum	PR:Q13761	runt-related transcription factor 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042212	level of laminin subunit gamma-2 (human) in blood serum	PR:Q13753	laminin subunit gamma-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042213	level of activin receptor type-2B (human) in blood serum	PR:Q13705	activin receptor type-2B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042214	level of four and a half LIM domains protein 1 (human) in blood serum	PR:Q13642	four and a half LIM domains protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042215	level of Ras-related protein Rab-31 (human) in blood serum	PR:Q13636	Ras-related protein Rab-31 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042216	level of GDP-L-fucose synthase (human) in blood serum	PR:Q13630	GDP-L-fucose synthase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042217	level of dual specificity tyrosine-phosphorylation-regulated kinase 1A (human) in blood serum	PR:Q13627	dual specificity tyrosine-phosphorylation-regulated kinase 1A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042218	level of cullin-4B (human) in blood serum	PR:Q13620	cullin-4B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042219	level of cullin-3 (human) in blood serum	PR:Q13618	cullin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042220	level of cullin-1 (human) in blood serum	PR:Q13616	cullin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042221	level of myotubularin-related protein 1 (human) in blood serum	PR:Q13613	myotubularin-related protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042222	level of sorting nexin-1 (human) in blood serum	PR:Q13596	sorting nexin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042223	level of GRB2-related adapter protein (human) in blood serum	PR:Q13588	GRB2-related adapter protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042224	level of inositol-tetrakisphosphate 1-kinase (human) in blood serum	PR:Q13572	inositol-tetrakisphosphate 1-kinase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042225	level of interferon regulatory factor 5 (human) in blood serum	PR:Q13568	interferon regulatory factor 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042226	level of NEDD8-activating enzyme E1 regulatory subunit (human) in blood serum	PR:Q13564	NEDD8-activating enzyme E1 regulatory subunit (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042227	level of eukaryotic translation initiation factor 4E-binding protein 1 (human) in blood serum	PR:Q13541	eukaryotic translation initiation factor 4E-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042228	level of peptidyl-prolyl cis-trans isomerase NIMA-interacting 1 (human) in blood serum	PR:Q13526	peptidyl-prolyl cis-trans isomerase NIMA-interacting 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042229	level of protein phosphatase 1 regulatory subunit 1A (human) in blood serum	PR:Q13522	protein phosphatase 1 regulatory subunit 1A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042230	level of frizzled-2 (human) in blood serum	PR:Q14332	frizzled-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042231	level of protein FRG1 (human) in blood serum	PR:Q14331	protein FRG1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042232	level of myosin-binding protein C, fast-type (human) in blood serum	PR:Q14324	myosin-binding protein C, fast-type (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042233	level of protein FAM50A (human) in blood serum	PR:Q14320	protein FAM50A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042234	level of eukaryotic initiation factor 4A-II (human) in blood serum	PR:Q14240	eukaryotic initiation factor 4A-II (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042235	level of translation initiation factor eIF-2B subunit alpha (human) in blood serum	PR:Q14232	translation initiation factor eIF-2B subunit alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042236	level of interleukin-27 subunit beta (human) in blood serum	PR:Q14213	interleukin-27 subunit beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042237	level of calcipressin-2 (human) in blood serum	PR:Q14206	calcipressin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042238	level of peptidyl-tRNA hydrolase ICT1, mitochondrial (human) in blood serum	PR:Q14197	peptidyl-tRNA hydrolase ICT1, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042239	level of dihydropyrimidinase-related protein 3 (human) in blood serum	PR:Q14195	dihydropyrimidinase-related protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042240	level of dihydropyrimidinase-related protein 1 (human) in blood serum	PR:Q14194	dihydropyrimidinase-related protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042241	level of double C2-like domain-containing protein beta (human) in blood serum	PR:Q14184	double C2-like domain-containing protein beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042242	level of MAGUK p55 subfamily member 2 (human) in blood serum	PR:Q14168	MAGUK p55 subfamily member 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042243	level of tubulin--tyrosine ligase-like protein 12 (human) in blood serum	PR:Q14166	tubulin--tyrosine ligase-like protein 12 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042244	level of malectin (human) in blood serum	PR:Q14165	malectin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042245	level of Rho guanine nucleotide exchange factor 7 (human) in blood serum	PR:Q14155	Rho guanine nucleotide exchange factor 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042246	level of septin-6 (human) in blood serum	PR:Q14141	septin-6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042247	level of transcription cofactor vestigial-like protein 4 (human) in blood serum	PR:Q14135	transcription cofactor vestigial-like protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042248	level of protein DGCR6 (human) in blood serum	PR:Q14129	protein DGCR6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042249	level of dystroglycan 1 (human) in blood serum	PR:Q14118	dystroglycan 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042250	level of dihydropyrimidinase (human) in blood serum	PR:Q14117	dihydropyrimidinase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042251	level of heterogeneous nuclear ribonucleoprotein D0 (human) in blood serum	PR:Q14103	heterogeneous nuclear ribonucleoprotein D0 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042252	level of Ras-related protein Rab-33A (human) in blood serum	PR:Q14088	Ras-related protein Rab-33A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042253	level of collagen alpha-3(IX) chain (human) in blood serum	PR:Q14050	collagen alpha-3(IX) chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042254	level of cyclic nucleotide-gated cation channel beta-1 (human) in blood serum	PR:Q14028	cyclic nucleotide-gated cation channel beta-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042255	level of cold-inducible RNA-binding protein (human) in blood serum	PR:Q14011	cold-inducible RNA-binding protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042256	level of pro-interleukin-16 (human) in blood serum	PR:Q14005	pro-interleukin-16 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042257	level of carcinoembryonic antigen-related cell adhesion molecule 7 (human) in blood serum	PR:Q14002	carcinoembryonic antigen-related cell adhesion molecule 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042258	level of cGMP-dependent protein kinase 1 (human) in blood serum	PR:Q13976	cGMP-dependent protein kinase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042259	level of retinal cone rhodopsin-sensitive cGMP 3',5'-cyclic phosphodiesterase subunit gamma (human) in blood serum	PR:Q13956	retinal cone rhodopsin-sensitive cGMP 3',5'-cyclic phosphodiesterase subunit gamma (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042260	level of core-binding factor subunit beta (human) in blood serum	PR:Q13951	core-binding factor subunit beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042261	level of LRP chaperone MESD (human) in blood serum	PR:Q14696	LRP chaperone MESD (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042262	level of ubiquitin carboxyl-terminal hydrolase 10 (human) in blood serum	PR:Q14694	ubiquitin carboxyl-terminal hydrolase 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042263	level of phosphatidate phosphatase LPIN1 (human) in blood serum	PR:Q14693	phosphatidate phosphatase LPIN1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042264	level of DNA replication complex GINS protein PSF1 (human) in blood serum	PR:Q14691	DNA replication complex GINS protein PSF1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042265	level of BTB/POZ domain-containing protein KCTD2 (human) in blood serum	PR:Q14681	BTB/POZ domain-containing protein KCTD2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042266	level of clathrin interactor 1 (human) in blood serum	PR:Q14677	clathrin interactor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042267	level of interferon regulatory factor 3 (human) in blood serum	PR:Q14653	interferon regulatory factor 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042268	level of plastin-1 (human) in blood serum	PR:Q14651	plastin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042269	level of inositol polyphosphate-5-phosphatase A (human) in blood serum	PR:Q14642	inositol polyphosphate-5-phosphatase A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042270	level of early placenta insulin-like peptide (human) in blood serum	PR:Q14641	early placenta insulin-like peptide (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042271	level of Indian hedgehog protein (human) in blood serum	PR:Q14623	Indian hedgehog protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042272	level of next to BRCA1 gene 1 protein (human) in blood serum	PR:Q14596	next to BRCA1 gene 1 protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042273	level of DNA replication licensing factor MCM6 (human) in blood serum	PR:Q14566	DNA replication licensing factor MCM6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042274	level of meiotic recombination protein DMC1/LIM15 homolog (human) in blood serum	PR:Q14565	meiotic recombination protein DMC1/LIM15 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042275	level of ATP-dependent RNA helicase DHX8 (human) in blood serum	PR:Q14562	ATP-dependent RNA helicase DHX8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042276	level of phosphoribosyl pyrophosphate synthase-associated protein 1 (human) in blood serum	PR:Q14558	phosphoribosyl pyrophosphate synthase-associated protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042277	level of protein disulfide-isomerase A5 (human) in blood serum	PR:Q14554	protein disulfide-isomerase A5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042278	level of hyaluronan-binding protein 2 (human) in blood serum	PR:Q14520	hyaluronan-binding protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042279	level of fibroblast growth factor-binding protein 1 (human) in blood serum	PR:Q14512	fibroblast growth factor-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042280	level of enhancer of filamentation 1 (human) in blood serum	PR:Q14511	enhancer of filamentation 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042281	level of WAP four-disulfide core domain protein 2 (human) in blood serum	PR:Q14508	WAP four-disulfide core domain protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042282	level of epididymal secretory protein E3-alpha (human) in blood serum	PR:Q14507	epididymal secretory protein E3-alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042283	level of endoplasmic reticulum membrane sensor NFE2L1 (human) in blood serum	PR:Q14494	endoplasmic reticulum membrane sensor NFE2L1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042284	level of histone RNA hairpin-binding protein (human) in blood serum	PR:Q14493	histone RNA hairpin-binding protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042285	level of transcription factor HES-1 (human) in blood serum	PR:Q14469	transcription factor HES-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042286	level of beclin-1 (human) in blood serum	PR:Q14457	beclin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042287	level of growth factor receptor-bound protein 7 (human) in blood serum	PR:Q14451	growth factor receptor-bound protein 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042288	level of growth factor receptor-bound protein 14 (human) in blood serum	PR:Q14449	growth factor receptor-bound protein 14 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042289	level of polypeptide N-acetylgalactosaminyltransferase 3 (human) in blood serum	PR:Q14435	polypeptide N-acetylgalactosaminyltransferase 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042290	level of growth arrest-specific protein 6 (human) in blood serum	PR:Q14393	growth arrest-specific protein 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042291	level of transforming growth factor beta activator LRRC32 (human) in blood serum	PR:Q14392	transforming growth factor beta activator LRRC32 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042292	level of sorting nexin-17 (human) in blood serum	PR:Q15036	sorting nexin-17 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042293	level of TNFAIP3-interacting protein 1 (human) in blood serum	PR:Q15025	TNFAIP3-interacting protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042294	level of BRISC complex subunit Abraxas 2 (human) in blood serum	PR:Q15018	BRISC complex subunit Abraxas 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042295	level of mortality factor 4-like protein 2 (human) in blood serum	PR:Q15014	mortality factor 4-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042296	level of MAD2L1-binding protein (human) in blood serum	PR:Q15013	MAD2L1-binding protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042297	level of 26S proteasome non-ATPase regulatory subunit 6 (human) in blood serum	PR:Q15008	26S proteasome non-ATPase regulatory subunit 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042298	level of pre-mRNA-splicing regulator WTAP (human) in blood serum	PR:Q15007	pre-mRNA-splicing regulator WTAP (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042299	level of PCNA-associated factor (human) in blood serum	PR:Q15004	PCNA-associated factor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042300	level of transmembrane protein 132B (human) in blood serum	PR:Q14DG7	transmembrane protein 132B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042301	level of hepatocyte cell adhesion molecule (human) in blood serum	PR:Q14CZ8	hepatocyte cell adhesion molecule (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042302	level of HUWE1-associated protein modifying stress responses (human) in blood serum	PR:Q14CZ0	HUWE1-associated protein modifying stress responses (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042303	level of UBX domain-containing protein 2B (human) in blood serum	PR:Q14CS0	UBX domain-containing protein 2B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042304	level of keratin, type II cytoskeletal 72 (human) in blood serum	PR:Q14CN4	keratin, type II cytoskeletal 72 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042305	level of transmembrane protein 132D (human) in blood serum	PR:Q14C87	transmembrane protein 132D (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042306	level of nuclear receptor subfamily 1 group D member 2 (human) in blood serum	PR:Q14995	nuclear receptor subfamily 1 group D member 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042307	level of nuclear factor of activated T-cells, cytoplasmic 4 (human) in blood serum	PR:Q14934	nuclear factor of activated T-cells, cytoplasmic 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042308	level of Dr1-associated corepressor (human) in blood serum	PR:Q14919	Dr1-associated corepressor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042309	level of prostaglandin reductase 1 (human) in blood serum	PR:Q14914	prostaglandin reductase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042310	level of myosin-binding protein C, cardiac-type (human) in blood serum	PR:Q14896	myosin-binding protein C, cardiac-type (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042311	level of LIM and SH3 domain protein 1 (human) in blood serum	PR:Q14847	LIM and SH3 domain protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042312	level of metabotropic glutamate receptor 4 (human) in blood serum	PR:Q14833	metabotropic glutamate receptor 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042313	level of myocyte-specific enhancer factor 2D (human) in blood serum	PR:Q14814	myocyte-specific enhancer factor 2D (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042314	level of kinesin-like protein KIF22 (human) in blood serum	PR:Q14807	kinesin-like protein KIF22 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042315	level of single-pass membrane and coiled-coil domain-containing protein 1 (human) in blood serum	PR:Q147U7	single-pass membrane and coiled-coil domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042316	level of chromobox protein homolog 2 (human) in blood serum	PR:Q14781	chromobox protein homolog 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042317	level of intercellular adhesion molecule 4 (human) in blood serum	PR:Q14773	intercellular adhesion molecule 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042318	level of major vault protein (human) in blood serum	PR:Q14764	major vault protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042319	level of glycine N-methyltransferase (human) in blood serum	PR:Q14749	glycine N-methyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042320	level of serine/threonine-protein phosphatase 2A 56 kDa regulatory subunit delta isoform (human) in blood serum	PR:Q14738	serine/threonine-protein phosphatase 2A 56 kDa regulatory subunit delta isoform (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042321	level of sarcospan (human) in blood serum	PR:Q14714	sarcospan (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042322	level of membrane-bound transcription factor site-1 protease (human) in blood serum	PR:Q14703	membrane-bound transcription factor site-1 protease (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042323	level of transmembrane emp24 domain-containing protein 2 (human) in blood serum	PR:Q15363	transmembrane emp24 domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042324	level of transcription factor E2F5 (human) in blood serum	PR:Q15329	transcription factor E2F5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042325	level of ankyrin repeat domain-containing protein 1 (human) in blood serum	PR:Q15327	ankyrin repeat domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042326	level of interferon regulatory factor 4 (human) in blood serum	PR:Q15306	interferon regulatory factor 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042327	level of retinoblastoma-binding protein 5 (human) in blood serum	PR:Q15291	retinoblastoma-binding protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042328	level of Rab GTPase-binding effector protein 1 (human) in blood serum	PR:Q15276	Rab GTPase-binding effector protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042329	level of nicotinate-nucleotide pyrophosphorylase [carboxylating] (human) in blood serum	PR:Q15274	nicotinate-nucleotide pyrophosphorylase [carboxylating] (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042330	level of serine/threonine-protein phosphatase 2A activator (human) in blood serum	PR:Q15257	serine/threonine-protein phosphatase 2A activator (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042331	level of receptor-type tyrosine-protein phosphatase R (human) in blood serum	PR:Q15256	receptor-type tyrosine-protein phosphatase R (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042332	level of pregnancy-specific beta-1-glycoprotein 5 (human) in blood serum	PR:Q15238	pregnancy-specific beta-1-glycoprotein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042333	level of non-POU domain-containing octamer-binding protein (human) in blood serum	PR:Q15233	non-POU domain-containing octamer-binding protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042334	level of platelet-derived growth factor receptor-like protein (human) in blood serum	PR:Q15198	platelet-derived growth factor receptor-like protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042335	level of prostaglandin E synthase 3 (human) in blood serum	PR:Q15185	prostaglandin E synthase 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042336	level of serine/threonine-protein phosphatase 2A 56 kDa regulatory subunit alpha isoform (human) in blood serum	PR:Q15172	serine/threonine-protein phosphatase 2A 56 kDa regulatory subunit alpha isoform (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042337	level of transcription elongation factor A protein-like 1 (human) in blood serum	PR:Q15170	transcription elongation factor A protein-like 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042338	level of serum paraoxonase/arylesterase 2 (human) in blood serum	PR:Q15165	serum paraoxonase/arylesterase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042339	level of phosphomevalonate kinase (human) in blood serum	PR:Q15126	phosphomevalonate kinase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042340	level of phosphoglucomutase-like protein 5 (human) in blood serum	PR:Q15124	phosphoglucomutase-like protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042341	level of astrocytic phosphoprotein PEA-15 (human) in blood serum	PR:Q15121	astrocytic phosphoprotein PEA-15 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042342	level of [pyruvate dehydrogenase (acetyl-transferring)] kinase isozyme 2, mitochondrial (human) in blood serum	PR:Q15119	[pyruvate dehydrogenase (acetyl-transferring)] kinase isozyme 2, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042343	level of programmed cell death protein 1 (human) in blood serum	PR:Q15116	programmed cell death protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042344	level of procollagen C-endopeptidase enhancer 1 (human) in blood serum	PR:Q15113	procollagen C-endopeptidase enhancer 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042345	level of platelet-activating factor acetylhydrolase IB subunit alpha1 (human) in blood serum	PR:Q15102	platelet-activating factor acetylhydrolase IB subunit alpha1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042346	level of protein disulfide-isomerase A6 (human) in blood serum	PR:Q15084	protein disulfide-isomerase A6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042347	level of early endosome antigen 1 (human) in blood serum	PR:Q15075	early endosome antigen 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042348	level of peroxisomal acyl-coenzyme A oxidase 1 (human) in blood serum	PR:Q15067	peroxisomal acyl-coenzyme A oxidase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042349	level of Arf-GAP with coiled-coil, ANK repeat and PH domain-containing protein 2 (human) in blood serum	PR:Q15057	Arf-GAP with coiled-coil, ANK repeat and PH domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042350	level of uncharacterized protein KIAA0040 (human) in blood serum	PR:Q15053	uncharacterized protein KIAA0040 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042351	level of lysine--tRNA ligase (human) in blood serum	PR:Q15046	lysine--tRNA ligase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042352	level of ADP-ribosylation factor-like protein 6-interacting protein 1 (human) in blood serum	PR:Q15041	ADP-ribosylation factor-like protein 6-interacting protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042353	level of josephin-1 (human) in blood serum	PR:Q15040	josephin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042354	level of NGFI-A-binding protein 2 (human) in blood serum	PR:Q15742	NGFI-A-binding protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042355	level of sterol-4-alpha-carboxylate 3-dehydrogenase, decarboxylating (human) in blood serum	PR:Q15738	sterol-4-alpha-carboxylate 3-dehydrogenase, decarboxylating (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042356	level of metastasis-suppressor KiSS-1 (human) in blood serum	PR:Q15726	metastasis-suppressor KiSS-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042357	level of leukotriene B4 receptor 1 (human) in blood serum	PR:Q15722	leukotriene B4 receptor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042358	level of ELAV-like protein 1 (human) in blood serum	PR:Q15717	ELAV-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042359	level of disks large homolog 2 (human) in blood serum	PR:Q15700	disks large homolog 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042360	level of zinc finger protein 174 (human) in blood serum	PR:Q15697	zinc finger protein 174 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042361	level of microtubule-associated protein RP/EB family member 1 (human) in blood serum	PR:Q15691	microtubule-associated protein RP/EB family member 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042362	level of tryptase alpha/beta-1 (human) in blood serum	PR:Q15661	tryptase alpha/beta-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042363	level of NF-kappa-B inhibitor beta (human) in blood serum	PR:Q15653	NF-kappa-B inhibitor beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042364	level of high mobility group nucleosome-binding domain-containing protein 3 (human) in blood serum	PR:Q15651	high mobility group nucleosome-binding domain-containing protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042365	level of Cdc42-interacting protein 4 (human) in blood serum	PR:Q15642	Cdc42-interacting protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042366	level of splicing factor 1 (human) in blood serum	PR:Q15637	splicing factor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042367	level of RISC-loading complex subunit TARBP2 (human) in blood serum	PR:Q15633	RISC-loading complex subunit TARBP2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042368	level of translin (human) in blood serum	PR:Q15631	translin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042369	level of dixin (human) in blood serum	PR:Q155Q3	dixin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042370	level of nuclear receptor coactivator 2 (human) in blood serum	PR:Q15596	nuclear receptor coactivator 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042371	level of transcriptional enhancer factor TEF-3 (human) in blood serum	PR:Q15561	transcriptional enhancer factor TEF-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042372	level of transcription elongation factor A protein 2 (human) in blood serum	PR:Q15560	transcription elongation factor A protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042373	level of microtubule-associated protein RP/EB family member 2 (human) in blood serum	PR:Q15555	microtubule-associated protein RP/EB family member 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042374	level of surfeit locus protein 1 (human) in blood serum	PR:Q15526	surfeit locus protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042375	level of corneodesmosin (human) in blood serum	PR:Q15517	corneodesmosin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042376	level of sperm surface protein Sp17 (human) in blood serum	PR:Q15506	sperm surface protein Sp17 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042377	level of regucalcin (human) in blood serum	PR:Q15493	regucalcin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042378	level of cytohesin-1 (human) in blood serum	PR:Q15438	cytohesin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042379	level of splicing factor 3B subunit 4 (human) in blood serum	PR:Q15427	splicing factor 3B subunit 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042380	level of ribosomal protein S6 kinase alpha-1 (human) in blood serum	PR:Q15418	ribosomal protein S6 kinase alpha-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042381	level of mitochondrial fission regulator 1 (human) in blood serum	PR:Q15390	mitochondrial fission regulator 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042382	level of mitochondrial import receptor subunit TOM20 homolog (human) in blood serum	PR:Q15388	mitochondrial import receptor subunit TOM20 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042383	level of ephrin type-A receptor 7 (human) in blood serum	PR:Q15375	ephrin type-A receptor 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042384	level of poly(rC)-binding protein 1 (human) in blood serum	PR:Q15365	poly(rC)-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042385	level of transcription initiation factor TFIID subunit 12 (human) in blood serum	PR:Q16514	transcription initiation factor TFIID subunit 12 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042386	level of serine/threonine-protein kinase N2 (human) in blood serum	PR:Q16513	serine/threonine-protein kinase N2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042387	level of serine/threonine-protein kinase N1 (human) in blood serum	PR:Q16512	serine/threonine-protein kinase N1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042388	level of 26S proteasome non-ATPase regulatory subunit 5 (human) in blood serum	PR:Q16401	26S proteasome non-ATPase regulatory subunit 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042389	level of laminin subunit alpha-4 (human) in blood serum	PR:Q16363	laminin subunit alpha-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042390	level of alpha-internexin (human) in blood serum	PR:Q16352	alpha-internexin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042391	level of potassium voltage-gated channel subfamily A member 10 (human) in blood serum	PR:Q16322	potassium voltage-gated channel subfamily A member 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042392	level of cyclic nucleotide-gated olfactory channel (human) in blood serum	PR:Q16280	cyclic nucleotide-gated olfactory channel (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042393	level of nuclear factor erythroid 2-related factor 2 (human) in blood serum	PR:Q16236	nuclear factor erythroid 2-related factor 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042394	level of UDP-N-acetylhexosamine pyrophosphorylase (human) in blood serum	PR:Q16222	UDP-N-acetylhexosamine pyrophosphorylase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042395	level of ecto-NOX disulfide-thiol exchanger 2 (human) in blood serum	PR:Q16206	ecto-NOX disulfide-thiol exchanger 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042396	level of proteasomal ubiquitin receptor ADRM1 (human) in blood serum	PR:Q16186	proteasomal ubiquitin receptor ADRM1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042397	level of zyxin (human) in blood serum	PR:Q15942	zyxin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042398	level of histone-lysine N-methyltransferase EZH2 (human) in blood serum	PR:Q15910	histone-lysine N-methyltransferase EZH2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042399	level of Ras-related protein Rab-11B (human) in blood serum	PR:Q15907	Ras-related protein Rab-11B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042400	level of endosomal transmembrane epsin interactor 1 (human) in blood serum	PR:Q15884	endosomal transmembrane epsin interactor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042401	level of upstream stimulatory factor 2 (human) in blood serum	PR:Q15853	upstream stimulatory factor 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042402	level of urea transporter 2 (human) in blood serum	PR:Q15849	urea transporter 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042403	level of clusterin-like protein 1 (human) in blood serum	PR:Q15846	clusterin-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042404	level of NEDD8 protein (human) in blood serum	PR:Q15843	NEDD8 protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042405	level of ubiquitin-conjugating enzyme E2 variant 2 (human) in blood serum	PR:Q15819	ubiquitin-conjugating enzyme E2 variant 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042406	level of neuronal pentraxin-1 (human) in blood serum	PR:Q15818	neuronal pentraxin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042407	level of tubulin-specific chaperone C (human) in blood serum	PR:Q15814	tubulin-specific chaperone C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042408	level of tubulin-specific chaperone E (human) in blood serum	PR:Q15813	tubulin-specific chaperone E (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042409	level of intersectin-1 (human) in blood serum	PR:Q15811	intersectin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042410	level of mothers against decapentaplegic homolog 1 (human) in blood serum	PR:Q15797	mothers against decapentaplegic homolog 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042411	level of chitinase-3-like protein 2 (human) in blood serum	PR:Q15782	chitinase-3-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042412	level of metallophosphoesterase MPPED2 (human) in blood serum	PR:Q15777	metallophosphoesterase MPPED2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042413	level of probable E3 ubiquitin-protein ligase HERC1 (human) in blood serum	PR:Q15751	probable E3 ubiquitin-protein ligase HERC1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042414	level of CCAAT/enhancer-binding protein epsilon (human) in blood serum	PR:Q15744	CCAAT/enhancer-binding protein epsilon (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042415	level of ovarian cancer G-protein coupled receptor 1 (human) in blood serum	PR:Q15743	ovarian cancer G-protein coupled receptor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042416	level of laminin subunit alpha-3 (human) in blood serum	PR:Q16787	laminin subunit alpha-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042417	level of hydroxyacylglutathione hydrolase, mitochondrial (human) in blood serum	PR:Q16775	hydroxyacylglutathione hydrolase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042418	level of guanylate kinase (human) in blood serum	PR:Q16774	guanylate kinase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042419	level of kynurenine--oxoglutarate transaminase 1 (human) in blood serum	PR:Q16773	kynurenine--oxoglutarate transaminase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042420	level of glutaminyl-peptide cyclotransferase (human) in blood serum	PR:Q16769	glutaminyl-peptide cyclotransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042421	level of ubiquitin-conjugating enzyme E2 S (human) in blood serum	PR:Q16763	ubiquitin-conjugating enzyme E2 S (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042422	level of thiosulfate sulfurtransferase (human) in blood serum	PR:Q16762	thiosulfate sulfurtransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042423	level of ATP-dependent Clp protease proteolytic subunit, mitochondrial (human) in blood serum	PR:Q16740	ATP-dependent Clp protease proteolytic subunit, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042424	level of NADH dehydrogenase [ubiquinone] 1 alpha subcomplex subunit 5 (human) in blood serum	PR:Q16718	NADH dehydrogenase [ubiquinone] 1 alpha subcomplex subunit 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042425	level of 2,4-dienoyl-CoA reductase [(3E)-enoyl-CoA-producing], mitochondrial (human) in blood serum	PR:Q16698	2,4-dienoyl-CoA reductase [(3E)-enoyl-CoA-producing], mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042426	level of cyclin-dependent kinase inhibitor 3 (human) in blood serum	PR:Q16667	cyclin-dependent kinase inhibitor 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042427	level of guanylate cyclase activator 2B (human) in blood serum	PR:Q16661	guanylate cyclase activator 2B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042428	level of mitogen-activated protein kinase 6 (human) in blood serum	PR:Q16659	mitogen-activated protein kinase 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042429	level of fascin (human) in blood serum	PR:Q16658	fascin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042430	level of melanoma antigen recognized by T-cells 1 (human) in blood serum	PR:Q16655	melanoma antigen recognized by T-cells 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042431	level of myelin-oligodendrocyte glycoprotein (human) in blood serum	PR:Q16653	myelin-oligodendrocyte glycoprotein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042432	level of prostasin (human) in blood serum	PR:Q16651	prostasin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042433	level of survival motor neuron protein (human) in blood serum	PR:Q16637	survival motor neuron protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042434	level of POU domain class 2-associating factor 1 (human) in blood serum	PR:Q16633	POU domain class 2-associating factor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042435	level of serine/arginine-rich splicing factor 7 (human) in blood serum	PR:Q16629	serine/arginine-rich splicing factor 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042436	level of occludin (human) in blood serum	PR:Q16625	occludin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042437	level of neuronal regeneration-related protein (human) in blood serum	PR:Q16612	neuronal regeneration-related protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042438	level of frataxin, mitochondrial (human) in blood serum	PR:Q16595	frataxin, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042439	level of mitogen-activated protein kinase kinase kinase 11 (human) in blood serum	PR:Q16584	mitogen-activated protein kinase kinase kinase 11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042440	level of cocaine- and amphetamine-regulated transcript protein (human) in blood serum	PR:Q16568	cocaine- and amphetamine-regulated transcript protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042441	level of calcium/calmodulin-dependent protein kinase type IV (human) in blood serum	PR:Q16566	calcium/calmodulin-dependent protein kinase type IV (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042442	level of pregnancy-specific beta-1-glycoprotein 3 (human) in blood serum	PR:Q16557	pregnancy-specific beta-1-glycoprotein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042443	level of dihydropyrimidinase-related protein 2 (human) in blood serum	PR:Q16555	dihydropyrimidinase-related protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042444	level of hepatic leukemia factor (human) in blood serum	PR:Q16534	hepatic leukemia factor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042445	level of cysteine and glycine-rich protein 2 (human) in blood serum	PR:Q16527	cysteine and glycine-rich protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042446	level of basic leucine zipper transcriptional factor ATF-like (human) in blood serum	PR:Q16520	basic leucine zipper transcriptional factor ATF-like (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042447	level of kelch-like protein 40 (human) in blood serum	PR:Q2TBA0	kelch-like protein 40 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042448	level of brorin (human) in blood serum	PR:Q2TAL6	brorin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042449	level of PWWP domain-containing DNA repair factor 3A (human) in blood serum	PR:Q2TAK8	PWWP domain-containing DNA repair factor 3A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042450	level of vimentin-type intermediate filament-associated coiled-coil protein (human) in blood serum	PR:Q2NL98	vimentin-type intermediate filament-associated coiled-coil protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042451	level of UPF0561 protein C2orf68 (human) in blood serum	PR:Q2NKX9	UPF0561 protein C2orf68 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042452	level of R-spondin-1 (human) in blood serum	PR:Q2MKA7	R-spondin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042453	level of regulator of G-protein signaling 21 (human) in blood serum	PR:Q2M5E4	regulator of G-protein signaling 21 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042454	level of hyaluronidase-4 (human) in blood serum	PR:Q2M3T9	hyaluronidase-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042455	level of TBC1 domain family member 28 (human) in blood serum	PR:Q2M2D7	TBC1 domain family member 28 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042456	level of methenyltetrahydrofolate synthase domain-containing protein (human) in blood serum	PR:Q2M296	methenyltetrahydrofolate synthase domain-containing protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042457	level of transmembrane protein 132A (human) in blood serum	PR:Q24JP5	transmembrane protein 132A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042458	level of izumo sperm-egg fusion protein 4 (human) in blood serum	PR:Q1ZYL8	izumo sperm-egg fusion protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042459	level of serine protease inhibitor Kazal-type 13 (human) in blood serum	PR:Q1W4C9	serine protease inhibitor Kazal-type 13 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042460	level of S-adenosylmethionine sensor upstream of mTORC1 (human) in blood serum	PR:Q1RMZ1	S-adenosylmethionine sensor upstream of mTORC1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042461	level of prostate-associated microseminoprotein (human) in blood serum	PR:Q1L6U9	prostate-associated microseminoprotein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042462	level of zinc finger SWIM domain-containing protein 7 (human) in blood serum	PR:Q19AV6	zinc finger SWIM domain-containing protein 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042463	level of putative deoxyribonuclease TATDN3 (human) in blood serum	PR:Q17R31	putative deoxyribonuclease TATDN3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042464	level of tumor protein D53 (human) in blood serum	PR:Q16890	tumor protein D53 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042465	level of thioredoxin reductase 1, cytoplasmic (human) in blood serum	PR:Q16881	thioredoxin reductase 1, cytoplasmic (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042466	level of 6-phosphofructo-2-kinase/fructose-2,6-bisphosphatase 4 (human) in blood serum	PR:Q16877	6-phosphofructo-2-kinase/fructose-2,6-bisphosphatase 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042467	level of 6-phosphofructo-2-kinase/fructose-2,6-bisphosphatase 3 (human) in blood serum	PR:Q16875	6-phosphofructo-2-kinase/fructose-2,6-bisphosphatase 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042468	level of membrane primary amine oxidase (human) in blood serum	PR:Q16853	membrane primary amine oxidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042469	level of UTP--glucose-1-phosphate uridylyltransferase (human) in blood serum	PR:Q16851	UTP--glucose-1-phosphate uridylyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042470	level of receptor-type tyrosine-protein phosphatase-like N (human) in blood serum	PR:Q16849	receptor-type tyrosine-protein phosphatase-like N (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042471	level of CMP-N-acetylneuraminate-beta-galactosamide-alpha-2,3-sialyltransferase 2 (human) in blood serum	PR:Q16842	CMP-N-acetylneuraminate-beta-galactosamide-alpha-2,3-sialyltransferase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042472	level of hydroxyacyl-coenzyme A dehydrogenase, mitochondrial (human) in blood serum	PR:Q16836	hydroxyacyl-coenzyme A dehydrogenase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042473	level of uridine phosphorylase 1 (human) in blood serum	PR:Q16831	uridine phosphorylase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042474	level of dual specificity protein phosphatase 6 (human) in blood serum	PR:Q16828	dual specificity protein phosphatase 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042475	level of phosphoenolpyruvate carboxykinase [GTP], mitochondrial (human) in blood serum	PR:Q16822	phosphoenolpyruvate carboxykinase [GTP], mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042476	level of meprin A subunit alpha (human) in blood serum	PR:Q16819	meprin A subunit alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042477	level of reticulon-1 (human) in blood serum	PR:Q16799	reticulon-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042478	level of dual specificity phosphatase 28 (human) in blood serum	PR:Q4G0W2	dual specificity phosphatase 28 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042479	level of NAD kinase 2, mitochondrial (human) in blood serum	PR:Q4G0N4	NAD kinase 2, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042480	level of vacuolar protein sorting-associated protein 26B (human) in blood serum	PR:Q4G0F5	vacuolar protein sorting-associated protein 26B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042481	level of cytochrome c oxidase assembly protein COX19 (human) in blood serum	PR:Q49B96	cytochrome c oxidase assembly protein COX19 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042482	level of Schlafen-like protein 1 (human) in blood serum	PR:Q499Z3	Schlafen-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042483	level of neuritin-like protein (human) in blood serum	PR:Q496H8	neuritin-like protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042484	level of CMRF35-like molecule 2 (human) in blood serum	PR:Q496F6	CMRF35-like molecule 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042485	level of alpha-(1,3)-fucosyltransferase 11 (human) in blood serum	PR:Q495W5	alpha-(1,3)-fucosyltransferase 11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042486	level of T-cell immunoreceptor with Ig and ITIM domains (human) in blood serum	PR:Q495A1	T-cell immunoreceptor with Ig and ITIM domains (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042487	level of galectin-related protein (human) in blood serum	PR:Q3ZCW2	galectin-related protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042488	level of mitochondrial import inner membrane translocase subunit TIM50 (human) in blood serum	PR:Q3ZCQ8	mitochondrial import inner membrane translocase subunit TIM50 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042489	level of Rab-like protein 6 (human) in blood serum	PR:Q3YEC7	Rab-like protein 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042490	level of keratin, type II cytoskeletal 71 (human) in blood serum	PR:Q3SY84	keratin, type II cytoskeletal 71 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042491	level of transcription factor Sp6 (human) in blood serum	PR:Q3SY56	transcription factor Sp6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042492	level of leucine-rich repeat, immunoglobulin-like domain and transmembrane domain-containing protein 3 (human) in blood serum	PR:Q3SXY7	leucine-rich repeat, immunoglobulin-like domain and transmembrane domain-containing protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042493	level of TBC1 domain family member 25 (human) in blood serum	PR:Q3MII6	TBC1 domain family member 25 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042494	level of protein LSM12 (human) in blood serum	PR:Q3MHD2	protein LSM12 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042495	level of triokinase/FMN cyclase (human) in blood serum	PR:Q3LXA3	triokinase/FMN cyclase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042496	level of carcinoembryonic antigen-related cell adhesion molecule 21 (human) in blood serum	PR:Q3KPI0	carcinoembryonic antigen-related cell adhesion molecule 21 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042497	level of patched domain-containing protein 3 (human) in blood serum	PR:Q3KNS1	patched domain-containing protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042498	level of prolyl 3-hydroxylase 1 (human) in blood serum	PR:Q32P28	prolyl 3-hydroxylase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042499	level of beta-defensin 110 (human) in blood serum	PR:Q30KQ9	beta-defensin 110 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042500	level of beta-defensin 112 (human) in blood serum	PR:Q30KQ8	beta-defensin 112 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042501	level of beta-defensin 113 (human) in blood serum	PR:Q30KQ7	beta-defensin 113 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042502	level of beta-defensin 115 (human) in blood serum	PR:Q30KQ5	beta-defensin 115 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042503	level of beta-defensin 116 (human) in blood serum	PR:Q30KQ4	beta-defensin 116 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042504	level of beta-defensin 135 (human) in blood serum	PR:Q30KP9	beta-defensin 135 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042505	level of defensin beta 136 (human) in blood serum	PR:Q30KP8	defensin beta 136 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042506	level of electroneutral sodium bicarbonate exchanger 1 (human) in blood serum	PR:Q2Y0W8	electroneutral sodium bicarbonate exchanger 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042507	level of carcinoembryonic antigen-related cell adhesion molecule 16 (human) in blood serum	PR:Q2WEN9	carcinoembryonic antigen-related cell adhesion molecule 16 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042508	level of WSC domain-containing protein 2 (human) in blood serum	PR:Q2TBF2	WSC domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042509	level of PDZ domain-containing protein 11 (human) in blood serum	PR:Q5EBL8	PDZ domain-containing protein 11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042510	level of RILP-like protein 1 (human) in blood serum	PR:Q5EBL4	RILP-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042511	level of serine protease inhibitor Kazal-type 9 (human) in blood serum	PR:Q5DT21	serine protease inhibitor Kazal-type 9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042512	level of uromodulin-like 1 (human) in blood serum	PR:Q5DID0	uromodulin-like 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042513	level of endoribonuclease ZC3H12A (human) in blood serum	PR:Q5D1E8	endoribonuclease ZC3H12A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042514	level of UPF0692 protein C19orf54 (human) in blood serum	PR:Q5BKX5	UPF0692 protein C19orf54 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042515	level of oxidoreductase-like domain-containing protein 1 (human) in blood serum	PR:Q5BKU9	oxidoreductase-like domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042516	level of shadow of prion protein (human) in blood serum	PR:Q5BIV9	shadow of prion protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042517	level of bromodomain testis-specific protein (human) in blood serum	PR:Q58F21	bromodomain testis-specific protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042518	level of TPT1-like protein (human) in blood serum	PR:Q56UQ5	TPT1-like protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042519	level of protein Largen (human) in blood serum	PR:Q569H4	protein Largen (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042520	level of BolA-like protein 3 (human) in blood serum	PR:Q53S33	BolA-like protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042521	level of fibulin-7 (human) in blood serum	PR:Q53RD9	fibulin-7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042522	level of coiled-coil domain-containing protein 92 (human) in blood serum	PR:Q53HC0	coiled-coil domain-containing protein 92 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042523	level of endoribonuclease LACTB2 (human) in blood serum	PR:Q53H82	endoribonuclease LACTB2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042524	level of akirin-2 (human) in blood serum	PR:Q53H80	akirin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042525	level of phospholipase A1 member A (human) in blood serum	PR:Q53H76	phospholipase A1 member A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042526	level of histone-lysine N-methyltransferase SETMAR (human) in blood serum	PR:Q53H47	histone-lysine N-methyltransferase SETMAR (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042527	level of PDZ and LIM domain protein 3 (human) in blood serum	PR:Q53GG5	PDZ and LIM domain protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042528	level of kelch-like protein 12 (human) in blood serum	PR:Q53G59	kelch-like protein 12 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042529	level of protein Hikeshi (human) in blood serum	PR:Q53FT3	protein Hikeshi (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042530	level of quinone oxidoreductase PIG3 (human) in blood serum	PR:Q53FA7	quinone oxidoreductase PIG3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042531	level of programmed cell death protein 4 (human) in blood serum	PR:Q53EL6	programmed cell death protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042532	level of leucine-rich repeat-containing protein 24 (human) in blood serum	PR:Q50LG9	leucine-rich repeat-containing protein 24 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042533	level of extracellular tyrosine-protein kinase PKDCC (human) in blood serum	PR:Q504Y2	extracellular tyrosine-protein kinase PKDCC (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042534	level of angiomotin (human) in blood serum	PR:Q4VCS5	angiomotin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042535	level of B-cell CLL/lymphoma 7 protein family member A (human) in blood serum	PR:Q4VC05	B-cell CLL/lymphoma 7 protein family member A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042536	level of transmembrane protein 119 (human) in blood serum	PR:Q4V9L6	transmembrane protein 119 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042537	level of GRIP1-associated protein 1 (human) in blood serum	PR:Q4V328	GRIP1-associated protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042538	level of transmembrane protein 52B (human) in blood serum	PR:Q4KMG9	transmembrane protein 52B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042539	level of glucoside xylosyltransferase 1 (human) in blood serum	PR:Q4G148	glucoside xylosyltransferase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042540	level of sperm protein associated with the nucleus on the X chromosome N4 (human) in blood serum	PR:Q5MJ08	sperm protein associated with the nucleus on the X chromosome N4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042541	level of cytospin-B (human) in blood serum	PR:Q5M775	cytospin-B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042542	level of probable methyltransferase-like protein 24 (human) in blood serum	PR:Q5JXM2	probable methyltransferase-like protein 24 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042543	level of signal-regulatory protein beta-2 (human) in blood serum	PR:Q5JXA9	signal-regulatory protein beta-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042544	level of protein FAM209B (human) in blood serum	PR:Q5JX69	protein FAM209B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042545	level of guanine nucleotide-binding protein G(s) subunit alpha isoforms XLas-1/XLas-2/XLas-3 (human) in blood serum	PR:Q5JWF2	guanine nucleotide-binding protein G(s) subunit alpha isoforms XLas-1/XLas-2/XLas-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042546	level of intracellular hyaluronan-binding protein 4 (human) in blood serum	PR:Q5JVS0	intracellular hyaluronan-binding protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042547	level of spindlin-3 (human) in blood serum	PR:Q5JUX0	spindlin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042548	level of testis-expressed protein 30 (human) in blood serum	PR:Q5JUR7	testis-expressed protein 30 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042549	level of meiosis expressed gene 1 protein homolog (human) in blood serum	PR:Q5JSS6	meiosis expressed gene 1 protein homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042550	level of proteasome assembly chaperone 4 (human) in blood serum	PR:Q5JS54	proteasome assembly chaperone 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042551	level of NHL repeat-containing protein 3 (human) in blood serum	PR:Q5JS37	NHL repeat-containing protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042552	level of microtubule-associated tumor suppressor candidate 2 (human) in blood serum	PR:Q5JR59	microtubule-associated tumor suppressor candidate 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042553	level of nodal modulator 2 (human) in blood serum	PR:Q5JPE7	nodal modulator 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042554	level of ER membrane protein complex subunit 4 (human) in blood serum	PR:Q5J8M3	ER membrane protein complex subunit 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042555	level of beta-defensin 121 (human) in blood serum	PR:Q5J5C9	beta-defensin 121 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042556	level of tetratricopeptide repeat protein 32 (human) in blood serum	PR:Q5I0X7	tetratricopeptide repeat protein 32 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042557	level of cancer/testis antigen family 45 member A1 (human) in blood serum	PR:Q5HYN5	cancer/testis antigen family 45 member A1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042558	level of 2-methoxy-6-polyprenyl-1,4-benzoquinol methylase, mitochondrial (human) in blood serum	PR:Q5HYK3	2-methoxy-6-polyprenyl-1,4-benzoquinol methylase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042559	level of Rab-like protein 3 (human) in blood serum	PR:Q5HYI8	Rab-like protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042560	level of transcription elongation factor A protein-like 5 (human) in blood serum	PR:Q5H9L2	transcription elongation factor A protein-like 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042561	level of protein BEX5 (human) in blood serum	PR:Q5H9J7	protein BEX5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042562	level of Kita-kyushu lung cancer antigen 1 (human) in blood serum	PR:Q5H943	Kita-kyushu lung cancer antigen 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042563	level of FRAS1-related extracellular matrix protein 1 (human) in blood serum	PR:Q5H8C1	FRAS1-related extracellular matrix protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042564	level of neuromedin-S (human) in blood serum	PR:Q5H8A3	neuromedin-S (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042565	level of probable E3 ubiquitin-protein ligase HERC4 (human) in blood serum	PR:Q5GLZ8	probable E3 ubiquitin-protein ligase HERC4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042566	level of von Willebrand factor A domain-containing protein 2 (human) in blood serum	PR:Q5GFL6	von Willebrand factor A domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042567	level of inactive ribonuclease-like protein 10 (human) in blood serum	PR:Q5GAN6	inactive ribonuclease-like protein 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042568	level of probable inactive ribonuclease-like protein 13 (human) in blood serum	PR:Q5GAN3	probable inactive ribonuclease-like protein 13 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042569	level of F-box only protein 48 (human) in blood serum	PR:Q5FWF7	F-box only protein 48 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042570	level of centromere protein W (human) in blood serum	PR:Q5EE01	centromere protein W (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042571	level of uncharacterized protein C1orf185 (human) in blood serum	PR:Q5T7R7	uncharacterized protein C1orf185 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042572	level of synaptotagmin-6 (human) in blood serum	PR:Q5T7P8	synaptotagmin-6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042573	level of protein FAM162B (human) in blood serum	PR:Q5T6X4	protein FAM162B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042574	level of DDB1- and CUL4-associated factor 12 (human) in blood serum	PR:Q5T6F0	DDB1- and CUL4-associated factor 12 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042575	level of 39S ribosomal protein L2, mitochondrial (human) in blood serum	PR:Q5T653	39S ribosomal protein L2, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042576	level of adhesion G-protein coupled receptor F1 (human) in blood serum	PR:Q5T601	adhesion G-protein coupled receptor F1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042577	level of late cornified envelope protein 3C (human) in blood serum	PR:Q5T5A8	late cornified envelope protein 3C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042578	level of secreted frizzled-related protein 5 (human) in blood serum	PR:Q5T4F7	secreted frizzled-related protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042579	level of E3 ubiquitin-protein ligase HECTD3 (human) in blood serum	PR:Q5T447	E3 ubiquitin-protein ligase HECTD3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042580	level of Na(+)/H(+) exchange regulatory cofactor NHE-RF3 (human) in blood serum	PR:Q5T2W1	Na(+)/H(+) exchange regulatory cofactor NHE-RF3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042581	level of MAGUK p55 subfamily member 7 (human) in blood serum	PR:Q5T2T1	MAGUK p55 subfamily member 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042582	level of OTU domain-containing protein 3 (human) in blood serum	PR:Q5T2D3	OTU domain-containing protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042583	level of trem-like transcript 2 protein (human) in blood serum	PR:Q5T2D2	trem-like transcript 2 protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042584	level of noncompact myelin-associated protein (human) in blood serum	PR:Q5T1S8	noncompact myelin-associated protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042585	level of protein eyes shut homolog (human) in blood serum	PR:Q5T1H1	protein eyes shut homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042586	level of acyl-coenzyme A thioesterase THEM4 (human) in blood serum	PR:Q5T1C6	acyl-coenzyme A thioesterase THEM4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042587	level of spermatogenesis-associated protein 46 (human) in blood serum	PR:Q5T0L3	spermatogenesis-associated protein 46 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042588	level of FRAS1-related extracellular matrix protein 2 (human) in blood serum	PR:Q5SZK8	FRAS1-related extracellular matrix protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042589	level of BEN domain-containing protein 6 (human) in blood serum	PR:Q5SZJ8	BEN domain-containing protein 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042590	level of low density lipoprotein receptor adapter protein 1 (human) in blood serum	PR:Q5SW96	low density lipoprotein receptor adapter protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042591	level of glycoprotein endo-alpha-1,2-mannosidase (human) in blood serum	PR:Q5SRI9	glycoprotein endo-alpha-1,2-mannosidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042592	level of phytanoyl-CoA dioxygenase domain-containing protein 1 (human) in blood serum	PR:Q5SRE7	phytanoyl-CoA dioxygenase domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042593	level of protein phosphatase 1L (human) in blood serum	PR:Q5SGD2	protein phosphatase 1L (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042594	level of protein phosphatase 1 regulatory subunit 29 (human) in blood serum	PR:Q5R3F8	protein phosphatase 1 regulatory subunit 29 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042595	level of putative inactive group IIC secretory phospholipase A2 (human) in blood serum	PR:Q5R387	putative inactive group IIC secretory phospholipase A2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042596	level of Rab GTPase-activating protein 1-like isoforms 1/2/3/4/5/6/7/8/9 (human) in blood serum	PR:Q5R372	Rab GTPase-activating protein 1-like isoforms 1/2/3/4/5/6/7/8/9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042597	level of tubulin-specific chaperone cofactor E-like protein (human) in blood serum	PR:Q5QJ74	tubulin-specific chaperone cofactor E-like protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042598	level of C-type lectin domain family 12 member A (human) in blood serum	PR:Q5QGZ9	C-type lectin domain family 12 member A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042599	level of breast cancer metastasis-suppressor 1-like protein (human) in blood serum	PR:Q5PSV4	breast cancer metastasis-suppressor 1-like protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042600	level of protein Smaug homolog 2 (human) in blood serum	PR:Q5PRF9	protein Smaug homolog 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042601	level of sperm protein associated with the nucleus on the X chromosome N3 (human) in blood serum	PR:Q5MJ09	sperm protein associated with the nucleus on the X chromosome N3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042602	level of KH domain-containing, RNA-binding, signal transduction-associated protein 2 (human) in blood serum	PR:Q5VWX1	KH domain-containing, RNA-binding, signal transduction-associated protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042603	level of complement C1q-like protein 3 (human) in blood serum	PR:Q5VWW1	complement C1q-like protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042604	level of muscular LMNA-interacting protein (human) in blood serum	PR:Q5VWP3	muscular LMNA-interacting protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042605	level of interleukin-23 receptor (human) in blood serum	PR:Q5VWK5	interleukin-23 receptor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042606	level of protein GPR107 (human) in blood serum	PR:Q5VW38	protein GPR107 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042607	level of BRO1 domain-containing protein BROX (human) in blood serum	PR:Q5VW32	BRO1 domain-containing protein BROX (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042608	level of deubiquitinase MYSM1 (human) in blood serum	PR:Q5VVJ2	deubiquitinase MYSM1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042609	level of Rho guanine nucleotide exchange factor 16 (human) in blood serum	PR:Q5VV41	Rho guanine nucleotide exchange factor 16 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042610	level of succinate dehydrogenase assembly factor 4, mitochondrial (human) in blood serum	PR:Q5VUM1	succinate dehydrogenase assembly factor 4, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042611	level of protein FAM171A1 (human) in blood serum	PR:Q5VUB5	protein FAM171A1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042612	level of nuclear pore membrane glycoprotein 210-like (human) in blood serum	PR:Q5VU65	nuclear pore membrane glycoprotein 210-like (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042613	level of myomesin-3 (human) in blood serum	PR:Q5VTT5	myomesin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042614	level of serine/threonine-protein kinase MRCK alpha (human) in blood serum	PR:Q5VT25	serine/threonine-protein kinase MRCK alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042615	level of vacuolar protein sorting-associated protein 53 homolog (human) in blood serum	PR:Q5VIR6	vacuolar protein sorting-associated protein 53 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042616	level of ER membrane protein complex subunit 10 (human) in blood serum	PR:Q5UCC4	ER membrane protein complex subunit 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042617	level of ankyrin repeat domain-containing protein 45 (human) in blood serum	PR:Q5TZF3	ankyrin repeat domain-containing protein 45 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042618	level of MICOS complex subunit MIC10 (human) in blood serum	PR:Q5TGZ0	MICOS complex subunit MIC10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042619	level of transcription factor HES-3 (human) in blood serum	PR:Q5TGS1	transcription factor HES-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042620	level of hepatoma-derived growth factor-like protein 1 (human) in blood serum	PR:Q5TGJ6	hepatoma-derived growth factor-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042621	level of 5'-nucleotidase domain-containing protein 1 (human) in blood serum	PR:Q5TFE4	5'-nucleotidase domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042622	level of arginine-hydroxylase NDUFAF5, mitochondrial (human) in blood serum	PR:Q5TEU4	arginine-hydroxylase NDUFAF5, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042623	level of protein sel-1 homolog 2 (human) in blood serum	PR:Q5TEA6	protein sel-1 homolog 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042624	level of lengsin (human) in blood serum	PR:Q5TDP6	lengsin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042625	level of protein DDI1 homolog 2 (human) in blood serum	PR:Q5TDH0	protein DDI1 homolog 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042626	level of collagen alpha-1(XIII) chain (human) in blood serum	PR:Q5TAT6	collagen alpha-1(XIII) chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042627	level of transcription factor HES-5 (human) in blood serum	PR:Q5TA89	transcription factor HES-5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042628	level of late cornified envelope protein 3B (human) in blood serum	PR:Q5TA77	late cornified envelope protein 3B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042629	level of ceramide-1-phosphate transfer protein (human) in blood serum	PR:Q5TA50	ceramide-1-phosphate transfer protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042630	level of small RNA 2'-O-methyltransferase (human) in blood serum	PR:Q5T8I9	small RNA 2'-O-methyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042631	level of protein FAM102B (human) in blood serum	PR:Q5T8I3	protein FAM102B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042632	level of RAB6-interacting golgin (human) in blood serum	PR:Q5T7V8	RAB6-interacting golgin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042633	level of atlastin-3 (human) in blood serum	PR:Q6DD88	atlastin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042634	level of AMMECR1-like protein (human) in blood serum	PR:Q6DCA0	AMMECR1-like protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042635	level of NADH-cytochrome b5 reductase 2 (human) in blood serum	PR:Q6BCY4	NADH-cytochrome b5 reductase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042636	level of Fc receptor-like B (human) in blood serum	PR:Q6BAA4	Fc receptor-like B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042637	level of ankyrin repeat domain-containing protein 40 (human) in blood serum	PR:Q6AI12	ankyrin repeat domain-containing protein 40 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042638	level of CWF19-like protein 1 (human) in blood serum	PR:Q69YN2	CWF19-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042639	level of nuclear apoptosis-inducing factor 1 (human) in blood serum	PR:Q69YI7	nuclear apoptosis-inducing factor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042640	level of dual specificity phosphatase 29 (human) in blood serum	PR:Q68J44	dual specificity phosphatase 29 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042641	level of LEM domain-containing protein 1 (human) in blood serum	PR:Q68G75	LEM domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042642	level of integrator complex subunit 3 (human) in blood serum	PR:Q68E01	integrator complex subunit 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042643	level of acyl-coenzyme A thioesterase MBLAC2 (human) in blood serum	PR:Q68D91	acyl-coenzyme A thioesterase MBLAC2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042644	level of natural cytotoxicity triggering receptor 3 ligand 1 (human) in blood serum	PR:Q68D85	natural cytotoxicity triggering receptor 3 ligand 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042645	level of glycosyltransferase 8 domain-containing protein 1 (human) in blood serum	PR:Q68CQ7	glycosyltransferase 8 domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042646	level of tubulin polyglutamylase complex subunit 2 (human) in blood serum	PR:Q68CL5	tubulin polyglutamylase complex subunit 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042647	level of carboxypeptidase Z (human) in blood serum	PR:Q66K79	carboxypeptidase Z (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042648	level of meteorin-like protein (human) in blood serum	PR:Q641Q3	meteorin-like protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042649	level of tensin-2 (human) in blood serum	PR:Q63HR2	tensin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042650	level of pikachurin (human) in blood serum	PR:Q63HQ2	pikachurin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042651	level of AP-1 complex-associated regulatory protein (human) in blood serum	PR:Q63HQ0	AP-1 complex-associated regulatory protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042652	level of PI-PLC X domain-containing protein 3 (human) in blood serum	PR:Q63HM9	PI-PLC X domain-containing protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042653	level of putative caspase recruitment domain-containing protein 17P (human) in blood serum	PR:Q5XLA6	putative caspase recruitment domain-containing protein 17P (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042654	level of protein FAM219B (human) in blood serum	PR:Q5XKK7	protein FAM219B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042655	level of LysM and putative peptidoglycan-binding domain-containing protein 4 (human) in blood serum	PR:Q5XG99	LysM and putative peptidoglycan-binding domain-containing protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042656	level of phospholipid phosphatase 4 (human) in blood serum	PR:Q5VZY2	phospholipid phosphatase 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042657	level of protein-lysine methyltransferase METTL21C (human) in blood serum	PR:Q5VZV1	protein-lysine methyltransferase METTL21C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042658	level of muscleblind-like protein 2 (human) in blood serum	PR:Q5VZF2	muscleblind-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042659	level of Janus kinase and microtubule-interacting protein 3 (human) in blood serum	PR:Q5VZ66	Janus kinase and microtubule-interacting protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042660	level of UL16-binding protein 6 (human) in blood serum	PR:Q5VY80	UL16-binding protein 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042661	level of lipase member K (human) in blood serum	PR:Q5VXJ0	lipase member K (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042662	level of lipase member N (human) in blood serum	PR:Q5VXI9	lipase member N (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042663	level of lysophospholipase-like protein 1 (human) in blood serum	PR:Q5VWZ2	lysophospholipase-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042664	level of CapZ-interacting protein (human) in blood serum	PR:Q6JBY9	CapZ-interacting protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042665	level of leukocyte-associated immunoglobulin-like receptor 2 (human) in blood serum	PR:Q6ISS4	leukocyte-associated immunoglobulin-like receptor 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042666	level of pleckstrin homology domain-containing family A member 7 (human) in blood serum	PR:Q6IQ23	pleckstrin homology domain-containing family A member 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042667	level of N-acyl-phosphatidylethanolamine-hydrolyzing phospholipase D (human) in blood serum	PR:Q6IQ20	N-acyl-phosphatidylethanolamine-hydrolyzing phospholipase D (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042668	level of tRNA wybutosine-synthesizing protein 3 homolog (human) in blood serum	PR:Q6IPR3	tRNA wybutosine-synthesizing protein 3 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042669	level of serine/threonine-protein phosphatase 4 regulatory subunit 3A (human) in blood serum	PR:Q6IN85	serine/threonine-protein phosphatase 4 regulatory subunit 3A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042670	level of rRNA methyltransferase 1, mitochondrial (human) in blood serum	PR:Q6IN84	rRNA methyltransferase 1, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042671	level of sulfotransferase 6B1 (human) in blood serum	PR:Q6IMI4	sulfotransferase 6B1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042672	level of serine protease inhibitor Kazal-type 14 (human) in blood serum	PR:Q6IE38	serine protease inhibitor Kazal-type 14 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042673	level of retrotransposon Gag-like protein 6 (human) in blood serum	PR:Q6ICC9	retrotransposon Gag-like protein 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042674	level of sesquipedalian-2 (human) in blood serum	PR:Q6ICB4	sesquipedalian-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042675	level of desumoylating isopeptidase 1 (human) in blood serum	PR:Q6ICB0	desumoylating isopeptidase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042676	level of twinfilin-2 (human) in blood serum	PR:Q6IBS0	twinfilin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042677	level of glycine N-acyltransferase (human) in blood serum	PR:Q6IB77	glycine N-acyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042678	level of single Ig IL-1-related receptor (human) in blood serum	PR:Q6IA17	single Ig IL-1-related receptor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042679	level of astacin-like metalloendopeptidase (human) in blood serum	PR:Q6HA08	astacin-like metalloendopeptidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042680	level of UL-16 binding protein 5 (human) in blood serum	PR:Q6H3X3	UL-16 binding protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042681	level of leukocyte-associated immunoglobulin-like receptor 1 (human) in blood serum	PR:Q6GTX8	leukocyte-associated immunoglobulin-like receptor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042682	level of OTU domain-containing protein 7B (human) in blood serum	PR:Q6GQQ9	OTU domain-containing protein 7B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042683	level of chymotrypsinogen B2 (human) in blood serum	PR:Q6GPI1	chymotrypsinogen B2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042684	level of inositol 1,4,5-trisphosphate receptor-interacting protein-like 1 (human) in blood serum	PR:Q6GPH6	inositol 1,4,5-trisphosphate receptor-interacting protein-like 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042685	level of fatty-acid amide hydrolase 2 (human) in blood serum	PR:Q6GMR7	fatty-acid amide hydrolase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042686	level of secreted frizzled-related protein 4 (human) in blood serum	PR:Q6FHJ7	secreted frizzled-related protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042687	level of putative uncharacterized protein TXNRD3NB (human) in blood serum	PR:Q6F5E7	putative uncharacterized protein TXNRD3NB (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042688	level of vasorin (human) in blood serum	PR:Q6EMK4	vasorin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042689	level of C-type lectin domain family 6 member A (human) in blood serum	PR:Q6EIG7	C-type lectin domain family 6 member A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042690	level of small ubiquitin-related modifier 4 (human) in blood serum	PR:Q6EEV6	small ubiquitin-related modifier 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042691	level of interleukin-31 (human) in blood serum	PR:Q6EBC2	interleukin-31 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042692	level of dermokine (human) in blood serum	PR:Q6E0U4	dermokine (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042693	level of Fc receptor-like protein 6 (human) in blood serum	PR:Q6DN72	Fc receptor-like protein 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042694	level of transmembrane protein PVRIG (human) in blood serum	PR:Q6DKI7	transmembrane protein PVRIG (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042695	level of alpha-(1,3)-fucosyltransferase 10 (human) in blood serum	PR:Q6P4F1	alpha-(1,3)-fucosyltransferase 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042696	level of protein GOLM2 (human) in blood serum	PR:Q6P4E1	protein GOLM2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042697	level of phospholipase B-like 1 (human) in blood serum	PR:Q6P4A8	phospholipase B-like 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042698	level of tetratricopeptide repeat protein 27 (human) in blood serum	PR:Q6P3X3	tetratricopeptide repeat protein 27 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042699	level of enhancer of mRNA-decapping protein 4 (human) in blood serum	PR:Q6P2E9	enhancer of mRNA-decapping protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042700	level of Myb/SANT-like DNA-binding domain-containing protein 2 (human) in blood serum	PR:Q6P1R3	Myb/SANT-like DNA-binding domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042701	level of tRNA N(3)-methylcytidine methyltransferase METTL2B (human) in blood serum	PR:Q6P1Q9	tRNA N(3)-methylcytidine methyltransferase METTL2B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042702	level of LETM1 domain-containing protein 1 (human) in blood serum	PR:Q6P1Q0	LETM1 domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042703	level of deoxyribonuclease TATDN1 (human) in blood serum	PR:Q6P1N9	deoxyribonuclease TATDN1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042704	level of 39S ribosomal protein L14, mitochondrial (human) in blood serum	PR:Q6P1L8	39S ribosomal protein L14, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042705	level of polyamine-modulated factor 1 (human) in blood serum	PR:Q6P1K2	polyamine-modulated factor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042706	level of endoplasmic reticulum aminopeptidase 2 (human) in blood serum	PR:Q6P179	endoplasmic reticulum aminopeptidase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042707	level of caveolae-associated protein 1 (human) in blood serum	PR:Q6NZI2	caveolae-associated protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042708	level of bifunctional arginine demethylase and lysyl-hydroxylase JMJD6 (human) in blood serum	PR:Q6NYC1	bifunctional arginine demethylase and lysyl-hydroxylase JMJD6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042709	level of ankyrin repeat domain-containing protein 54 (human) in blood serum	PR:Q6NXT1	ankyrin repeat domain-containing protein 54 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042710	level of epithelial splicing regulatory protein 1 (human) in blood serum	PR:Q6NXG1	epithelial splicing regulatory protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042711	level of zinc finger protein 774 (human) in blood serum	PR:Q6NX45	zinc finger protein 774 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042712	level of RWD domain-containing protein 4 (human) in blood serum	PR:Q6NW29	RWD domain-containing protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042713	level of 3-hydroxyisobutyryl-CoA hydrolase, mitochondrial (human) in blood serum	PR:Q6NVY1	3-hydroxyisobutyryl-CoA hydrolase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042714	level of PWWP domain-containing protein 2B (human) in blood serum	PR:Q6NUJ5	PWWP domain-containing protein 2B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042715	level of uncharacterized protein C11orf87 (human) in blood serum	PR:Q6NUJ2	uncharacterized protein C11orf87 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042716	level of proactivator polypeptide-like 1 (human) in blood serum	PR:Q6NUJ1	proactivator polypeptide-like 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042717	level of G antigen 2A (human) in blood serum	PR:Q6NT46	G antigen 2A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042718	level of DNA oxidative demethylase ALKBH2 (human) in blood serum	PR:Q6NS38	DNA oxidative demethylase ALKBH2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042719	level of teneurin-4 (human) in blood serum	PR:Q6N022	teneurin-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042720	level of calpain-13 (human) in blood serum	PR:Q6MZZ7	calpain-13 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042721	level of follistatin-related protein 4 (human) in blood serum	PR:Q6MZW2	follistatin-related protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042722	level of proline-rich protein 27 (human) in blood serum	PR:Q6MZM9	proline-rich protein 27 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042723	level of ferroxidase HEPHL1 (human) in blood serum	PR:Q6MZM0	ferroxidase HEPHL1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042724	level of epididymal-specific lipocalin-8 (human) in blood serum	PR:Q6JVE9	epididymal-specific lipocalin-8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042725	level of epididymal-specific lipocalin-10 (human) in blood serum	PR:Q6JVE6	epididymal-specific lipocalin-10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042726	level of von Hippel-Lindau-like protein (human) in blood serum	PR:Q6RSH7	von Hippel-Lindau-like protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042727	level of biogenesis of lysosome-related organelles complex 1 subunit 2 (human) in blood serum	PR:Q6QNY1	biogenesis of lysosome-related organelles complex 1 subunit 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042728	level of biogenesis of lysosome-related organelles complex 1 subunit 3 (human) in blood serum	PR:Q6QNY0	biogenesis of lysosome-related organelles complex 1 subunit 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042729	level of adhesion G-protein coupled receptor D1 (human) in blood serum	PR:Q6QNK2	adhesion G-protein coupled receptor D1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042730	level of cell surface glycoprotein CD200 receptor 2 (human) in blood serum	PR:Q6Q8B3	cell surface glycoprotein CD200 receptor 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042731	level of apolipoprotein A-V (human) in blood serum	PR:Q6Q788	apolipoprotein A-V (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042732	level of complexin-2 (human) in blood serum	PR:Q6PUV4	complexin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042733	level of BRICHOS domain-containing protein 5 (human) in blood serum	PR:Q6PL45	BRICHOS domain-containing protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042734	level of ATPase family AAA domain-containing protein 2 (human) in blood serum	PR:Q6PL18	ATPase family AAA domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042735	level of leucine-rich repeat and fibronectin type-III domain-containing protein 4 (human) in blood serum	PR:Q6PJG9	leucine-rich repeat and fibronectin type-III domain-containing protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042736	level of BRCA1-associated ATM activator 1 (human) in blood serum	PR:Q6PJG6	BRCA1-associated ATM activator 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042737	level of T-cell receptor-associated transmembrane adapter 1 (human) in blood serum	PR:Q6PIZ9	T-cell receptor-associated transmembrane adapter 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042738	level of hydroxyacylglutathione hydrolase-like protein (human) in blood serum	PR:Q6PII5	hydroxyacylglutathione hydrolase-like protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042739	level of tetratricopeptide repeat protein 33 (human) in blood serum	PR:Q6PID6	tetratricopeptide repeat protein 33 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042740	level of leukocyte immunoglobulin-like receptor subfamily A member 6 (human) in blood serum	PR:Q6PI73	leukocyte immunoglobulin-like receptor subfamily A member 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042741	level of aspartate--tRNA ligase, mitochondrial (human) in blood serum	PR:Q6PI48	aspartate--tRNA ligase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042742	level of serine/threonine-protein kinase ULK3 (human) in blood serum	PR:Q6PHR2	serine/threonine-protein kinase ULK3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042743	level of DCN1-like protein 2 (human) in blood serum	PR:Q6PH85	DCN1-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042744	level of sperm-associated antigen 11A (human) in blood serum	PR:Q6PDA7	sperm-associated antigen 11A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042745	level of von Willebrand factor A domain-containing protein 1 (human) in blood serum	PR:Q6PCB0	von Willebrand factor A domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042746	level of putative chondrosarcoma-associated gene 1 protein (human) in blood serum	PR:Q6PB30	putative chondrosarcoma-associated gene 1 protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042747	level of GTPase IMAP family member 6 (human) in blood serum	PR:Q6P9H5	GTPase IMAP family member 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042748	level of transmembrane protein 154 (human) in blood serum	PR:Q6P9G4	transmembrane protein 154 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042749	level of E3 ubiquitin ligase TRIM40 (human) in blood serum	PR:Q6P9F5	E3 ubiquitin ligase TRIM40 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042750	level of palmitoleoyl-protein carboxylesterase NOTUM (human) in blood serum	PR:Q6P988	palmitoleoyl-protein carboxylesterase NOTUM (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042751	level of ankyrin repeat domain-containing protein 16 (human) in blood serum	PR:Q6P6B7	ankyrin repeat domain-containing protein 16 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042752	level of protein LEG1 homolog (human) in blood serum	PR:Q6P5S2	protein LEG1 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042753	level of kinesin light chain 3 (human) in blood serum	PR:Q6P597	kinesin light chain 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042754	level of acylpyruvase FAHD1, mitochondrial (human) in blood serum	PR:Q6P587	acylpyruvase FAHD1, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042755	level of mitotic-spindle organizing protein 2A (human) in blood serum	PR:Q6P582	mitotic-spindle organizing protein 2A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042756	level of ferredoxin-2, mitochondrial (human) in blood serum	PR:Q6P4F2	ferredoxin-2, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042757	level of V-set and transmembrane domain-containing protein 1 (human) in blood serum	PR:Q6UX27	V-set and transmembrane domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042758	level of BRCA1-A complex subunit Abraxas 1 (human) in blood serum	PR:Q6UWZ7	BRCA1-A complex subunit Abraxas 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042759	level of olfactomedin-like protein 1 (human) in blood serum	PR:Q6UWY5	olfactomedin-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042760	level of serine protease 57 (human) in blood serum	PR:Q6UWY2	serine protease 57 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042761	level of arylsulfatase K (human) in blood serum	PR:Q6UWY0	arylsulfatase K (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042762	level of carboxylesterase 3 (human) in blood serum	PR:Q6UWW8	carboxylesterase 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042763	level of protein shisa-like-2A (human) in blood serum	PR:Q6UWV7	protein shisa-like-2A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042764	level of bombesin receptor-activated protein C6orf89 (human) in blood serum	PR:Q6UWU4	bombesin receptor-activated protein C6orf89 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042765	level of uncharacterized protein C5orf46 (human) in blood serum	PR:Q6UWT4	uncharacterized protein C5orf46 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042766	level of protein PET117 homolog, mitochondrial (human) in blood serum	PR:Q6UWS5	protein PET117 homolog, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042767	level of glycerophosphocholine cholinephosphodiesterase ENPP6 (human) in blood serum	PR:Q6UWR7	glycerophosphocholine cholinephosphodiesterase ENPP6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042768	level of suprabasin (human) in blood serum	PR:Q6UWP8	suprabasin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042769	level of dehydrogenase/reductase SDR family member 11 (human) in blood serum	PR:Q6UWP2	dehydrogenase/reductase SDR family member 11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042770	level of serine protease inhibitor Kazal-type 6 (human) in blood serum	PR:Q6UWN8	serine protease inhibitor Kazal-type 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042771	level of lactase-like protein (human) in blood serum	PR:Q6UWM7	lactase-like protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042772	level of kin of IRRE-like protein 2 (human) in blood serum	PR:Q6UWL6	kin of IRRE-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042773	level of sushi domain-containing protein 1 (human) in blood serum	PR:Q6UWL2	sushi domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042774	level of protein shisa-2 homolog (human) in blood serum	PR:Q6UWI4	protein shisa-2 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042775	level of SLP adapter and CSK-interacting membrane protein (human) in blood serum	PR:Q6UWF3	SLP adapter and CSK-interacting membrane protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042776	level of E3 ubiquitin-protein ligase LRSAM1 (human) in blood serum	PR:Q6UWE0	E3 ubiquitin-protein ligase LRSAM1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042777	level of transmembrane protein C16orf54 (human) in blood serum	PR:Q6UWD8	transmembrane protein C16orf54 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042778	level of interleukin-27 receptor subunit alpha (human) in blood serum	PR:Q6UWB1	interleukin-27 receptor subunit alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042779	level of regenerating islet-derived protein 3-gamma (human) in blood serum	PR:Q6UW15	regenerating islet-derived protein 3-gamma (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042780	level of surfactant-associated protein 2 (human) in blood serum	PR:Q6UW10	surfactant-associated protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042781	level of C-type lectin domain family 2 member A (human) in blood serum	PR:Q6UVW9	C-type lectin domain family 2 member A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042782	level of chondroitin sulfate proteoglycan 4 (human) in blood serum	PR:Q6UVK1	chondroitin sulfate proteoglycan 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042783	level of CREB-regulated transcription coactivator 3 (human) in blood serum	PR:Q6UUV7	CREB-regulated transcription coactivator 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042784	level of methionine aminopeptidase 1D, mitochondrial (human) in blood serum	PR:Q6UB28	methionine aminopeptidase 1D, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042785	level of ADP-ribosylation factor-like protein 9 (human) in blood serum	PR:Q6T311	ADP-ribosylation factor-like protein 9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042786	level of SHC-transforming protein 4 (human) in blood serum	PR:Q6S5L8	SHC-transforming protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042787	level of POTE ankyrin domain family member G (human) in blood serum	PR:Q6S5H5	POTE ankyrin domain family member G (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042788	level of tripartite motif-containing protein 72 (human) in blood serum	PR:Q6ZMU5	tripartite motif-containing protein 72 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042789	level of transmembrane protease serine 11A (human) in blood serum	PR:Q6ZMR5	transmembrane protease serine 11A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042790	level of scavenger receptor class A member 5 (human) in blood serum	PR:Q6ZMJ2	scavenger receptor class A member 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042791	level of gliomedin (human) in blood serum	PR:Q6ZMI3	gliomedin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042792	level of sialic acid-binding Ig-like lectin 15 (human) in blood serum	PR:Q6ZMC9	sialic acid-binding Ig-like lectin 15 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042793	level of acetylgalactosaminyl-O-glycosyl-glycoprotein beta-1,3-N-acetylglucosaminyltransferase (human) in blood serum	PR:Q6ZMB0	acetylgalactosaminyl-O-glycosyl-glycoprotein beta-1,3-N-acetylglucosaminyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042794	level of kynurenine--oxoglutarate transaminase 3 (human) in blood serum	PR:Q6YP21	kynurenine--oxoglutarate transaminase 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042795	level of hydroxysteroid dehydrogenase-like protein 2 (human) in blood serum	PR:Q6YN16	hydroxysteroid dehydrogenase-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042796	level of beta-1,3-glucosyltransferase (human) in blood serum	PR:Q6Y288	beta-1,3-glucosyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042797	level of zona pellucida-binding protein 2 (human) in blood serum	PR:Q6X784	zona pellucida-binding protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042798	level of sclerostin domain-containing protein 1 (human) in blood serum	PR:Q6X4U4	sclerostin domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042799	level of chordin-like protein 2 (human) in blood serum	PR:Q6WN34	chordin-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042800	level of protein delta homolog 2 (human) in blood serum	PR:Q6UY11	protein delta homolog 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042801	level of carcinoembryonic antigen-related cell adhesion molecule 20 (human) in blood serum	PR:Q6UY09	carcinoembryonic antigen-related cell adhesion molecule 20 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042802	level of GDNF family receptor alpha-like (human) in blood serum	PR:Q6UXV0	GDNF family receptor alpha-like (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042803	level of uncharacterized protein C2orf66 (human) in blood serum	PR:Q6UXQ4	uncharacterized protein C2orf66 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042804	level of protein FAM151B (human) in blood serum	PR:Q6UXP7	protein FAM151B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042805	level of C-type lectin domain family 9 member A (human) in blood serum	PR:Q6UXN8	C-type lectin domain family 9 member A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042806	level of interleukin-20 receptor subunit beta (human) in blood serum	PR:Q6UXL0	interleukin-20 receptor subunit beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042807	level of nephronectin (human) in blood serum	PR:Q6UXI9	nephronectin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042808	level of vitrin (human) in blood serum	PR:Q6UXI7	vitrin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042809	level of angiopoietin-like protein 8 (human) in blood serum	PR:Q6UXH0	angiopoietin-like protein 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042810	level of butyrophilin-like protein 9 (human) in blood serum	PR:Q6UXG8	butyrophilin-like protein 9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042811	level of CMRF35-like molecule 9 (human) in blood serum	PR:Q6UXG3	CMRF35-like molecule 9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042812	level of butyrophilin-like protein 3 (human) in blood serum	PR:Q6UXE8	butyrophilin-like protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042813	level of C-type lectin domain family 4 member G (human) in blood serum	PR:Q6UXB4	C-type lectin domain family 4 member G (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042814	level of C-X-C motif chemokine 17 (human) in blood serum	PR:Q6UXB2	C-X-C motif chemokine 17 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042815	level of insulin growth factor-like family member 3 (human) in blood serum	PR:Q6UXB1	insulin growth factor-like family member 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042816	level of Ly6/PLAUR domain-containing protein 8 (human) in blood serum	PR:Q6UX82	Ly6/PLAUR domain-containing protein 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042817	level of ALK and LTK ligand 2 (human) in blood serum	PR:Q6UX46	ALK and LTK ligand 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042818	level of butyrophilin-like protein 8 (human) in blood serum	PR:Q6UX41	butyrophilin-like protein 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042819	level of synaptic vesicle glycoprotein 2A (human) in blood serum	PR:Q7L0J3	synaptic vesicle glycoprotein 2A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042820	level of staphylococcal nuclease domain-containing protein 1 (human) in blood serum	PR:Q7KZF4	staphylococcal nuclease domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042821	level of butyrophilin subfamily 2 member A1 (human) in blood serum	PR:Q7KYR7	butyrophilin subfamily 2 member A1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042822	level of E3 ubiquitin-protein ligase HECW1 (human) in blood serum	PR:Q76N89	E3 ubiquitin-protein ligase HECW1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042823	level of protein MTSS 2 (human) in blood serum	PR:Q765P7	protein MTSS 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042824	level of urotensin-2B (human) in blood serum	PR:Q765I0	urotensin-2B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042825	level of transmembrane and ubiquitin-like domain-containing protein 2 (human) in blood serum	PR:Q71RG4	transmembrane and ubiquitin-like domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042826	level of BTB/POZ domain-containing protein KCTD1 (human) in blood serum	PR:Q719H9	BTB/POZ domain-containing protein KCTD1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042827	level of ubiquitin-conjugating enzyme E2 R2 (human) in blood serum	PR:Q712K3	ubiquitin-conjugating enzyme E2 R2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042828	level of cyclic AMP-responsive element-binding protein 3-like protein 2 (human) in blood serum	PR:Q70SY1	cyclic AMP-responsive element-binding protein 3-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042829	level of protein unc-13 homolog D (human) in blood serum	PR:Q70J99	protein unc-13 homolog D (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042830	level of ubiquitin carboxyl-terminal hydrolase 30 (human) in blood serum	PR:Q70CQ3	ubiquitin carboxyl-terminal hydrolase 30 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042831	level of regulator of hemoglobinization and erythroid cell expansion protein (human) in blood serum	PR:Q6ZWK4	regulator of hemoglobinization and erythroid cell expansion protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042832	level of syntaxin-binding protein 4 (human) in blood serum	PR:Q6ZWJ1	syntaxin-binding protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042833	level of ankyrin repeat and SAM domain-containing protein 3 (human) in blood serum	PR:Q6ZW76	ankyrin repeat and SAM domain-containing protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042834	level of PAX-interacting protein 1 (human) in blood serum	PR:Q6ZW49	PAX-interacting protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042835	level of TOM1-like protein 2 (human) in blood serum	PR:Q6ZVM7	TOM1-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042836	level of UPF0606 protein KIAA1549L (human) in blood serum	PR:Q6ZVL6	UPF0606 protein KIAA1549L (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042837	level of coiled-coil domain-containing protein 149 (human) in blood serum	PR:Q6ZUS6	coiled-coil domain-containing protein 149 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042838	level of phosphoinositide 3-kinase adapter protein 1 (human) in blood serum	PR:Q6ZUJ8	phosphoinositide 3-kinase adapter protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042839	level of spermatogenesis-associated protein 31D4 (human) in blood serum	PR:Q6ZUB0	spermatogenesis-associated protein 31D4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042840	level of cadherin-related family member 3 (human) in blood serum	PR:Q6ZTQ4	cadherin-related family member 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042841	level of lipocalin-like 1 protein (human) in blood serum	PR:Q6ZST4	lipocalin-like 1 protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042842	level of RNA-binding protein with multiple splicing 2 (human) in blood serum	PR:Q6ZRY4	RNA-binding protein with multiple splicing 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042843	level of sulfhydryl oxidase 2 (human) in blood serum	PR:Q6ZRP7	sulfhydryl oxidase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042844	level of Rho GTPase-activating protein 36 (human) in blood serum	PR:Q6ZRI8	Rho GTPase-activating protein 36 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042845	level of BICD family-like cargo adapter 1 (human) in blood serum	PR:Q6ZP65	BICD family-like cargo adapter 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042846	level of acid phosphatase type 7 (human) in blood serum	PR:Q6ZNF0	acid phosphatase type 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042847	level of guanylate-binding protein 6 (human) in blood serum	PR:Q6ZN66	guanylate-binding protein 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042848	level of netrin receptor UNC5A (human) in blood serum	PR:Q6ZN44	netrin receptor UNC5A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042849	level of protein lin-28 homolog B (human) in blood serum	PR:Q6ZN17	protein lin-28 homolog B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042850	level of chemokine-like protein TAFA-5 (human) in blood serum	PR:Q7Z5A7	chemokine-like protein TAFA-5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042851	level of lysozyme-like protein 2 (human) in blood serum	PR:Q7Z4W2	lysozyme-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042852	level of L-xylulose reductase (human) in blood serum	PR:Q7Z4W1	L-xylulose reductase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042853	level of growth/differentiation factor 7 (human) in blood serum	PR:Q7Z4P5	growth/differentiation factor 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042854	level of protein phosphatase 1 regulatory subunit 42 (human) in blood serum	PR:Q7Z4L9	protein phosphatase 1 regulatory subunit 42 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042855	level of protein O-glucosyltransferase 3 (human) in blood serum	PR:Q7Z4H8	protein O-glucosyltransferase 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042856	level of protein ADM2 (human) in blood serum	PR:Q7Z4H4	protein ADM2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042857	level of COMM domain-containing protein 6 (human) in blood serum	PR:Q7Z4G1	COMM domain-containing protein 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042858	level of low-density lipoprotein receptor-related protein 10 (human) in blood serum	PR:Q7Z4F1	low-density lipoprotein receptor-related protein 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042859	level of CUB and sushi domain-containing protein 2 (human) in blood serum	PR:Q7Z408	CUB and sushi domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042860	level of LysM and putative peptidoglycan-binding domain-containing protein 3 (human) in blood serum	PR:Q7Z3D4	LysM and putative peptidoglycan-binding domain-containing protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042861	level of MAM domain-containing protein 2 (human) in blood serum	PR:Q7Z304	MAM domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042862	level of PTB-containing, cubilin and LRP1-interacting protein (human) in blood serum	PR:Q7Z2X4	PTB-containing, cubilin and LRP1-interacting protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042863	level of 39S ribosomal protein L21, mitochondrial (human) in blood serum	PR:Q7Z2W9	39S ribosomal protein L21, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042864	level of aprataxin (human) in blood serum	PR:Q7Z2E3	aprataxin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042865	level of transcription factor 24 (human) in blood serum	PR:Q7RTU0	transcription factor 24 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042866	level of carbohydrate sulfotransferase 3 (human) in blood serum	PR:Q7LGC8	carbohydrate sulfotransferase 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042867	level of heparan sulfate 2-O-sulfotransferase 1 (human) in blood serum	PR:Q7LGA3	heparan sulfate 2-O-sulfotransferase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042868	level of ribonucleoside-diphosphate reductase subunit M2 B (human) in blood serum	PR:Q7LG56	ribonucleoside-diphosphate reductase subunit M2 B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042869	level of activity-regulated cytoskeleton-associated protein (human) in blood serum	PR:Q7LC44	activity-regulated cytoskeleton-associated protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042870	level of charged multivesicular body protein 1b (human) in blood serum	PR:Q7LBR1	charged multivesicular body protein 1b (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042871	level of MOB kinase activator 1B (human) in blood serum	PR:Q7L9L4	MOB kinase activator 1B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042872	level of synaptotagmin-13 (human) in blood serum	PR:Q7L8C5	synaptotagmin-13 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042873	level of E3 ubiquitin-protein transferase MAEA (human) in blood serum	PR:Q7L5Y9	E3 ubiquitin-protein transferase MAEA (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042874	level of lysophosphatidylcholine acyltransferase 2 (human) in blood serum	PR:Q7L5N7	lysophosphatidylcholine acyltransferase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042875	level of Fc receptor-like A (human) in blood serum	PR:Q7L513	Fc receptor-like A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042876	level of eukaryotic translation initiation factor 3 subunit M (human) in blood serum	PR:Q7L2H7	eukaryotic translation initiation factor 3 subunit M (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042877	level of isoaspartyl peptidase/L-asparaginase (human) in blood serum	PR:Q7L266	isoaspartyl peptidase/L-asparaginase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042878	level of cytochrome b5 reductase 4 (human) in blood serum	PR:Q7L1T6	cytochrome b5 reductase 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042879	level of carbohydrate sulfotransferase 9 (human) in blood serum	PR:Q7L1S5	carbohydrate sulfotransferase 9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042880	level of developmental pluripotency-associated protein 4 (human) in blood serum	PR:Q7L190	developmental pluripotency-associated protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042881	level of desmoglein-4 (human) in blood serum	PR:Q86SJ6	desmoglein-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042882	level of nucleoplasmin-2 (human) in blood serum	PR:Q86SE8	nucleoplasmin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042883	level of RNA-binding Raly-like protein (human) in blood serum	PR:Q86SE5	RNA-binding Raly-like protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042884	level of UDP-GlcNAc:betaGal beta-1,3-N-acetylglucosaminyltransferase 8 (human) in blood serum	PR:Q7Z7M8	UDP-GlcNAc:betaGal beta-1,3-N-acetylglucosaminyltransferase 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042885	level of centromere protein V (human) in blood serum	PR:Q7Z7K6	centromere protein V (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042886	level of 39S ribosomal protein L10, mitochondrial (human) in blood serum	PR:Q7Z7H8	39S ribosomal protein L10, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042887	level of transmembrane emp24 domain-containing protein 4 (human) in blood serum	PR:Q7Z7H5	transmembrane emp24 domain-containing protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042888	level of ciliogenesis-associated TTC17-interacting protein (human) in blood serum	PR:Q7Z7H3	ciliogenesis-associated TTC17-interacting protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042889	level of cytokine-dependent hematopoietic cell linker (human) in blood serum	PR:Q7Z7G1	cytokine-dependent hematopoietic cell linker (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042890	level of 39S ribosomal protein L55, mitochondrial (human) in blood serum	PR:Q7Z7F7	39S ribosomal protein L55, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042891	level of ubiquitin-conjugating enzyme E2 Q1 (human) in blood serum	PR:Q7Z7E8	ubiquitin-conjugating enzyme E2 Q1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042892	level of beta-defensin 128 (human) in blood serum	PR:Q7Z7B8	beta-defensin 128 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042893	level of beta-defensin 132 (human) in blood serum	PR:Q7Z7B7	beta-defensin 132 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042894	level of tRNA-specific adenosine deaminase 2 (human) in blood serum	PR:Q7Z6V5	tRNA-specific adenosine deaminase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042895	level of allergin-1 (human) in blood serum	PR:Q7Z6M3	allergin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042896	level of Rab9 effector protein with kelch motifs (human) in blood serum	PR:Q7Z6M1	Rab9 effector protein with kelch motifs (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042897	level of proline-rich transmembrane protein 2 (human) in blood serum	PR:Q7Z6L0	proline-rich transmembrane protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042898	level of Rho GTPase-activating protein 30 (human) in blood serum	PR:Q7Z6I6	Rho GTPase-activating protein 30 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042899	level of E3 ubiquitin-protein ligase RBBP6 (human) in blood serum	PR:Q7Z6E9	E3 ubiquitin-protein ligase RBBP6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042900	level of B- and T-lymphocyte attenuator (human) in blood serum	PR:Q7Z6A9	B- and T-lymphocyte attenuator (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042901	level of sprouty-related, EVH1 domain-containing protein 1 (human) in blood serum	PR:Q7Z699	sprouty-related, EVH1 domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042902	level of carcinoembryonic antigen-related cell adhesion molecule 19 (human) in blood serum	PR:Q7Z692	carcinoembryonic antigen-related cell adhesion molecule 19 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042903	level of neuroepithelial cell-transforming gene 1 protein (human) in blood serum	PR:Q7Z628	neuroepithelial cell-transforming gene 1 protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042904	level of probable G-protein coupled receptor 142 (human) in blood serum	PR:Q7Z601	probable G-protein coupled receptor 142 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042905	level of RNA 5'-monophosphate methyltransferase (human) in blood serum	PR:Q7Z5W3	RNA 5'-monophosphate methyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042906	level of amyloid beta A4 precursor protein-binding family B member 1-interacting protein (human) in blood serum	PR:Q7Z5R6	amyloid beta A4 precursor protein-binding family B member 1-interacting protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042907	level of complement C1q-like protein 2 (human) in blood serum	PR:Q7Z5L3	complement C1q-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042908	level of Rho GTPase-activating protein 22 (human) in blood serum	PR:Q7Z5H3	Rho GTPase-activating protein 22 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042909	level of golgin subfamily A member 7 (human) in blood serum	PR:Q7Z5G4	golgin subfamily A member 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042910	level of protein RIC-3 (human) in blood serum	PR:Q7Z5B4	protein RIC-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042911	level of chemokine-like protein TAFA-3 (human) in blood serum	PR:Q7Z5A8	chemokine-like protein TAFA-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042912	level of calcium-binding protein 7 (human) in blood serum	PR:Q86V35	calcium-binding protein 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042913	level of acetoacetyl-CoA synthetase (human) in blood serum	PR:Q86V21	acetoacetyl-CoA synthetase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042914	level of 5'-nucleotidase domain-containing protein 3 (human) in blood serum	PR:Q86UY8	5'-nucleotidase domain-containing protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042915	level of inter-alpha-trypsin inhibitor heavy chain H5 (human) in blood serum	PR:Q86UX2	inter-alpha-trypsin inhibitor heavy chain H5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042916	level of hyaluronan and proteoglycan link protein 4 (human) in blood serum	PR:Q86UW8	hyaluronan and proteoglycan link protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042917	level of calcium-dependent secretion activator 2 (human) in blood serum	PR:Q86UW7	calcium-dependent secretion activator 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042918	level of tachykinin-4 (human) in blood serum	PR:Q86UU9	tachykinin-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042919	level of CUB and zona pellucida-like domain-containing protein 1 (human) in blood serum	PR:Q86UP6	CUB and zona pellucida-like domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042920	level of reticulon-4 receptor-like 1 (human) in blood serum	PR:Q86UN2	reticulon-4 receptor-like 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042921	level of membrane-associated guanylate kinase, WW and PDZ domain-containing protein 2 (human) in blood serum	PR:Q86UL8	membrane-associated guanylate kinase, WW and PDZ domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042922	level of zinc finger protein 329 (human) in blood serum	PR:Q86UD4	zinc finger protein 329 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042923	level of out at first protein homolog (human) in blood serum	PR:Q86UD1	out at first protein homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042924	level of RPA-interacting protein (human) in blood serum	PR:Q86UA6	RPA-interacting protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042925	level of protein polybromo-1 (human) in blood serum	PR:Q86U86	protein polybromo-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042926	level of LIM domain-binding protein 1 (human) in blood serum	PR:Q86U70	LIM domain-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042927	level of N6-adenosine-methyltransferase catalytic subunit (human) in blood serum	PR:Q86U44	N6-adenosine-methyltransferase catalytic subunit (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042928	level of polyadenylate-binding protein 2 isoforms 1/2 (human) in blood serum	PR:Q86U42	polyadenylate-binding protein 2 isoforms 1/2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042929	level of serpin A11 (human) in blood serum	PR:Q86U17	serpin A11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042930	level of probable RNA-binding protein 23 (human) in blood serum	PR:Q86U06	probable RNA-binding protein 23 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042931	level of actin-histidine N-methyltransferase (human) in blood serum	PR:Q86TU7	actin-histidine N-methyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042932	level of 39S ribosomal protein L52, mitochondrial (human) in blood serum	PR:Q86TS9	39S ribosomal protein L52, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042933	level of tRNA 2'-phosphotransferase 1 (human) in blood serum	PR:Q86TN4	tRNA 2'-phosphotransferase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042934	level of ADAMTS-like protein 2 (human) in blood serum	PR:Q86TH1	ADAMTS-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042935	level of sarcalumenin (human) in blood serum	PR:Q86TD4	sarcalumenin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042936	level of MOB kinase activator 3B (human) in blood serum	PR:Q86TA1	MOB kinase activator 3B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042937	level of transmembrane protease serine 11B (human) in blood serum	PR:Q86T26	transmembrane protease serine 11B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042938	level of transcriptional regulator Kaiso (human) in blood serum	PR:Q86T24	transcriptional regulator Kaiso (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042939	level of trafficking protein particle complex subunit 6B (human) in blood serum	PR:Q86SZ2	trafficking protein particle complex subunit 6B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042940	level of glutaredoxin-related protein 5, mitochondrial (human) in blood serum	PR:Q86SX6	glutaredoxin-related protein 5, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042941	level of synaptotagmin-9 (human) in blood serum	PR:Q86SS6	synaptotagmin-9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042942	level of polypeptide N-acetylgalactosaminyltransferase 10 (human) in blood serum	PR:Q86SR1	polypeptide N-acetylgalactosaminyltransferase 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042943	level of gastrokine-2 (human) in blood serum	PR:Q86XP6	gastrokine-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042944	level of V-set and immunoglobulin domain-containing protein 1 (human) in blood serum	PR:Q86XK7	V-set and immunoglobulin domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042945	level of protein phosphatase 1 regulatory subunit 3B (human) in blood serum	PR:Q86XI6	protein phosphatase 1 regulatory subunit 3B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042946	level of 4-hydroxy-2-oxoglutarate aldolase, mitochondrial (human) in blood serum	PR:Q86XE5	4-hydroxy-2-oxoglutarate aldolase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042947	level of calcium uptake protein 3, mitochondrial (human) in blood serum	PR:Q86XE3	calcium uptake protein 3, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042948	level of CST complex subunit TEN1 (human) in blood serum	PR:Q86WV5	CST complex subunit TEN1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042949	level of oocyte-secreted protein 2 (human) in blood serum	PR:Q86WS3	oocyte-secreted protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042950	level of coiled-coil domain-containing protein 25 (human) in blood serum	PR:Q86WR0	coiled-coil domain-containing protein 25 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042951	level of nuclear receptor 2C2-associated protein (human) in blood serum	PR:Q86WQ0	nuclear receptor 2C2-associated protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042952	level of interferon epsilon (human) in blood serum	PR:Q86WN2	interferon epsilon (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042953	level of F-BAR and double SH3 domains protein 1 (human) in blood serum	PR:Q86WN1	F-BAR and double SH3 domains protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042954	level of chromodomain-helicase-DNA-binding protein 1-like (human) in blood serum	PR:Q86WJ1	chromodomain-helicase-DNA-binding protein 1-like (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042955	level of serpin A9 (human) in blood serum	PR:Q86WD7	serpin A9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042956	level of protein phosphatase 1 regulatory subunit 27 (human) in blood serum	PR:Q86WC6	protein phosphatase 1 regulatory subunit 27 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042957	level of osteopetrosis-associated transmembrane protein 1 (human) in blood serum	PR:Q86WC4	osteopetrosis-associated transmembrane protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042958	level of sodium-independent sulfate anion transporter (human) in blood serum	PR:Q86WA9	sodium-independent sulfate anion transporter (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042959	level of valacyclovir hydrolase (human) in blood serum	PR:Q86WA6	valacyclovir hydrolase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042960	level of ankyrin repeat domain-containing protein 46 (human) in blood serum	PR:Q86W74	ankyrin repeat domain-containing protein 46 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042961	level of spermatogenesis-associated protein 24 (human) in blood serum	PR:Q86W54	spermatogenesis-associated protein 24 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042962	level of NACHT, LRR and PYD domains-containing protein 10 (human) in blood serum	PR:Q86W26	NACHT, LRR and PYD domains-containing protein 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042963	level of low-density lipoprotein receptor-related protein 11 (human) in blood serum	PR:Q86VZ4	low-density lipoprotein receptor-related protein 11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042964	level of Rho guanine nucleotide exchange factor 25 (human) in blood serum	PR:Q86VW2	Rho guanine nucleotide exchange factor 25 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042965	level of solute carrier family 22 member 16 (human) in blood serum	PR:Q86VW1	solute carrier family 22 member 16 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042966	level of catechol O-methyltransferase domain-containing protein 1 (human) in blood serum	PR:Q86VU5	catechol O-methyltransferase domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042967	level of four-jointed box protein 1 (human) in blood serum	PR:Q86VR8	four-jointed box protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042968	level of V-set and immunoglobulin domain-containing protein 10-like (human) in blood serum	PR:Q86VR7	V-set and immunoglobulin domain-containing protein 10-like (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042969	level of cullin-associated NEDD8-dissociated protein 1 (human) in blood serum	PR:Q86VP6	cullin-associated NEDD8-dissociated protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042970	level of Tax1-binding protein 1 (human) in blood serum	PR:Q86VP1	Tax1-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042971	level of zinc finger protein 410 (human) in blood serum	PR:Q86VK4	zinc finger protein 410 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042972	level of magnesium-dependent phosphatase 1 (human) in blood serum	PR:Q86V88	magnesium-dependent phosphatase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042973	level of metalloprotease TIKI1 (human) in blood serum	PR:Q86V40	metalloprotease TIKI1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042974	level of E3 ubiquitin-protein ligase SIAH1 (human) in blood serum	PR:Q8IUQ4	E3 ubiquitin-protein ligase SIAH1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042975	level of C-type lectin domain family 10 member A (human) in blood serum	PR:Q8IUN9	C-type lectin domain family 10 member A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042976	level of cartilage intermediate layer protein 2 (human) in blood serum	PR:Q8IUL8	cartilage intermediate layer protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042977	level of cerebellin-2 (human) in blood serum	PR:Q8IUK8	cerebellin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042978	level of plexin domain-containing protein 1 (human) in blood serum	PR:Q8IUK5	plexin domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042979	level of cytokine receptor-like factor 3 (human) in blood serum	PR:Q8IUI8	cytokine receptor-like factor 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042980	level of ribosomal oxygenase 2 (human) in blood serum	PR:Q8IUF8	ribosomal oxygenase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042981	level of homeobox protein TGIF2LX (human) in blood serum	PR:Q8IUE1	homeobox protein TGIF2LX (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042982	level of homeobox protein TGIF2LY (human) in blood serum	PR:Q8IUE0	homeobox protein TGIF2LY (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042983	level of ELKS/Rab6-interacting/CAST family member 1 (human) in blood serum	PR:Q8IUD2	ELKS/Rab6-interacting/CAST family member 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042984	level of polypeptide N-acetylgalactosaminyltransferase 13 (human) in blood serum	PR:Q8IUC8	polypeptide N-acetylgalactosaminyltransferase 13 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042985	level of rhophilin-2 (human) in blood serum	PR:Q8IUC4	rhophilin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042986	level of WAP four-disulfide core domain protein 13 (human) in blood serum	PR:Q8IUB5	WAP four-disulfide core domain protein 13 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042987	level of protein WFDC10B (human) in blood serum	PR:Q8IUB3	protein WFDC10B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042988	level of WAP four-disulfide core domain protein 3 (human) in blood serum	PR:Q8IUB2	WAP four-disulfide core domain protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042989	level of WAP four-disulfide core domain protein 8 (human) in blood serum	PR:Q8IUA0	WAP four-disulfide core domain protein 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042990	level of transmembrane protease serine 6 (human) in blood serum	PR:Q8IU80	transmembrane protease serine 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042991	level of interferon lambda receptor 1 (human) in blood serum	PR:Q8IU57	interferon lambda receptor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042992	level of complement C1q-like protein 4 (human) in blood serum	PR:Q86Z23	complement C1q-like protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042993	level of beta-klotho (human) in blood serum	PR:Q86Z14	beta-klotho (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042994	level of Ras-related protein Rab-43 (human) in blood serum	PR:Q86YS6	Ras-related protein Rab-43 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042995	level of homer protein homolog 1 (human) in blood serum	PR:Q86YM7	homer protein homolog 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042996	level of low-density lipoprotein receptor class A domain-containing protein 3 (human) in blood serum	PR:Q86YD5	low-density lipoprotein receptor class A domain-containing protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042997	level of transmembrane protein 25 (human) in blood serum	PR:Q86YD3	transmembrane protein 25 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042998	level of ERO1-like protein beta (human) in blood serum	PR:Q86YB8	ERO1-like protein beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2042999	level of histone-lysine N-methyltransferase KMT5C (human) in blood serum	PR:Q86Y97	histone-lysine N-methyltransferase KMT5C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043000	level of syntaxin-12 (human) in blood serum	PR:Q86Y82	syntaxin-12 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043001	level of B melanoma antigen 2 (human) in blood serum	PR:Q86Y30	B melanoma antigen 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043002	level of B melanoma antigen 3 (human) in blood serum	PR:Q86Y29	B melanoma antigen 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043003	level of E3 ubiquitin-protein ligase DTX1 (human) in blood serum	PR:Q86Y01	E3 ubiquitin-protein ligase DTX1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043004	level of TIR domain-containing adapter molecule 2 (human) in blood serum	PR:Q86XR7	TIR domain-containing adapter molecule 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043005	level of protein KIBRA (human) in blood serum	PR:Q8IX03	protein KIBRA (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043006	level of signal peptide, CUB and EGF-like domain-containing protein 1 (human) in blood serum	PR:Q8IWY4	signal peptide, CUB and EGF-like domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043007	level of extracellular sulfatase Sulf-2 (human) in blood serum	PR:Q8IWU5	extracellular sulfatase Sulf-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043008	level of cullin-9 (human) in blood serum	PR:Q8IWT3	cullin-9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043009	level of sodium channel subunit beta-4 (human) in blood serum	PR:Q8IWT1	sodium channel subunit beta-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043010	level of PHD finger protein 6 (human) in blood serum	PR:Q8IWS0	PHD finger protein 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043011	level of serine/threonine-protein kinase BRSK2 (human) in blood serum	PR:Q8IWQ3	serine/threonine-protein kinase BRSK2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043012	level of iron-sulfur cluster co-chaperone protein HscB (human) in blood serum	PR:Q8IWL3	iron-sulfur cluster co-chaperone protein HscB (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043013	level of MAX gene-associated protein (human) in blood serum	PR:Q8IWI9	MAX gene-associated protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043014	level of pleckstrin homology domain-containing family M member 2 (human) in blood serum	PR:Q8IWE5	pleckstrin homology domain-containing family M member 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043015	level of DCN1-like protein 3 (human) in blood serum	PR:Q8IWE4	DCN1-like protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043016	level of mitofusin-1 (human) in blood serum	PR:Q8IWA4	mitofusin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043017	level of SLIT and NTRK-like protein 4 (human) in blood serum	PR:Q8IW52	SLIT and NTRK-like protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043018	level of coiled-coil domain-containing protein 103 (human) in blood serum	PR:Q8IW40	coiled-coil domain-containing protein 103 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043019	level of V-set and transmembrane domain-containing protein 4 (human) in blood serum	PR:Q8IW00	V-set and transmembrane domain-containing protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043020	level of type III endosome membrane protein TEMP (human) in blood serum	PR:Q8IVY1	type III endosome membrane protein TEMP (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043021	level of FUN14 domain-containing protein 1 (human) in blood serum	PR:Q8IVP5	FUN14 domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043022	level of musculoskeletal embryonic nuclear protein 1 (human) in blood serum	PR:Q8IVN3	musculoskeletal embryonic nuclear protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043023	level of mitogen-activated protein kinase kinase kinase kinase 3 (human) in blood serum	PR:Q8IVH8	mitogen-activated protein kinase kinase kinase kinase 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043024	level of forkhead box protein P4 (human) in blood serum	PR:Q8IVH2	forkhead box protein P4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043025	level of Rho guanine nucleotide exchange factor TIAM2 (human) in blood serum	PR:Q8IVF5	Rho guanine nucleotide exchange factor TIAM2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043026	level of proline-rich protein 15 (human) in blood serum	PR:Q8IV56	proline-rich protein 15 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043027	level of ankyrin repeat and MYND domain-containing protein 2 (human) in blood serum	PR:Q8IV38	ankyrin repeat and MYND domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043028	level of protein HID1 (human) in blood serum	PR:Q8IV36	protein HID1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043029	level of purine nucleoside phosphorylase LACC1 (human) in blood serum	PR:Q8IV20	purine nucleoside phosphorylase LACC1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043030	level of 5'-3' exonuclease PLD3 (human) in blood serum	PR:Q8IV08	5'-3' exonuclease PLD3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043031	level of synaptotagmin-12 (human) in blood serum	PR:Q8IV01	synaptotagmin-12 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043032	level of epidermal growth factor-like protein 6 (human) in blood serum	PR:Q8IUX8	epidermal growth factor-like protein 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043033	level of RELT-like protein 1 (human) in blood serum	PR:Q8IUW5	RELT-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043034	level of armadillo repeat-containing protein 8 (human) in blood serum	PR:Q8IUR7	armadillo repeat-containing protein 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043035	level of trafficking protein particle complex subunit 5 (human) in blood serum	PR:Q8IUR0	trafficking protein particle complex subunit 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043036	level of dyslexia-associated protein KIAA0319-like protein (human) in blood serum	PR:Q8IZA0	dyslexia-associated protein KIAA0319-like protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043037	level of neurensin-1 (human) in blood serum	PR:Q8IZ57	neurensin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043038	level of zinc finger protein 34 (human) in blood serum	PR:Q8IZ26	zinc finger protein 34 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043039	level of G-protein coupled receptor 135 (human) in blood serum	PR:Q8IZ08	G-protein coupled receptor 135 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043040	level of calcium uptake protein 2, mitochondrial (human) in blood serum	PR:Q8IYU8	calcium uptake protein 2, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043041	level of osteoclast-associated immunoglobulin-like receptor (human) in blood serum	PR:Q8IYS5	osteoclast-associated immunoglobulin-like receptor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043042	level of dynein axonemal assembly factor 8 (human) in blood serum	PR:Q8IYS4	dynein axonemal assembly factor 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043043	level of uncharacterized protein KIAA2013 (human) in blood serum	PR:Q8IYS2	uncharacterized protein KIAA2013 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043044	level of protein Aster-C (human) in blood serum	PR:Q8IYS0	protein Aster-C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043045	level of tomoregulin-1 (human) in blood serum	PR:Q8IYR6	tomoregulin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043046	level of transcription elongation factor A protein-like 8 (human) in blood serum	PR:Q8IYN2	transcription elongation factor A protein-like 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043047	level of procollagen galactosyltransferase 2 (human) in blood serum	PR:Q8IYK4	procollagen galactosyltransferase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043048	level of synaptotagmin-like protein 1 (human) in blood serum	PR:Q8IYJ3	synaptotagmin-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043049	level of lung adenoma susceptibility protein 2 (human) in blood serum	PR:Q8IYD9	lung adenoma susceptibility protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043050	level of eukaryotic peptide chain release factor GTP-binding subunit ERF3B (human) in blood serum	PR:Q8IYD1	eukaryotic peptide chain release factor GTP-binding subunit ERF3B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043051	level of stromal membrane-associated protein 1 (human) in blood serum	PR:Q8IYB5	stromal membrane-associated protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043052	level of nucleotidyltransferase MB21D2 (human) in blood serum	PR:Q8IYB1	nucleotidyltransferase MB21D2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043053	level of homeobox protein Mohawk (human) in blood serum	PR:Q8IYA7	homeobox protein Mohawk (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043054	level of MICAL-like protein 2 (human) in blood serum	PR:Q8IY33	MICAL-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043055	level of intraflagellar transport protein 20 homolog (human) in blood serum	PR:Q8IY31	intraflagellar transport protein 20 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043056	level of C-Maf-inducing protein (human) in blood serum	PR:Q8IY22	C-Maf-inducing protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043057	level of doublesex- and mab-3-related transcription factor C2 (human) in blood serum	PR:Q8IXT2	doublesex- and mab-3-related transcription factor C2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043058	level of kelch-like protein 7 (human) in blood serum	PR:Q8IXQ5	kelch-like protein 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043059	level of chromatin complexes subunit BAP18 (human) in blood serum	PR:Q8IXM2	chromatin complexes subunit BAP18 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043060	level of methionine-R-sulfoxide reductase B3 (human) in blood serum	PR:Q8IXL7	methionine-R-sulfoxide reductase B3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043061	level of extracellular serine/threonine protein kinase FAM20C (human) in blood serum	PR:Q8IXL6	extracellular serine/threonine protein kinase FAM20C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043062	level of mitochondrial Rho GTPase 1 (human) in blood serum	PR:Q8IXI2	mitochondrial Rho GTPase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043063	level of DnaJ homolog subfamily C member 10 (human) in blood serum	PR:Q8IXB1	DnaJ homolog subfamily C member 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043064	level of sperm acrosome membrane-associated protein 3 (human) in blood serum	PR:Q8IXA5	sperm acrosome membrane-associated protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043065	level of signal peptide, CUB and EGF-like domain-containing protein 3 (human) in blood serum	PR:Q8IX30	signal peptide, CUB and EGF-like domain-containing protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043066	level of mast cell-expressed membrane protein 1 (human) in blood serum	PR:Q8IX19	mast cell-expressed membrane protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043067	level of NADH dehydrogenase [ubiquinone] 1 alpha subcomplex assembly factor 2 (human) in blood serum	PR:Q8N183	NADH dehydrogenase [ubiquinone] 1 alpha subcomplex assembly factor 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043068	level of N-acetylglutamate synthase, mitochondrial (human) in blood serum	PR:Q8N159	N-acetylglutamate synthase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043069	level of leukocyte immunoglobulin-like receptor subfamily A member 2 (human) in blood serum	PR:Q8N149	leukocyte immunoglobulin-like receptor subfamily A member 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043070	level of leucine-rich repeat LGI family member 3 (human) in blood serum	PR:Q8N145	leucine-rich repeat LGI family member 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043071	level of adenylosuccinate synthetase isozyme 1 (human) in blood serum	PR:Q8N142	adenylosuccinate synthetase isozyme 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043072	level of EP300-interacting inhibitor of differentiation 3 (human) in blood serum	PR:Q8N140	EP300-interacting inhibitor of differentiation 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043073	level of protein canopy homolog 4 (human) in blood serum	PR:Q8N129	protein canopy homolog 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043074	level of protein FAM177A1 (human) in blood serum	PR:Q8N128	protein FAM177A1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043075	level of killer cell immunoglobulin-like receptor 2DL5A (human) in blood serum	PR:Q8N109	killer cell immunoglobulin-like receptor 2DL5A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043076	level of beta-defensin 106 (human) in blood serum	PR:Q8N104	beta-defensin 106 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043077	level of V-set and immunoglobulin domain-containing protein 10 (human) in blood serum	PR:Q8N0Z9	V-set and immunoglobulin domain-containing protein 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043078	level of spartin (human) in blood serum	PR:Q8N0X7	spartin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043079	level of citramalyl-CoA lyase, mitochondrial (human) in blood serum	PR:Q8N0X4	citramalyl-CoA lyase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043080	level of N-acetyllactosaminide beta-1,6-N-acetylglucosaminyl-transferase (human) in blood serum	PR:Q8N0V5	N-acetyllactosaminide beta-1,6-N-acetylglucosaminyl-transferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043081	level of protein APCDD1 (human) in blood serum	PR:Q8J025	protein APCDD1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043082	level of tensin-4 (human) in blood serum	PR:Q8IZW8	tensin-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043083	level of retinol dehydrogenase 10 (human) in blood serum	PR:Q8IZV5	retinol dehydrogenase 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043084	level of protein FAM9B (human) in blood serum	PR:Q8IZU0	protein FAM9B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043085	level of heparan sulfate glucosamine 3-O-sulfotransferase 5 (human) in blood serum	PR:Q8IZT8	heparan sulfate glucosamine 3-O-sulfotransferase 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043086	level of voltage-dependent calcium channel subunit alpha-2/delta-3 (human) in blood serum	PR:Q8IZS8	voltage-dependent calcium channel subunit alpha-2/delta-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043087	level of CKLF-like MARVEL transmembrane domain-containing protein 4 (human) in blood serum	PR:Q8IZR5	CKLF-like MARVEL transmembrane domain-containing protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043088	level of selenoprotein H (human) in blood serum	PR:Q8IZQ5	selenoprotein H (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043089	level of adhesion G-protein coupled receptor G2 (human) in blood serum	PR:Q8IZP9	adhesion G-protein coupled receptor G2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043090	level of heparan-sulfate 6-O-sulfotransferase 3 (human) in blood serum	PR:Q8IZP7	heparan-sulfate 6-O-sulfotransferase 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043091	level of beta-defensin 107 (human) in blood serum	PR:Q8IZN7	beta-defensin 107 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043092	level of palmitoyltransferase ZDHHC14 (human) in blood serum	PR:Q8IZN3	palmitoyltransferase ZDHHC14 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043093	level of cyclin-dependent kinase 20 (human) in blood serum	PR:Q8IZL9	cyclin-dependent kinase 20 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043094	level of netrin receptor UNC5B (human) in blood serum	PR:Q8IZJ1	netrin receptor UNC5B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043095	level of interferon lambda-3 (human) in blood serum	PR:Q8IZI9	interferon lambda-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043096	level of adhesion G-protein coupled receptor F2 (human) in blood serum	PR:Q8IZF7	adhesion G-protein coupled receptor F2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043097	level of adhesion G protein-coupled receptor F5 (human) in blood serum	PR:Q8IZF2	adhesion G protein-coupled receptor F5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043098	level of prostaglandin reductase 3 (human) in blood serum	PR:Q8N4Q0	prostaglandin reductase 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043099	level of coiled-coil domain-containing protein 24 (human) in blood serum	PR:Q8N4L8	coiled-coil domain-containing protein 24 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043100	level of carnosine N-methyltransferase (human) in blood serum	PR:Q8N4J0	carnosine N-methyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043101	level of ferritin, mitochondrial (human) in blood serum	PR:Q8N4E7	ferritin, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043102	level of phosducin-like protein 2 (human) in blood serum	PR:Q8N4E4	phosducin-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043103	level of polypeptide N-acetylgalactosaminyltransferase 4 (human) in blood serum	PR:Q8N4A0	polypeptide N-acetylgalactosaminyltransferase 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043104	level of RING1 and YY1-binding protein (human) in blood serum	PR:Q8N488	RING1 and YY1-binding protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043105	level of follistatin-related protein 5 (human) in blood serum	PR:Q8N475	follistatin-related protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043106	level of zinc finger protein 843 (human) in blood serum	PR:Q8N446	zinc finger protein 843 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043107	level of fibroblast growth factor receptor-like 1 (human) in blood serum	PR:Q8N441	fibroblast growth factor receptor-like 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043108	level of polypeptide N-acetylgalactosaminyltransferase 16 (human) in blood serum	PR:Q8N428	polypeptide N-acetylgalactosaminyltransferase 16 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043109	level of thioredoxin domain-containing protein 3 (human) in blood serum	PR:Q8N427	thioredoxin domain-containing protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043110	level of inactive serine protease 35 (human) in blood serum	PR:Q8N3Z0	inactive serine protease 35 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043111	level of protein PALS1 (human) in blood serum	PR:Q8N3R9	protein PALS1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043112	level of cell adhesion molecule 2 (human) in blood serum	PR:Q8N3J6	cell adhesion molecule 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043113	level of chemokine-like protein TAFA-2 (human) in blood serum	PR:Q8N3H0	chemokine-like protein TAFA-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043114	level of MICAL-like protein 1 (human) in blood serum	PR:Q8N3F8	MICAL-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043115	level of 1-phosphatidylinositol 4,5-bisphosphate phosphodiesterase delta-3 (human) in blood serum	PR:Q8N3E9	1-phosphatidylinositol 4,5-bisphosphate phosphodiesterase delta-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043116	level of bifunctional peptidase and arginyl-hydroxylase JMJD5 (human) in blood serum	PR:Q8N371	bifunctional peptidase and arginyl-hydroxylase JMJD5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043117	level of voltage-dependent calcium channel beta subunit-associated regulatory protein (human) in blood serum	PR:Q8N350	voltage-dependent calcium channel beta subunit-associated regulatory protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043118	level of angiogenic factor with G patch and FHA domains 1 (human) in blood serum	PR:Q8N302	angiogenic factor with G patch and FHA domains 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043119	level of small vasohibin-binding protein (human) in blood serum	PR:Q8N300	small vasohibin-binding protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043120	level of neuroligin-1 (human) in blood serum	PR:Q8N2Q7	neuroligin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043121	level of lysophosphatidylserine lipase ABHD12 (human) in blood serum	PR:Q8N2K0	lysophosphatidylserine lipase ABHD12 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043122	level of GH3 domain-containing protein (human) in blood serum	PR:Q8N2G8	GH3 domain-containing protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043123	level of Ly6/PLAUR domain-containing protein 1 (human) in blood serum	PR:Q8N2G4	Ly6/PLAUR domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043124	level of armadillo repeat-containing protein 10 (human) in blood serum	PR:Q8N2F6	armadillo repeat-containing protein 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043125	level of Rho GTPase-activating protein 24 (human) in blood serum	PR:Q8N264	Rho GTPase-activating protein 24 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043126	level of histone H2B type 3-B (human) in blood serum	PR:Q8N257	histone H2B type 3-B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043127	level of cap-specific mRNA (nucleoside-2'-O-)-methyltransferase 1 (human) in blood serum	PR:Q8N1G2	cap-specific mRNA (nucleoside-2'-O-)-methyltransferase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043128	level of lysozyme g-like protein 1 (human) in blood serum	PR:Q8N1E2	lysozyme g-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043129	level of protein NATD1 (human) in blood serum	PR:Q8N6N6	protein NATD1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043130	level of tetratricopeptide repeat protein 9B (human) in blood serum	PR:Q8N6N2	tetratricopeptide repeat protein 9B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043131	level of testis-expressed protein 29 (human) in blood serum	PR:Q8N6K0	testis-expressed protein 29 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043132	level of ADP-ribosylation factor GTPase-activating protein 2 (human) in blood serum	PR:Q8N6H7	ADP-ribosylation factor GTPase-activating protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043133	level of ADAMTS-like protein 1 (human) in blood serum	PR:Q8N6G6	ADAMTS-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043134	level of chondroitin sulfate N-acetylgalactosaminyltransferase 2 (human) in blood serum	PR:Q8N6G5	chondroitin sulfate N-acetylgalactosaminyltransferase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043135	level of leukocyte immunoglobulin-like receptor subfamily A member 3 (human) in blood serum	PR:Q8N6C8	leukocyte immunoglobulin-like receptor subfamily A member 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043136	level of Myc target protein 1 (human) in blood serum	PR:Q8N699	Myc target protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043137	level of sodium-coupled monocarboxylate transporter 1 (human) in blood serum	PR:Q8N695	sodium-coupled monocarboxylate transporter 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043138	level of beta-defensin 119 (human) in blood serum	PR:Q8N690	beta-defensin 119 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043139	level of beta-defensin 125 (human) in blood serum	PR:Q8N687	beta-defensin 125 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043140	level of COMM domain-containing protein 1 (human) in blood serum	PR:Q8N668	COMM domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043141	level of inactive dipeptidyl peptidase 10 (human) in blood serum	PR:Q8N608	inactive dipeptidyl peptidase 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043142	level of BTB/POZ domain-containing protein KCTD17 (human) in blood serum	PR:Q8N5Z5	BTB/POZ domain-containing protein KCTD17 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043143	level of kynurenine/alpha-aminoadipate aminotransferase, mitochondrial (human) in blood serum	PR:Q8N5Z0	kynurenine/alpha-aminoadipate aminotransferase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043144	level of protein mono-ADP-ribosyltransferase PARP16 (human) in blood serum	PR:Q8N5Y8	protein mono-ADP-ribosyltransferase PARP16 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043145	level of protein FAM24B (human) in blood serum	PR:Q8N5W8	protein FAM24B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043146	level of uncharacterized protein C2orf73 (human) in blood serum	PR:Q8N5S3	uncharacterized protein C2orf73 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043147	level of zinc finger CCCH domain-containing protein 8 (human) in blood serum	PR:Q8N5P1	zinc finger CCCH domain-containing protein 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043148	level of CDGSH iron-sulfur domain-containing protein 2 (human) in blood serum	PR:Q8N5K1	CDGSH iron-sulfur domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043149	level of potassium channel regulatory protein (human) in blood serum	PR:Q8N5I3	potassium channel regulatory protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043150	level of SH2 domain-containing protein 3C (human) in blood serum	PR:Q8N5H7	SH2 domain-containing protein 3C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043151	level of macoilin (human) in blood serum	PR:Q8N5G2	macoilin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043152	level of ceramide synthase 5 (human) in blood serum	PR:Q8N5B7	ceramide synthase 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043153	level of melanoregulin (human) in blood serum	PR:Q8N565	melanoregulin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043154	level of zinc finger protein 276 (human) in blood serum	PR:Q8N554	zinc finger protein 276 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043155	level of fibrinogen C domain-containing protein 1 (human) in blood serum	PR:Q8N539	fibrinogen C domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043156	level of actin filament-associated protein 1-like 2 (human) in blood serum	PR:Q8N4X5	actin filament-associated protein 1-like 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043157	level of ER membrane protein complex subunit 5 (human) in blood serum	PR:Q8N4V1	ER membrane protein complex subunit 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043158	level of 3-oxoacyl-[acyl-carrier-protein] reductase (human) in blood serum	PR:Q8N4T8	3-oxoacyl-[acyl-carrier-protein] reductase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043159	level of MARVEL domain-containing protein 2 (human) in blood serum	PR:Q8N4S9	MARVEL domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043160	level of probable E3 ubiquitin-protein ligase TRIML1 (human) in blood serum	PR:Q8N9V2	probable E3 ubiquitin-protein ligase TRIML1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043161	level of probable RNA-binding protein EIF1AD (human) in blood serum	PR:Q8N9N8	probable RNA-binding protein EIF1AD (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043162	level of activating signal cointegrator 1 complex subunit 1 (human) in blood serum	PR:Q8N9N2	activating signal cointegrator 1 complex subunit 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043163	level of synaptotagmin-2 (human) in blood serum	PR:Q8N9I0	synaptotagmin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043164	level of lysophospholipase D GDPD1 (human) in blood serum	PR:Q8N9F7	lysophospholipase D GDPD1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043165	level of nuclear envelope phosphatase-regulatory subunit 1 (human) in blood serum	PR:Q8N9A8	nuclear envelope phosphatase-regulatory subunit 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043166	level of coiled-coil domain-containing protein 89 (human) in blood serum	PR:Q8N998	coiled-coil domain-containing protein 89 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043167	level of N-terminal EF-hand calcium-binding protein 1 (human) in blood serum	PR:Q8N987	N-terminal EF-hand calcium-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043168	level of leucine-rich repeat and transmembrane domain-containing protein 2 (human) in blood serum	PR:Q8N967	leucine-rich repeat and transmembrane domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043169	level of nutritionally-regulated adipose and cardiac enriched protein homolog (human) in blood serum	PR:Q8N912	nutritionally-regulated adipose and cardiac enriched protein homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043170	level of discoidin, CUB and LCCL domain-containing protein 1 (human) in blood serum	PR:Q8N8Z6	discoidin, CUB and LCCL domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043171	level of chromodomain Y-like protein 2 (human) in blood serum	PR:Q8N8U2	chromodomain Y-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043172	level of protein enabled homolog (human) in blood serum	PR:Q8N8S7	protein enabled homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043173	level of probable transmembrane reductase CYB561D1 (human) in blood serum	PR:Q8N8Q1	probable transmembrane reductase CYB561D1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043174	level of prostaglandin reductase 2 (human) in blood serum	PR:Q8N8N7	prostaglandin reductase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043175	level of uncharacterized protein FAM241A (human) in blood serum	PR:Q8N8J7	uncharacterized protein FAM241A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043176	level of sterile alpha motif domain-containing protein 12 (human) in blood serum	PR:Q8N8I0	sterile alpha motif domain-containing protein 12 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043177	level of leucine-rich single-pass membrane protein 1 (human) in blood serum	PR:Q8N8F7	leucine-rich single-pass membrane protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043178	level of centrosomal protein of 112 kDa (human) in blood serum	PR:Q8N8E3	centrosomal protein of 112 kDa (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043179	level of uncharacterized protein C12orf76 (human) in blood serum	PR:Q8N812	uncharacterized protein C12orf76 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043180	level of protein disulfide-isomerase-like protein of the testis (human) in blood serum	PR:Q8N807	protein disulfide-isomerase-like protein of the testis (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043181	level of cyclin-Y-like protein 1 (human) in blood serum	PR:Q8N7R7	cyclin-Y-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043182	level of inactive phospholipase D5 (human) in blood serum	PR:Q8N7P1	inactive phospholipase D5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043183	level of putative protein N-methyltransferase FAM86B1 (human) in blood serum	PR:Q8N7N1	putative protein N-methyltransferase FAM86B1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043184	level of HORMA domain-containing protein 2 (human) in blood serum	PR:Q8N7B1	HORMA domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043185	level of ER membrane protein complex subunit 1 (human) in blood serum	PR:Q8N766	ER membrane protein complex subunit 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043186	level of casein kinase I isoform alpha-like (human) in blood serum	PR:Q8N752	casein kinase I isoform alpha-like (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043187	level of NAD-dependent protein deacylase sirtuin-6 (human) in blood serum	PR:Q8N6T7	NAD-dependent protein deacylase sirtuin-6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043188	level of ADP-ribosylation factor GTPase-activating protein 1 (human) in blood serum	PR:Q8N6T3	ADP-ribosylation factor GTPase-activating protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043189	level of transmembrane and coiled-coil domain-containing protein 5A (human) in blood serum	PR:Q8N6Q1	transmembrane and coiled-coil domain-containing protein 5A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043190	level of acyl-CoA-binding domain-containing protein 7 (human) in blood serum	PR:Q8N6N7	acyl-CoA-binding domain-containing protein 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043191	level of probable aminopeptidase NPEPL1 (human) in blood serum	PR:Q8NDH3	probable aminopeptidase NPEPL1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043192	level of polypeptide N-acetylgalactosaminyltransferase 11 (human) in blood serum	PR:Q8NCW6	polypeptide N-acetylgalactosaminyltransferase 11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043193	level of NAD(P)H-hydrate epimerase (human) in blood serum	PR:Q8NCW5	NAD(P)H-hydrate epimerase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043194	level of carbohydrate sulfotransferase 14 (human) in blood serum	PR:Q8NCH0	carbohydrate sulfotransferase 14 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043195	level of carbohydrate sulfotransferase 4 (human) in blood serum	PR:Q8NCG5	carbohydrate sulfotransferase 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043196	level of BTB/POZ domain-containing protein KCTD6 (human) in blood serum	PR:Q8NC69	BTB/POZ domain-containing protein KCTD6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043197	level of neuropilin and tolloid-like protein 2 (human) in blood serum	PR:Q8NC67	neuropilin and tolloid-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043198	level of E3 ubiquitin-protein ligase RNF149 (human) in blood serum	PR:Q8NC42	E3 ubiquitin-protein ligase RNF149 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043199	level of RELT-like protein 2 (human) in blood serum	PR:Q8NC24	RELT-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043200	level of acyl-CoA-binding domain-containing protein 4 (human) in blood serum	PR:Q8NC06	acyl-CoA-binding domain-containing protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043201	level of UDP-glucuronic acid decarboxylase 1 (human) in blood serum	PR:Q8NBZ7	UDP-glucuronic acid decarboxylase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043202	level of INO80 complex subunit E (human) in blood serum	PR:Q8NBZ0	INO80 complex subunit E (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043203	level of synaptotagmin-8 (human) in blood serum	PR:Q8NBV8	synaptotagmin-8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043204	level of outer mitochondrial transmembrane helix translocase (human) in blood serum	PR:Q8NBU5	outer mitochondrial transmembrane helix translocase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043205	level of thioredoxin domain-containing protein 5 (human) in blood serum	PR:Q8NBS9	thioredoxin domain-containing protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043206	level of tumor protein p53-inducible protein 13 (human) in blood serum	PR:Q8NBR0	tumor protein p53-inducible protein 13 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043207	level of estradiol 17-beta-dehydrogenase 11 (human) in blood serum	PR:Q8NBQ5	estradiol 17-beta-dehydrogenase 11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043208	level of retinol dehydrogenase 13 (human) in blood serum	PR:Q8NBN7	retinol dehydrogenase 13 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043209	level of prenylcysteine oxidase-like (human) in blood serum	PR:Q8NBM8	prenylcysteine oxidase-like (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043210	level of protein O-glucosyltransferase 1 (human) in blood serum	PR:Q8NBL1	protein O-glucosyltransferase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043211	level of formylglycine-generating enzyme (human) in blood serum	PR:Q8NBK3	formylglycine-generating enzyme (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043212	level of inactive C-alpha-formylglycine-generating enzyme 2 (human) in blood serum	PR:Q8NBJ7	inactive C-alpha-formylglycine-generating enzyme 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043213	level of procollagen galactosyltransferase 1 (human) in blood serum	PR:Q8NBJ5	procollagen galactosyltransferase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043214	level of Golgi membrane protein 1 (human) in blood serum	PR:Q8NBJ4	Golgi membrane protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043215	level of xyloside xylosyltransferase 1 (human) in blood serum	PR:Q8NBI6	xyloside xylosyltransferase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043216	level of draxin (human) in blood serum	PR:Q8NBI3	draxin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043217	level of NHL repeat-containing protein 2 (human) in blood serum	PR:Q8NBF2	NHL repeat-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043218	level of ribosome biogenesis protein SPATA5 (human) in blood serum	PR:Q8NB90	ribosome biogenesis protein SPATA5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043219	level of keratinocyte differentiation factor 1 (human) in blood serum	PR:Q8NAX2	keratinocyte differentiation factor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043220	level of protein O-linked-mannose beta-1,4-N-acetylglucosaminyltransferase 2 (human) in blood serum	PR:Q8NAT1	protein O-linked-mannose beta-1,4-N-acetylglucosaminyltransferase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043221	level of leucine-rich repeat-containing protein 75A (human) in blood serum	PR:Q8NAA5	leucine-rich repeat-containing protein 75A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043222	level of putative phospholipase B-like 2 (human) in blood serum	PR:Q8NHP8	putative phospholipase B-like 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043223	level of piRNA biogenesis protein EXD1 (human) in blood serum	PR:Q8NHP7	piRNA biogenesis protein EXD1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043224	level of leukocyte immunoglobulin-like receptor subfamily B member 4 (human) in blood serum	PR:Q8NHJ6	leukocyte immunoglobulin-like receptor subfamily B member 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043225	level of small VCP/p97-interacting protein (human) in blood serum	PR:Q8NHG7	small VCP/p97-interacting protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043226	level of tubulin--tyrosine ligase (human) in blood serum	PR:Q8NG68	tubulin--tyrosine ligase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043227	level of neuroligin-4, Y-linked (human) in blood serum	PR:Q8NFZ3	neuroligin-4, Y-linked (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043228	level of semaphorin-6D (human) in blood serum	PR:Q8NFY4	semaphorin-6D (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043229	level of syntaxin-binding protein 6 (human) in blood serum	PR:Q8NFX7	syntaxin-binding protein 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043230	level of follicular dendritic cell secreted peptide (human) in blood serum	PR:Q8NFU4	follicular dendritic cell secreted peptide (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043231	level of thiosulfate:glutathione sulfurtransferase (human) in blood serum	PR:Q8NFU3	thiosulfate:glutathione sulfurtransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043232	level of interleukin-17 receptor E (human) in blood serum	PR:Q8NFR9	interleukin-17 receptor E (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043233	level of diphosphoinositol polyphosphate phosphohydrolase 3-alpha (human) in blood serum	PR:Q8NFP7	diphosphoinositol polyphosphate phosphohydrolase 3-alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043234	level of MAM domain-containing glycosylphosphatidylinositol anchor protein 1 (human) in blood serum	PR:Q8NFP4	MAM domain-containing glycosylphosphatidylinositol anchor protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043235	level of interleukin-17 receptor D (human) in blood serum	PR:Q8NFM7	interleukin-17 receptor D (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043236	level of cytosolic endo-beta-N-acetylglucosaminidase (human) in blood serum	PR:Q8NFI3	cytosolic endo-beta-N-acetylglucosaminidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043237	level of RalBP1-associated Eps domain-containing protein 2 (human) in blood serum	PR:Q8NFH8	RalBP1-associated Eps domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043238	level of transmembrane protein 185A (human) in blood serum	PR:Q8NFB2	transmembrane protein 185A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043239	level of histone-lysine N-methyltransferase 2C (human) in blood serum	PR:Q8NEZ4	histone-lysine N-methyltransferase 2C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043240	level of V-type proton ATPase subunit C 2 (human) in blood serum	PR:Q8NEY4	V-type proton ATPase subunit C 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043241	level of protein WFDC11 (human) in blood serum	PR:Q8NEX6	protein WFDC11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043242	level of beta-defensin 108B (human) in blood serum	PR:Q8NET1	beta-defensin 108B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043243	level of transmembrane protein C1orf162 (human) in blood serum	PR:Q8NEQ5	transmembrane protein C1orf162 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043244	level of neuroguidin (human) in blood serum	PR:Q8NEJ9	neuroguidin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043245	level of dual specificity protein phosphatase 18 (human) in blood serum	PR:Q8NEJ0	dual specificity protein phosphatase 18 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043246	level of serum response factor-binding protein 1 (human) in blood serum	PR:Q8NEF9	serum response factor-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043247	level of phosphatidylinositol 3-kinase catalytic subunit type 3 (human) in blood serum	PR:Q8NEB9	phosphatidylinositol 3-kinase catalytic subunit type 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043248	level of uncharacterized protein C19orf18 (human) in blood serum	PR:Q8NEA5	uncharacterized protein C19orf18 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043249	level of transmembrane protein 52 (human) in blood serum	PR:Q8NDY8	transmembrane protein 52 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043250	level of G-protein coupled receptor 26 (human) in blood serum	PR:Q8NDV2	G-protein coupled receptor 26 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043251	level of alpha-N-acetylgalactosaminide alpha-2,6-sialyltransferase 3 (human) in blood serum	PR:Q8NDV1	alpha-N-acetylgalactosaminide alpha-2,6-sialyltransferase 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043252	level of EH domain-binding protein 1 (human) in blood serum	PR:Q8NDI1	EH domain-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043253	level of solute carrier family 35 member G2 (human) in blood serum	PR:Q8TBE7	solute carrier family 35 member G2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043254	level of NEDD8-activating enzyme E1 catalytic subunit (human) in blood serum	PR:Q8TBC4	NEDD8-activating enzyme E1 catalytic subunit (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043255	level of SH3KBP1-binding protein 1 (human) in blood serum	PR:Q8TBC3	SH3KBP1-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043256	level of E3 ubiquitin-protein ligase LNX (human) in blood serum	PR:Q8TBB1	E3 ubiquitin-protein ligase LNX (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043257	level of protein NDNF (human) in blood serum	PR:Q8TB73	protein NDNF (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043258	level of (lyso)-N-acylphosphatidylethanolamine lipase (human) in blood serum	PR:Q8TB40	(lyso)-N-acylphosphatidylethanolamine lipase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043259	level of spermatogenesis-associated protein 20 (human) in blood serum	PR:Q8TB22	spermatogenesis-associated protein 20 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043260	level of uncharacterized protein CXorf38 (human) in blood serum	PR:Q8TB03	uncharacterized protein CXorf38 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043261	level of nuclear protein localization protein 4 homolog (human) in blood serum	PR:Q8TAT6	nuclear protein localization protein 4 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043262	level of SUN domain-containing protein 3 (human) in blood serum	PR:Q8TAQ9	SUN domain-containing protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043263	level of centrosomal protein of 76 kDa (human) in blood serum	PR:Q8TAP6	centrosomal protein of 76 kDa (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043264	level of LIM domain only protein 3 (human) in blood serum	PR:Q8TAP4	LIM domain only protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043265	level of ermin (human) in blood serum	PR:Q8TAM6	ermin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043266	level of oligodendrocyte transcription factor 1 (human) in blood serum	PR:Q8TAK6	oligodendrocyte transcription factor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043267	level of WD repeat-containing protein 48 (human) in blood serum	PR:Q8TAF3	WD repeat-containing protein 48 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043268	level of growth arrest and DNA damage-inducible proteins-interacting protein 1 (human) in blood serum	PR:Q8TAE8	growth arrest and DNA damage-inducible proteins-interacting protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043269	level of smad nuclear-interacting protein 1 (human) in blood serum	PR:Q8TAD8	smad nuclear-interacting protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043270	level of proton-coupled zinc antiporter SLC30A5 (human) in blood serum	PR:Q8TAD4	proton-coupled zinc antiporter SLC30A5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043271	level of secretory carrier-associated membrane protein 5 (human) in blood serum	PR:Q8TAC9	secretory carrier-associated membrane protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043272	level of rieske domain-containing protein (human) in blood serum	PR:Q8TAC1	rieske domain-containing protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043273	level of Vang-like protein 1 (human) in blood serum	PR:Q8TAA9	Vang-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043274	level of retinitis pigmentosa 9 protein (human) in blood serum	PR:Q8TA86	retinitis pigmentosa 9 protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043275	level of NF-kappa-B inhibitor delta (human) in blood serum	PR:Q8NI38	NF-kappa-B inhibitor delta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043276	level of interleukin-31 receptor subunit alpha (human) in blood serum	PR:Q8NI17	interleukin-31 receptor subunit alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043277	level of nuclear receptor coactivator 7 (human) in blood serum	PR:Q8NI08	nuclear receptor coactivator 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043278	level of GTPase IMAP family member 7 (human) in blood serum	PR:Q8NHV1	GTPase IMAP family member 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043279	level of cancer/testis antigen family 45 member A3 (human) in blood serum	PR:Q8NHU0	cancer/testis antigen family 45 member A3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043280	level of spermatogenesis-associated protein 22 (human) in blood serum	PR:Q8NHS9	spermatogenesis-associated protein 22 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043281	level of DnaJ homolog subfamily B member 8 (human) in blood serum	PR:Q8NHS0	DnaJ homolog subfamily B member 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043282	level of profilin-4 (human) in blood serum	PR:Q8NHR9	profilin-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043283	level of telomere repeats-binding bouquet formation protein 2 (human) in blood serum	PR:Q8NHR7	telomere repeats-binding bouquet formation protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043284	level of biogenesis of lysosome-related organelles complex 1 subunit 5 (human) in blood serum	PR:Q8TDH9	biogenesis of lysosome-related organelles complex 1 subunit 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043285	level of neuropilin and tolloid-like protein 1 (human) in blood serum	PR:Q8TDF5	neuropilin and tolloid-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043286	level of E3 ubiquitin-protein ligase DTX3L (human) in blood serum	PR:Q8TDB6	E3 ubiquitin-protein ligase DTX3L (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043287	level of cell adhesion molecule DSCAML1 (human) in blood serum	PR:Q8TD84	cell adhesion molecule DSCAML1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043288	level of pleckstrin homology domain-containing family O member 2 (human) in blood serum	PR:Q8TD55	pleckstrin homology domain-containing family O member 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043289	level of alanine aminotransferase 2 (human) in blood serum	PR:Q8TD30	alanine aminotransferase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043290	level of sideroflexin-5 (human) in blood serum	PR:Q8TD22	sideroflexin-5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043291	level of anterior gradient protein 3 (human) in blood serum	PR:Q8TD06	anterior gradient protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043292	level of CD99 antigen-like protein 2 (human) in blood serum	PR:Q8TCZ2	CD99 antigen-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043293	level of melanocortin-2 receptor accessory protein (human) in blood serum	PR:Q8TCY5	melanocortin-2 receptor accessory protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043294	level of zona pellucida-like domain-containing protein 1 (human) in blood serum	PR:Q8TCW7	zona pellucida-like domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043295	level of WAP four-disulfide core domain protein 5 (human) in blood serum	PR:Q8TCV5	WAP four-disulfide core domain protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043296	level of phosphoethanolamine/phosphocholine phosphatase (human) in blood serum	PR:Q8TCT1	phosphoethanolamine/phosphocholine phosphatase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043297	level of polyribonucleotide nucleotidyltransferase 1, mitochondrial (human) in blood serum	PR:Q8TCS8	polyribonucleotide nucleotidyltransferase 1, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043298	level of AN1-type zinc finger protein 1 (human) in blood serum	PR:Q8TCF1	AN1-type zinc finger protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043299	level of DENN domain-containing protein 10 (human) in blood serum	PR:Q8TCE6	DENN domain-containing protein 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043300	level of pyridoxal phosphate phosphatase PHOSPHO2 (human) in blood serum	PR:Q8TCD6	pyridoxal phosphate phosphatase PHOSPHO2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043301	level of 5'(3')-deoxyribonucleotidase, cytosolic type (human) in blood serum	PR:Q8TCD5	5'(3')-deoxyribonucleotidase, cytosolic type (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043302	level of UPF0729 protein C18orf32 (human) in blood serum	PR:Q8TCD1	UPF0729 protein C18orf32 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043303	level of leucine-rich repeat-containing protein 20 (human) in blood serum	PR:Q8TCA0	leucine-rich repeat-containing protein 20 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043304	level of fibronectin type III domain-containing protein 8 (human) in blood serum	PR:Q8TC99	fibronectin type III domain-containing protein 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043305	level of fibronectin type 3 and ankyrin repeat domains protein 1 (human) in blood serum	PR:Q8TC84	fibronectin type 3 and ankyrin repeat domains protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043306	level of meiosis 1 arrest protein (human) in blood serum	PR:Q8TC57	meiosis 1 arrest protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043307	level of SUN domain-containing protein 5 (human) in blood serum	PR:Q8TC36	SUN domain-containing protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043308	level of disintegrin and metalloproteinase domain-containing protein 32 (human) in blood serum	PR:Q8TC27	disintegrin and metalloproteinase domain-containing protein 32 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043309	level of nuclear protein MDM1 (human) in blood serum	PR:Q8TC05	nuclear protein MDM1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043310	level of probable RNA-binding protein 46 (human) in blood serum	PR:Q8TBY0	probable RNA-binding protein 46 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043311	level of protein kish-A (human) in blood serum	PR:Q8TBQ9	protein kish-A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043312	level of membrane protein FAM174A (human) in blood serum	PR:Q8TBP5	membrane protein FAM174A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043313	level of guanine nucleotide exchange factor for Rab-3A (human) in blood serum	PR:Q8TBN0	guanine nucleotide exchange factor for Rab-3A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043314	level of N-acylneuraminate-9-phosphatase (human) in blood serum	PR:Q8TBE9	N-acylneuraminate-9-phosphatase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043315	level of scavenger receptor class B member 1 (human) in blood serum	PR:Q8WTV0	scavenger receptor class B member 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043316	level of C-type lectin domain family 4 member C (human) in blood serum	PR:Q8WTT0	C-type lectin domain family 4 member C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043317	level of 1-acylglycerol-3-phosphate O-acyltransferase ABHD5 (human) in blood serum	PR:Q8WTS1	1-acylglycerol-3-phosphate O-acyltransferase ABHD5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043318	level of dual specificity protein phosphatase 19 (human) in blood serum	PR:Q8WTR2	dual specificity protein phosphatase 19 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043319	level of beta-defensin 104 (human) in blood serum	PR:Q8WTQ1	beta-defensin 104 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043320	level of leucine-rich repeat-containing protein 15 (human) in blood serum	PR:Q8TF66	leucine-rich repeat-containing protein 15 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043321	level of PDZ domain-containing protein GIPC2 (human) in blood serum	PR:Q8TF65	PDZ domain-containing protein GIPC2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043322	level of zinc finger protein 526 (human) in blood serum	PR:Q8TF50	zinc finger protein 526 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043323	level of ubiquitin-associated and SH3 domain-containing protein B (human) in blood serum	PR:Q8TF42	ubiquitin-associated and SH3 domain-containing protein B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043324	level of dynein light chain roadblock-type 2 (human) in blood serum	PR:Q8TF09	dynein light chain roadblock-type 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043325	level of cyclic AMP-responsive element-binding protein 3-like protein 4 (human) in blood serum	PR:Q8TEY5	cyclic AMP-responsive element-binding protein 3-like protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043326	level of histone-lysine N-methyltransferase, H3 lysine-79 specific (human) in blood serum	PR:Q8TEK3	histone-lysine N-methyltransferase, H3 lysine-79 specific (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043327	level of uncharacterized protein C10orf105 (human) in blood serum	PR:Q8TEF2	uncharacterized protein C10orf105 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043328	level of actin filament-associated protein 1-like 1 (human) in blood serum	PR:Q8TED9	actin filament-associated protein 1-like 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043329	level of DDB1- and CUL4-associated factor 11 (human) in blood serum	PR:Q8TEB1	DDB1- and CUL4-associated factor 11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043330	level of D-aminoacyl-tRNA deacylase 1 (human) in blood serum	PR:Q8TEA8	D-aminoacyl-tRNA deacylase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043331	level of tRNA (cytosine(72)-C(5))-methyltransferase NSUN6 (human) in blood serum	PR:Q8TEA1	tRNA (cytosine(72)-C(5))-methyltransferase NSUN6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043332	level of 2-phosphoxylose phosphatase 1 (human) in blood serum	PR:Q8TE99	2-phosphoxylose phosphatase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043333	level of protein EOLA1 (human) in blood serum	PR:Q8TE69	protein EOLA1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043334	level of epidermal growth factor receptor kinase substrate 8-like protein 1 (human) in blood serum	PR:Q8TE68	epidermal growth factor receptor kinase substrate 8-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043335	level of epidermal growth factor receptor kinase substrate 8-like protein 3 (human) in blood serum	PR:Q8TE67	epidermal growth factor receptor kinase substrate 8-like protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043336	level of anion exchange transporter (human) in blood serum	PR:Q8TE54	anion exchange transporter (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043337	level of pantothenate kinase 1 (human) in blood serum	PR:Q8TE04	pantothenate kinase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043338	level of [F-actin]-monooxygenase MICAL1 (human) in blood serum	PR:Q8TDZ2	[F-actin]-monooxygenase MICAL1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043339	level of immunoglobulin superfamily DCC subclass member 4 (human) in blood serum	PR:Q8TDY8	immunoglobulin superfamily DCC subclass member 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043340	level of Arf-GAP with SH3 domain, ANK repeat and PH domain-containing protein 3 (human) in blood serum	PR:Q8TDY4	Arf-GAP with SH3 domain, ANK repeat and PH domain-containing protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043341	level of serine/threonine-protein kinase Nek7 (human) in blood serum	PR:Q8TDX7	serine/threonine-protein kinase Nek7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043342	level of hydroxycarboxylic acid receptor 2 (human) in blood serum	PR:Q8TDS4	hydroxycarboxylic acid receptor 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043343	level of CMRF35-like molecule 1 (human) in blood serum	PR:Q8TDQ1	CMRF35-like molecule 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043344	level of potassium voltage-gated channel subfamily G member 4 (human) in blood serum	PR:Q8TDN1	potassium voltage-gated channel subfamily G member 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043345	level of BPI fold-containing family B member 1 (human) in blood serum	PR:Q8TDL5	BPI fold-containing family B member 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043346	level of Sec1 family domain-containing protein 1 (human) in blood serum	PR:Q8WVM8	Sec1 family domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043347	level of dimethyladenosine transferase 1, mitochondrial (human) in blood serum	PR:Q8WVM0	dimethyladenosine transferase 1, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043348	level of NudC domain-containing protein 2 (human) in blood serum	PR:Q8WVJ2	NudC domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043349	level of complexin-3 (human) in blood serum	PR:Q8WVH0	complexin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043350	level of BTB/POZ domain-containing protein KCTD4 (human) in blood serum	PR:Q8WVF5	BTB/POZ domain-containing protein KCTD4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043351	level of unique cartilage matrix-associated protein (human) in blood serum	PR:Q8WVF2	unique cartilage matrix-associated protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043352	level of EEF1A lysine methyltransferase 1 (human) in blood serum	PR:Q8WVE0	EEF1A lysine methyltransferase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043353	level of RING finger protein 141 (human) in blood serum	PR:Q8WVD5	RING finger protein 141 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043354	level of AN1-type zinc finger protein 2B (human) in blood serum	PR:Q8WV99	AN1-type zinc finger protein 2B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043355	level of MIT domain-containing protein 1 (human) in blood serum	PR:Q8WV92	MIT domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043356	level of B-cell linker protein (human) in blood serum	PR:Q8WV28	B-cell linker protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043357	level of non-structural maintenance of chromosomes element 1 homolog (human) in blood serum	PR:Q8WV22	non-structural maintenance of chromosomes element 1 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043358	level of protein LTO1 homolog (human) in blood serum	PR:Q8WV07	protein LTO1 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043359	level of probable N-acetyltransferase 14 (human) in blood serum	PR:Q8WUY8	probable N-acetyltransferase 14 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043360	level of glutathione-specific gamma-glutamylcyclotransferase 2 (human) in blood serum	PR:Q8WUX2	glutathione-specific gamma-glutamylcyclotransferase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043361	level of protein BRICK1 (human) in blood serum	PR:Q8WUW1	protein BRICK1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043362	level of GATA zinc finger domain-containing protein 1 (human) in blood serum	PR:Q8WUU5	GATA zinc finger domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043363	level of UPF0235 protein C15orf40 (human) in blood serum	PR:Q8WUR7	UPF0235 protein C15orf40 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043364	level of ubiquitin domain-containing protein 2 (human) in blood serum	PR:Q8WUN7	ubiquitin domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043365	level of programmed cell death 6-interacting protein (human) in blood serum	PR:Q8WUM4	programmed cell death 6-interacting protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043366	level of phosphatidylglycerophosphatase and protein-tyrosine phosphatase 1 (human) in blood serum	PR:Q8WUK0	phosphatidylglycerophosphatase and protein-tyrosine phosphatase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043367	level of neuferricin (human) in blood serum	PR:Q8WUJ1	neuferricin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043368	level of serine/threonine/tyrosine-interacting protein (human) in blood serum	PR:Q8WUJ0	serine/threonine/tyrosine-interacting protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043369	level of cotranscriptional regulator FAM172A (human) in blood serum	PR:Q8WUF8	cotranscriptional regulator FAM172A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043370	level of cancer/testis antigen 55 (human) in blood serum	PR:Q8WUE5	cancer/testis antigen 55 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043371	level of Ras-related protein Rab-2B (human) in blood serum	PR:Q8WUD1	Ras-related protein Rab-2B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043372	level of thrombospondin-type laminin G domain and EAR repeat-containing protein (human) in blood serum	PR:Q8WU66	thrombospondin-type laminin G domain and EAR repeat-containing protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043373	level of marginal zone B- and B1-cell-specific protein (human) in blood serum	PR:Q8WU39	marginal zone B- and B1-cell-specific protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043374	level of fibroblast growth factor receptor substrate 2 (human) in blood serum	PR:Q8WU20	fibroblast growth factor receptor substrate 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043375	level of glycine N-acyltransferase-like protein 2 (human) in blood serum	PR:Q8WU03	glycine N-acyltransferase-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043376	level of cytosolic arginine sensor for mTORC1 subunit 1 (human) in blood serum	PR:Q8WTX7	cytosolic arginine sensor for mTORC1 subunit 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043377	level of protein S100-Z (human) in blood serum	PR:Q8WXG8	protein S100-Z (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043378	level of paraspeckle component 1 (human) in blood serum	PR:Q8WXF1	paraspeckle component 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043379	level of gem-associated protein 6 (human) in blood serum	PR:Q8WXD5	gem-associated protein 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043380	level of secretogranin-3 (human) in blood serum	PR:Q8WXD2	secretogranin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043381	level of pyrin domain-containing protein 1 (human) in blood serum	PR:Q8WXC3	pyrin domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043382	level of prostate and testis expressed protein 1 (human) in blood serum	PR:Q8WXA2	prostate and testis expressed protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043383	level of insulin-like growth factor-binding protein-like 1 (human) in blood serum	PR:Q8WX77	insulin-like growth factor-binding protein-like 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043384	level of oncoprotein-induced transcript 3 protein (human) in blood serum	PR:Q8WWZ8	oncoprotein-induced transcript 3 protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043385	level of interleukin-1 family member 10 (human) in blood serum	PR:Q8WWZ1	interleukin-1 family member 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043386	level of selenoprotein M (human) in blood serum	PR:Q8WWX9	selenoprotein M (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043387	level of Ras association domain-containing protein 5 (human) in blood serum	PR:Q8WWW0	Ras association domain-containing protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043388	level of high affinity immunoglobulin alpha and immunoglobulin mu Fc receptor (human) in blood serum	PR:Q8WWV6	high affinity immunoglobulin alpha and immunoglobulin mu Fc receptor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043389	level of reticulon-4-interacting protein 1, mitochondrial (human) in blood serum	PR:Q8WWV3	reticulon-4-interacting protein 1, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043390	level of T-complex protein 11 homolog (human) in blood serum	PR:Q8WWU5	T-complex protein 11 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043391	level of cytoglobin (human) in blood serum	PR:Q8WWM9	cytoglobin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043392	level of pseudouridylate synthase TRUB1 (human) in blood serum	PR:Q8WWH5	pseudouridylate synthase TRUB1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043393	level of calcyphosin-like protein (human) in blood serum	PR:Q8WWF8	calcyphosin-like protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043394	level of DnaJ homolog subfamily B member 3 (human) in blood serum	PR:Q8WWF6	DnaJ homolog subfamily B member 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043395	level of serine-rich single-pass membrane protein 1 (human) in blood serum	PR:Q8WWF3	serine-rich single-pass membrane protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043396	level of PIH1 domain-containing protein 2 (human) in blood serum	PR:Q8WWB5	PIH1 domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043397	level of intelectin-1 (human) in blood serum	PR:Q8WWA0	intelectin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043398	level of protein FAM151A (human) in blood serum	PR:Q8WW52	protein FAM151A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043399	level of gametocyte-specific factor 1 (human) in blood serum	PR:Q8WW33	gametocyte-specific factor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043400	level of DnaJ homolog subfamily A member 4 (human) in blood serum	PR:Q8WW22	DnaJ homolog subfamily A member 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043401	level of PEST proteolytic signal-containing nuclear protein (human) in blood serum	PR:Q8WW12	PEST proteolytic signal-containing nuclear protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043402	level of tRNA-splicing endonuclease subunit Sen15 (human) in blood serum	PR:Q8WW01	tRNA-splicing endonuclease subunit Sen15 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043403	level of ubiquitin-like domain-containing CTD phosphatase 1 (human) in blood serum	PR:Q8WVY7	ubiquitin-like domain-containing CTD phosphatase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043404	level of heterogeneous nuclear ribonucleoprotein L-like (human) in blood serum	PR:Q8WVV9	heterogeneous nuclear ribonucleoprotein L-like (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043405	level of butyrophilin subfamily 2 member A2 (human) in blood serum	PR:Q8WVV5	butyrophilin subfamily 2 member A2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043406	level of soluble calcium-activated nucleotidase 1 (human) in blood serum	PR:Q8WVQ1	soluble calcium-activated nucleotidase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043407	level of ubiquitin-conjugating enzyme E2 Q2 (human) in blood serum	PR:Q8WVN8	ubiquitin-conjugating enzyme E2 Q2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043408	level of protein FAM3C (human) in blood serum	PR:Q92520	protein FAM3C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043409	level of tribbles homolog 2 (human) in blood serum	PR:Q92519	tribbles homolog 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043410	level of piezo-type mechanosensitive ion channel component 1 (human) in blood serum	PR:Q92508	piezo-type mechanosensitive ion channel component 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043411	level of ATP-dependent RNA helicase DDX1 (human) in blood serum	PR:Q92499	ATP-dependent RNA helicase DDX1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043412	level of C-type lectin domain family 2 member B (human) in blood serum	PR:Q92478	C-type lectin domain family 2 member B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043413	level of CMP-N-acetylneuraminate-poly-alpha-2,8-sialyltransferase (human) in blood serum	PR:Q92187	CMP-N-acetylneuraminate-poly-alpha-2,8-sialyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043414	level of alpha-2,8-sialyltransferase 8B (human) in blood serum	PR:Q92186	alpha-2,8-sialyltransferase 8B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043415	level of alpha-N-acetylneuraminide alpha-2,8-sialyltransferase (human) in blood serum	PR:Q92185	alpha-N-acetylneuraminide alpha-2,8-sialyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043416	level of protein O-linked-mannose beta-1,2-N-acetylglucosaminyltransferase 1 (human) in blood serum	PR:Q8WZA1	protein O-linked-mannose beta-1,2-N-acetylglucosaminyltransferase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043417	level of protein LZIC (human) in blood serum	PR:Q8WZA0	protein LZIC (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043418	level of esterase OVCA2 (human) in blood serum	PR:Q8WZ82	esterase OVCA2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043419	level of deoxyribonuclease-2-beta (human) in blood serum	PR:Q8WZ79	deoxyribonuclease-2-beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043420	level of roundabout homolog 4 (human) in blood serum	PR:Q8WZ75	roundabout homolog 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043421	level of E3 ubiquitin-protein ligase rififylin (human) in blood serum	PR:Q8WZ73	E3 ubiquitin-protein ligase rififylin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043422	level of transmembrane protein 190 (human) in blood serum	PR:Q8WZ59	transmembrane protein 190 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043423	level of titin (human) in blood serum	PR:Q8WZ42	titin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043424	level of uncharacterized protein C22orf15 (human) in blood serum	PR:Q8WYQ4	uncharacterized protein C22orf15 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043425	level of coiled-coil-helix-coiled-coil-helix domain-containing protein 10, mitochondrial (human) in blood serum	PR:Q8WYQ3	coiled-coil-helix-coiled-coil-helix domain-containing protein 10, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043426	level of cysteine protease ATG4A (human) in blood serum	PR:Q8WYN0	cysteine protease ATG4A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043427	level of Jun dimerization protein 2 (human) in blood serum	PR:Q8WYK2	Jun dimerization protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043428	level of contactin-associated protein-like 5 (human) in blood serum	PR:Q8WYK1	contactin-associated protein-like 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043429	level of acetyl-coenzyme A thioesterase (human) in blood serum	PR:Q8WYK0	acetyl-coenzyme A thioesterase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043430	level of septin-1 (human) in blood serum	PR:Q8WYJ6	septin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043431	level of transmembrane protein 234 (human) in blood serum	PR:Q8WY98	transmembrane protein 234 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043432	level of peroxynitrite isomerase THAP4 (human) in blood serum	PR:Q8WY91	peroxynitrite isomerase THAP4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043433	level of VPS10 domain-containing receptor SorCS1 (human) in blood serum	PR:Q8WY21	VPS10 domain-containing receptor SorCS1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043434	level of ankyrin repeat and SOCS box protein 13 (human) in blood serum	PR:Q8WXK3	ankyrin repeat and SOCS box protein 13 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043435	level of C-type lectin domain family 4 member D (human) in blood serum	PR:Q8WXI8	C-type lectin domain family 4 member D (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043436	level of mucin-16 (human) in blood serum	PR:Q8WXI7	mucin-16 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043437	level of junctophilin-3 (human) in blood serum	PR:Q8WXH2	junctophilin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043438	level of nesprin-2 (human) in blood serum	PR:Q8WXH0	nesprin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043439	level of disks large homolog 3 (human) in blood serum	PR:Q92796	disks large homolog 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043440	level of CREB-binding protein (human) in blood serum	PR:Q92793	CREB-binding protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043441	level of cyclin-dependent kinase-like 2 (human) in blood serum	PR:Q92772	cyclin-dependent kinase-like 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043442	level of histone deacetylase 2 (human) in blood serum	PR:Q92769	histone deacetylase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043443	level of nuclear receptor ROR-beta (human) in blood serum	PR:Q92753	nuclear receptor ROR-beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043444	level of serine protease HTRA1 (human) in blood serum	PR:Q92743	serine protease HTRA1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043445	level of Rho-related GTP-binding protein Rho6 (human) in blood serum	PR:Q92730	Rho-related GTP-binding protein Rho6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043446	level of receptor-type tyrosine-protein phosphatase U (human) in blood serum	PR:Q92729	receptor-type tyrosine-protein phosphatase U (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043447	level of nectin-2 (human) in blood serum	PR:Q92692	nectin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043448	level of neurogranin (human) in blood serum	PR:Q92686	neurogranin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043449	level of dual specificity tyrosine-phosphorylation-regulated kinase 2 (human) in blood serum	PR:Q92630	dual specificity tyrosine-phosphorylation-regulated kinase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043450	level of peroxidasin homolog (human) in blood serum	PR:Q92626	peroxidasin homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043451	level of tetratricopeptide repeat protein 9A (human) in blood serum	PR:Q92623	tetratricopeptide repeat protein 9A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043452	level of pre-mRNA-splicing factor ATP-dependent RNA helicase PRP16 (human) in blood serum	PR:Q92620	pre-mRNA-splicing factor ATP-dependent RNA helicase PRP16 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043453	level of Rho GTPase-activating protein 45 (human) in blood serum	PR:Q92619	Rho GTPase-activating protein 45 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043454	level of nuclear pore complex-interacting protein family member B3 (human) in blood serum	PR:Q92617	nuclear pore complex-interacting protein family member B3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043455	level of TBC1 domain family member 5 (human) in blood serum	PR:Q92609	TBC1 domain family member 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043456	level of dedicator of cytokinesis protein 2 (human) in blood serum	PR:Q92608	dedicator of cytokinesis protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043457	level of CCR4-NOT transcription complex subunit 9 (human) in blood serum	PR:Q92600	CCR4-NOT transcription complex subunit 9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043458	level of heat shock protein 105 kDa (human) in blood serum	PR:Q92598	heat shock protein 105 kDa (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043459	level of PHD finger protein 3 (human) in blood serum	PR:Q92576	PHD finger protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043460	level of Rap guanine nucleotide exchange factor 5 (human) in blood serum	PR:Q92565	Rap guanine nucleotide exchange factor 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043461	level of polyphosphoinositide phosphatase (human) in blood serum	PR:Q92562	polyphosphoinositide phosphatase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043462	level of phytanoyl-CoA hydroxylase-interacting protein (human) in blood serum	PR:Q92561	phytanoyl-CoA hydroxylase-interacting protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043463	level of ubiquitin carboxyl-terminal hydrolase BAP1 (human) in blood serum	PR:Q92560	ubiquitin carboxyl-terminal hydrolase BAP1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043464	level of engulfment and cell motility protein 1 (human) in blood serum	PR:Q92556	engulfment and cell motility protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043465	level of inositol hexakisphosphate kinase 1 (human) in blood serum	PR:Q92551	inositol hexakisphosphate kinase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043466	level of DNA topoisomerase 2-binding protein 1 (human) in blood serum	PR:Q92547	DNA topoisomerase 2-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043467	level of RNA polymerase-associated protein RTF1 homolog (human) in blood serum	PR:Q92541	RNA polymerase-associated protein RTF1 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043468	level of carnitine O-palmitoyltransferase 1, muscle isoform (human) in blood serum	PR:Q92523	carnitine O-palmitoyltransferase 1, muscle isoform (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043469	level of histone H1.10 (human) in blood serum	PR:Q92522	histone H1.10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043470	level of stathmin-2 (human) in blood serum	PR:Q93045	stathmin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043471	level of N-alpha-acetyltransferase 80 (human) in blood serum	PR:Q93015	N-alpha-acetyltransferase 80 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043472	level of histone acetyltransferase KAT5 (human) in blood serum	PR:Q92993	histone acetyltransferase KAT5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043473	level of homeobox protein DLX-4 (human) in blood serum	PR:Q92988	homeobox protein DLX-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043474	level of Rho guanine nucleotide exchange factor 2 (human) in blood serum	PR:Q92974	Rho guanine nucleotide exchange factor 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043475	level of small conductance calcium-activated potassium channel protein 1 (human) in blood serum	PR:Q92952	small conductance calcium-activated potassium channel protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043476	level of glutaryl-CoA dehydrogenase, mitochondrial (human) in blood serum	PR:Q92947	glutaryl-CoA dehydrogenase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043477	level of far upstream element-binding protein 2 (human) in blood serum	PR:Q92945	far upstream element-binding protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043478	level of SWI/SNF complex subunit SMARCC1 (human) in blood serum	PR:Q92922	SWI/SNF complex subunit SMARCC1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043479	level of mitogen-activated protein kinase kinase kinase kinase 1 (human) in blood serum	PR:Q92918	mitogen-activated protein kinase kinase kinase kinase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043480	level of sodium/iodide cotransporter (human) in blood serum	PR:Q92911	sodium/iodide cotransporter (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043481	level of COP9 signalosome complex subunit 5 (human) in blood serum	PR:Q92905	COP9 signalosome complex subunit 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043482	level of ubiquitin recognition factor in ER-associated degradation protein 1 (human) in blood serum	PR:Q92890	ubiquitin recognition factor in ER-associated degradation protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043483	level of DNA repair endonuclease XPF (human) in blood serum	PR:Q92889	DNA repair endonuclease XPF (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043484	level of Rho guanine nucleotide exchange factor 1 (human) in blood serum	PR:Q92888	Rho guanine nucleotide exchange factor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043485	level of neurogenin-1 (human) in blood serum	PR:Q92886	neurogenin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043486	level of osteoclast-stimulating factor 1 (human) in blood serum	PR:Q92882	osteoclast-stimulating factor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043487	level of kallikrein-6 (human) in blood serum	PR:Q92876	kallikrein-6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043488	level of neogenin (human) in blood serum	PR:Q92859	neogenin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043489	level of transcription factor ATOH1 (human) in blood serum	PR:Q92858	transcription factor ATOH1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043490	level of semaphorin-4D (human) in blood serum	PR:Q92854	semaphorin-4D (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043491	level of TRAF family member-associated NF-kappa-B activator (human) in blood serum	PR:Q92844	TRAF family member-associated NF-kappa-B activator (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043492	level of phosphatidylinositol 3,4,5-trisphosphate 5-phosphatase 1 (human) in blood serum	PR:Q92835	phosphatidylinositol 3,4,5-trisphosphate 5-phosphatase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043493	level of protein Jumonji (human) in blood serum	PR:Q92833	protein Jumonji (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043494	level of protein kinase C-binding protein NELL1 (human) in blood serum	PR:Q92832	protein kinase C-binding protein NELL1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043495	level of histone acetyltransferase KAT2B (human) in blood serum	PR:Q92831	histone acetyltransferase KAT2B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043496	level of histone acetyltransferase KAT2A (human) in blood serum	PR:Q92830	histone acetyltransferase KAT2A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043497	level of gamma-glutamyl hydrolase (human) in blood serum	PR:Q92820	gamma-glutamyl hydrolase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043498	level of envoplakin (human) in blood serum	PR:Q92817	envoplakin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043499	level of TATA-binding protein-associated factor 2N (human) in blood serum	PR:Q92804	TATA-binding protein-associated factor 2N (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043500	level of NEDD4-binding protein 2-like 2 (human) in blood serum	PR:Q92802	NEDD4-binding protein 2-like 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043501	level of SLAM family member 9 (human) in blood serum	PR:Q96A28	SLAM family member 9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043502	level of protein FAM162A (human) in blood serum	PR:Q96A26	protein FAM162A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043503	level of transmembrane protein 106A (human) in blood serum	PR:Q96A25	transmembrane protein 106A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043504	level of protein phosphatase 1 regulatory subunit 14A (human) in blood serum	PR:Q96A00	protein phosphatase 1 regulatory subunit 14A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043505	level of alpha-N-acetylgalactosaminide alpha-2,6-sialyltransferase 6 (human) in blood serum	PR:Q969X2	alpha-N-acetylgalactosaminide alpha-2,6-sialyltransferase 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043506	level of RILP-like protein 2 (human) in blood serum	PR:Q969X0	RILP-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043507	level of protein TMEPAI (human) in blood serum	PR:Q969W9	protein TMEPAI (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043508	level of zinc finger protein 566 (human) in blood serum	PR:Q969W8	zinc finger protein 566 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043509	level of proteasome assembly chaperone 2 (human) in blood serum	PR:Q969U7	proteasome assembly chaperone 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043510	level of WW domain-binding protein 2 (human) in blood serum	PR:Q969T9	WW domain-binding protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043511	level of 7-methylguanosine phosphate-specific 5'-nucleotidase (human) in blood serum	PR:Q969T7	7-methylguanosine phosphate-specific 5'-nucleotidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043512	level of ubiquitin-conjugating enzyme E2 E3 (human) in blood serum	PR:Q969T4	ubiquitin-conjugating enzyme E2 E3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043513	level of endonuclease 8-like 2 (human) in blood serum	PR:Q969S2	endonuclease 8-like 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043514	level of lethal(3)malignant brain tumor-like protein 2 (human) in blood serum	PR:Q969R5	lethal(3)malignant brain tumor-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043515	level of Ras-related protein Rab-24 (human) in blood serum	PR:Q969Q5	Ras-related protein Rab-24 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043516	level of ADP-ribosylation factor-like protein 11 (human) in blood serum	PR:Q969Q4	ADP-ribosylation factor-like protein 11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043517	level of immunoglobulin superfamily member 8 (human) in blood serum	PR:Q969P0	immunoglobulin superfamily member 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043518	level of NEDD8-conjugating enzyme UBE2F (human) in blood serum	PR:Q969M7	NEDD8-conjugating enzyme UBE2F (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043519	level of E3 ubiquitin-protein ligase RNF34 (human) in blood serum	PR:Q969K3	E3 ubiquitin-protein ligase RNF34 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043520	level of BLOC-1-related complex subunit 5 (human) in blood serum	PR:Q969J3	BLOC-1-related complex subunit 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043521	level of myeloid-derived growth factor (human) in blood serum	PR:Q969H8	myeloid-derived growth factor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043522	level of riboflavin kinase (human) in blood serum	PR:Q969G6	riboflavin kinase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043523	level of protein naked cuticle homolog 2 (human) in blood serum	PR:Q969F2	protein naked cuticle homolog 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043524	level of fetal and adult testis-expressed transcript protein (human) in blood serum	PR:Q969F0	fetal and adult testis-expressed transcript protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043525	level of transcription elongation factor A protein-like 3 (human) in blood serum	PR:Q969E4	transcription elongation factor A protein-like 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043526	level of urocortin-3 (human) in blood serum	PR:Q969E3	urocortin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043527	level of homogentisate 1,2-dioxygenase (human) in blood serum	PR:Q93099	homogentisate 1,2-dioxygenase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043528	level of protein tyrosine phosphatase type IVA 1 (human) in blood serum	PR:Q93096	protein tyrosine phosphatase type IVA 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043529	level of ribonuclease K6 (human) in blood serum	PR:Q93091	ribonuclease K6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043530	level of sarcoplasmic/endoplasmic reticulum calcium ATPase 3 (human) in blood serum	PR:Q93084	sarcoplasmic/endoplasmic reticulum calcium ATPase 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043531	level of ecto-ADP-ribosyltransferase 4 (human) in blood serum	PR:Q93070	ecto-ADP-ribosyltransferase 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043532	level of transcriptional adapter 1 (human) in blood serum	PR:Q96BN2	transcriptional adapter 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043533	level of ADP-ribosylation factor-like protein 8A (human) in blood serum	PR:Q96BM9	ADP-ribosylation factor-like protein 8A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043534	level of Axin interactor, dorsalization-associated protein (human) in blood serum	PR:Q96BJ3	Axin interactor, dorsalization-associated protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043535	level of E3 ubiquitin-protein ligase RNF25 (human) in blood serum	PR:Q96BH1	E3 ubiquitin-protein ligase RNF25 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043536	level of transmembrane and immunoglobulin domain-containing protein 2 (human) in blood serum	PR:Q96BF3	transmembrane and immunoglobulin domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043537	level of spindle and kinetochore-associated protein 1 (human) in blood serum	PR:Q96BD8	spindle and kinetochore-associated protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043538	level of SPRY domain-containing SOCS box protein 1 (human) in blood serum	PR:Q96BD6	SPRY domain-containing SOCS box protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043539	level of cyclic AMP-responsive element-binding protein 3-like protein 1 (human) in blood serum	PR:Q96BA8	cyclic AMP-responsive element-binding protein 3-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043540	level of SH3 domain-containing kinase-binding protein 1 (human) in blood serum	PR:Q96B97	SH3 domain-containing kinase-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043541	level of arrestin domain-containing protein 3 (human) in blood serum	PR:Q96B67	arrestin domain-containing protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043542	level of proline-rich AKT1 substrate 1 (human) in blood serum	PR:Q96B36	proline-rich AKT1 substrate 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043543	level of exosome complex component RRP43 (human) in blood serum	PR:Q96B26	exosome complex component RRP43 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043544	level of ubiquitin-conjugating enzyme E2 W (human) in blood serum	PR:Q96B02	ubiquitin-conjugating enzyme E2 W (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043545	level of Ras-related protein Rab-37 (human) in blood serum	PR:Q96AX2	Ras-related protein Rab-37 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043546	level of vesicular, overexpressed in cancer, prosurvival protein 1 (human) in blood serum	PR:Q96AW1	vesicular, overexpressed in cancer, prosurvival protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043547	level of ribulose-phosphate 3-epimerase (human) in blood serum	PR:Q96AT9	ribulose-phosphate 3-epimerase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043548	level of uncharacterized protein KIAA1143 (human) in blood serum	PR:Q96AT1	uncharacterized protein KIAA1143 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043549	level of vesicle transport through interaction with t-SNAREs homolog 1A (human) in blood serum	PR:Q96AJ9	vesicle transport through interaction with t-SNAREs homolog 1A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043550	level of clusterin-associated protein 1 (human) in blood serum	PR:Q96AJ1	clusterin-associated protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043551	level of Ras-related protein Rab-7b (human) in blood serum	PR:Q96AH8	Ras-related protein Rab-7b (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043552	level of SOSS complex subunit B2 (human) in blood serum	PR:Q96AH0	SOSS complex subunit B2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043553	level of leucine-rich repeat-containing protein 59 (human) in blood serum	PR:Q96AG4	leucine-rich repeat-containing protein 59 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043554	level of far upstream element-binding protein 1 (human) in blood serum	PR:Q96AE4	far upstream element-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043555	level of patatin-like phospholipase domain-containing protein 2 (human) in blood serum	PR:Q96AD5	patatin-like phospholipase domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043556	level of protein N-terminal asparagine amidohydrolase (human) in blood serum	PR:Q96AB6	protein N-terminal asparagine amidohydrolase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043557	level of EMI domain-containing protein 1 (human) in blood serum	PR:Q96A84	EMI domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043558	level of protein mago nashi homolog 2 (human) in blood serum	PR:Q96A72	protein mago nashi homolog 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043559	level of Ras-related and estrogen-regulated growth inhibitor (human) in blood serum	PR:Q96A58	Ras-related and estrogen-regulated growth inhibitor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043560	level of transmembrane protein 230 (human) in blood serum	PR:Q96A57	transmembrane protein 230 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043561	level of synapse-associated protein 1 (human) in blood serum	PR:Q96A49	synapse-associated protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043562	level of myosin regulatory light chain 11 (human) in blood serum	PR:Q96A32	myosin regulatory light chain 11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043563	level of BPI fold-containing family A member 2 (human) in blood serum	PR:Q96DR5	BPI fold-containing family A member 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043564	level of endoplasmic reticulum resident protein 27 (human) in blood serum	PR:Q96DN0	endoplasmic reticulum resident protein 27 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043565	level of RNA-binding protein Musashi homolog 2 (human) in blood serum	PR:Q96DH6	RNA-binding protein Musashi homolog 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043566	level of carboxymethylenebutenolidase homolog (human) in blood serum	PR:Q96DG6	carboxymethylenebutenolidase homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043567	level of splicing factor ESS-2 homolog (human) in blood serum	PR:Q96DF8	splicing factor ESS-2 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043568	level of U8 snoRNA-decapping enzyme (human) in blood serum	PR:Q96DE0	U8 snoRNA-decapping enzyme (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043569	level of ubiquitin thioesterase OTUB2 (human) in blood serum	PR:Q96DC9	ubiquitin thioesterase OTUB2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043570	level of Ras-related protein Rab-39B (human) in blood serum	PR:Q96DA2	Ras-related protein Rab-39B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043571	level of atypical kinase COQ8B, mitochondrial (human) in blood serum	PR:Q96D53	atypical kinase COQ8B, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043572	level of reticulocalbin-3 (human) in blood serum	PR:Q96D15	reticulocalbin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043573	level of protein FAM241B (human) in blood serum	PR:Q96D05	protein FAM241B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043574	level of FAD-dependent oxidoreductase domain-containing protein 1 (human) in blood serum	PR:Q96CU9	FAD-dependent oxidoreductase domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043575	level of FAS-associated factor 2 (human) in blood serum	PR:Q96CS3	FAS-associated factor 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043576	level of HAUS augmin-like complex subunit 1 (human) in blood serum	PR:Q96CS2	HAUS augmin-like complex subunit 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043577	level of isochorismatase domain-containing protein 1 (human) in blood serum	PR:Q96CN7	isochorismatase domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043578	level of medium-chain acyl-CoA ligase ACSF2, mitochondrial (human) in blood serum	PR:Q96CM8	medium-chain acyl-CoA ligase ACSF2, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043579	level of collagen triple helix repeat-containing protein 1 (human) in blood serum	PR:Q96CG8	collagen triple helix repeat-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043580	level of TRAF-interacting protein with FHA domain-containing protein A (human) in blood serum	PR:Q96CG3	TRAF-interacting protein with FHA domain-containing protein A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043581	level of phosphopantothenoylcysteine decarboxylase (human) in blood serum	PR:Q96CD2	phosphopantothenoylcysteine decarboxylase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043582	level of baculoviral IAP repeat-containing protein 7 (human) in blood serum	PR:Q96CA5	baculoviral IAP repeat-containing protein 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043583	level of m7GpppX diphosphatase (human) in blood serum	PR:Q96C86	m7GpppX diphosphatase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043584	level of pyrroline-5-carboxylate reductase 2 (human) in blood serum	PR:Q96C36	pyrroline-5-carboxylate reductase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043585	level of EF-hand domain-containing protein D2 (human) in blood serum	PR:Q96C19	EF-hand domain-containing protein D2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043586	level of ATP-dependent RNA helicase DHX58 (human) in blood serum	PR:Q96C10	ATP-dependent RNA helicase DHX58 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043587	level of TBC1 domain family member 20 (human) in blood serum	PR:Q96BZ9	TBC1 domain family member 20 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043588	level of phosphotriesterase-related protein (human) in blood serum	PR:Q96BW5	phosphotriesterase-related protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043589	level of uracil phosphoribosyltransferase homolog (human) in blood serum	PR:Q96BW1	uracil phosphoribosyltransferase homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043590	level of calcineurin B homologous protein 3 (human) in blood serum	PR:Q96BS2	calcineurin B homologous protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043591	level of cytochrome c oxidase assembly factor 7 (human) in blood serum	PR:Q96BR5	cytochrome c oxidase assembly factor 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043592	level of serine/threonine-protein kinase Sgk3 (human) in blood serum	PR:Q96BR1	serine/threonine-protein kinase Sgk3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043593	level of ubiquitin thioesterase otulin (human) in blood serum	PR:Q96BN8	ubiquitin thioesterase otulin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043594	level of dysbindin (human) in blood serum	PR:Q96EV8	dysbindin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043595	level of C1GALT1-specific chaperone 1 (human) in blood serum	PR:Q96EU7	C1GALT1-specific chaperone 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043596	level of SAGA-associated factor 29 (human) in blood serum	PR:Q96ES7	SAGA-associated factor 29 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043597	level of mitochondrial potassium channel (human) in blood serum	PR:Q96ER9	mitochondrial potassium channel (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043598	level of small glutamine-rich tetratricopeptide repeat-containing protein beta (human) in blood serum	PR:Q96EQ0	small glutamine-rich tetratricopeptide repeat-containing protein beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043599	level of DAZ-associated protein 1 (human) in blood serum	PR:Q96EP5	DAZ-associated protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043600	level of E3 ubiquitin-protein ligase CHFR (human) in blood serum	PR:Q96EP1	E3 ubiquitin-protein ligase CHFR (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043601	level of E3 ubiquitin-protein ligase RNF31 (human) in blood serum	PR:Q96EP0	E3 ubiquitin-protein ligase RNF31 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043602	level of molybdenum cofactor sulfurase (human) in blood serum	PR:Q96EN8	molybdenum cofactor sulfurase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043603	level of trans-3-hydroxy-L-proline dehydratase (human) in blood serum	PR:Q96EM0	trans-3-hydroxy-L-proline dehydratase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043604	level of protein KTI12 homolog (human) in blood serum	PR:Q96EK9	protein KTI12 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043605	level of glucosamine 6-phosphate N-acetyltransferase (human) in blood serum	PR:Q96EK6	glucosamine 6-phosphate N-acetyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043606	level of KIF-binding protein (human) in blood serum	PR:Q96EK5	KIF-binding protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043607	level of transcription elongation factor A protein-like 4 (human) in blood serum	PR:Q96EI5	transcription elongation factor A protein-like 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043608	level of coiled-coil domain-containing protein 126 (human) in blood serum	PR:Q96EE4	coiled-coil domain-containing protein 126 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043609	level of protein YIPF6 (human) in blood serum	PR:Q96EC8	protein YIPF6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043610	level of NAD-dependent protein deacetylase sirtuin-1 (human) in blood serum	PR:Q96EB6	NAD-dependent protein deacetylase sirtuin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043611	level of protein Spindly (human) in blood serum	PR:Q96EA4	protein Spindly (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043612	level of Ras-related protein Rab-3C (human) in blood serum	PR:Q96E17	Ras-related protein Rab-3C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043613	level of ribosome-recycling factor, mitochondrial (human) in blood serum	PR:Q96E11	ribosome-recycling factor, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043614	level of endoplasmic reticulum lectin 1 (human) in blood serum	PR:Q96DZ1	endoplasmic reticulum lectin 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043615	level of dynein regulatory complex protein 10 (human) in blood serum	PR:Q96DY2	dynein regulatory complex protein 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043616	level of receptor-transporting protein 4 (human) in blood serum	PR:Q96DX8	receptor-transporting protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043617	level of ankyrin repeat and SOCS box protein 9 (human) in blood serum	PR:Q96DX5	ankyrin repeat and SOCS box protein 9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043618	level of mitochondrial glycine transporter (human) in blood serum	PR:Q96DW6	mitochondrial glycine transporter (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043619	level of 39S ribosomal protein L38, mitochondrial (human) in blood serum	PR:Q96DV4	39S ribosomal protein L38, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043620	level of polyadenylate-binding protein 5 (human) in blood serum	PR:Q96DU9	polyadenylate-binding protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043621	level of inositol-trisphosphate 3-kinase C (human) in blood serum	PR:Q96DU7	inositol-trisphosphate 3-kinase C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043622	level of zinc finger and BTB domain-containing protein 10 (human) in blood serum	PR:Q96DT7	zinc finger and BTB domain-containing protein 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043623	level of cysteine protease ATG4C (human) in blood serum	PR:Q96DT6	cysteine protease ATG4C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043624	level of mucin-like protein 1 (human) in blood serum	PR:Q96DR8	mucin-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043625	level of protein N-terminal glutamine amidohydrolase (human) in blood serum	PR:Q96HA8	protein N-terminal glutamine amidohydrolase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043626	level of probable RNA-binding protein 18 (human) in blood serum	PR:Q96H35	probable RNA-binding protein 18 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043627	level of tectonic-2 (human) in blood serum	PR:Q96GX1	tectonic-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043628	level of X antigen family member 2 (human) in blood serum	PR:Q96GT9	X antigen family member 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043629	level of fumarylacetoacetate hydrolase domain-containing protein 2A (human) in blood serum	PR:Q96GK7	fumarylacetoacetate hydrolase domain-containing protein 2A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043630	level of DCN1-like protein 1 (human) in blood serum	PR:Q96GG9	DCN1-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043631	level of polycomb protein SCMH1 (human) in blood serum	PR:Q96GD3	polycomb protein SCMH1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043632	level of serine dehydratase-like (human) in blood serum	PR:Q96GA7	serine dehydratase-like (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043633	level of diphosphoinositol polyphosphate phosphohydrolase 3-beta (human) in blood serum	PR:Q96G61	diphosphoinositol polyphosphate phosphohydrolase 3-beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043634	level of melanocortin-2 receptor accessory protein 2 (human) in blood serum	PR:Q96G30	melanocortin-2 receptor accessory protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043635	level of cilia- and flagella-associated protein 36 (human) in blood serum	PR:Q96G28	cilia- and flagella-associated protein 36 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043636	level of protein-lysine N-methyltransferase EEF2KMT (human) in blood serum	PR:Q96G04	protein-lysine N-methyltransferase EEF2KMT (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043637	level of phosphopentomutase (human) in blood serum	PR:Q96G03	phosphopentomutase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043638	level of charged multivesicular body protein 6 (human) in blood serum	PR:Q96FZ7	charged multivesicular body protein 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043639	level of THO complex subunit 1 (human) in blood serum	PR:Q96FV9	THO complex subunit 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043640	level of acid-sensing ion channel 4 (human) in blood serum	PR:Q96FT7	acid-sensing ion channel 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043641	level of protein S100-A16 (human) in blood serum	PR:Q96FQ6	protein S100-A16 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043642	level of D-aminoacyl-tRNA deacylase 2 (human) in blood serum	PR:Q96FN9	D-aminoacyl-tRNA deacylase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043643	level of polypeptide N-acetylgalactosaminyltransferase 14 (human) in blood serum	PR:Q96FL9	polypeptide N-acetylgalactosaminyltransferase 14 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043644	level of AMSH-like protease (human) in blood serum	PR:Q96FJ0	AMSH-like protease (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043645	level of phosphoinositide-3-kinase-interacting protein 1 (human) in blood serum	PR:Q96FE7	phosphoinositide-3-kinase-interacting protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043646	level of leucine-rich repeat and immunoglobulin-like domain-containing nogo receptor-interacting protein 1 (human) in blood serum	PR:Q96FE5	leucine-rich repeat and immunoglobulin-like domain-containing nogo receptor-interacting protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043647	level of phytanoyl-CoA hydroxylase-interacting protein-like (human) in blood serum	PR:Q96FC7	phytanoyl-CoA hydroxylase-interacting protein-like (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043648	level of E3 ubiquitin-protein ligase pellino homolog 1 (human) in blood serum	PR:Q96FA3	E3 ubiquitin-protein ligase pellino homolog 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043649	level of CB1 cannabinoid receptor-interacting protein 1 (human) in blood serum	PR:Q96F85	CB1 cannabinoid receptor-interacting protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043650	level of coiled-coil domain-containing protein 97 (human) in blood serum	PR:Q96F63	coiled-coil domain-containing protein 97 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043651	level of interleukin-17 receptor A (human) in blood serum	PR:Q96F46	interleukin-17 receptor A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043652	level of nuclear receptor-binding factor 2 (human) in blood serum	PR:Q96F24	nuclear receptor-binding factor 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043653	level of thialysine N-epsilon-acetyltransferase (human) in blood serum	PR:Q96F10	thialysine N-epsilon-acetyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043654	level of corrinoid adenosyltransferase MMAB (human) in blood serum	PR:Q96EY8	corrinoid adenosyltransferase MMAB (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043655	level of translation machinery-associated protein 16 (human) in blood serum	PR:Q96EY4	translation machinery-associated protein 16 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043656	level of protein disulfide-isomerase TMX3 (human) in blood serum	PR:Q96JJ7	protein disulfide-isomerase TMX3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043657	level of junctophilin-4 (human) in blood serum	PR:Q96JJ6	junctophilin-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043658	level of engulfment and cell motility protein 2 (human) in blood serum	PR:Q96JJ3	engulfment and cell motility protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043659	level of deubiquitinating protein VCPIP1 (human) in blood serum	PR:Q96JH7	deubiquitinating protein VCPIP1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043660	level of beta-galactoside alpha-2,6-sialyltransferase 2 (human) in blood serum	PR:Q96JF0	beta-galactoside alpha-2,6-sialyltransferase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043661	level of CDK5 regulatory subunit-associated protein 3 (human) in blood serum	PR:Q96JB5	CDK5 regulatory subunit-associated protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043662	level of leucine-rich repeats and immunoglobulin-like domains protein 1 (human) in blood serum	PR:Q96JA1	leucine-rich repeats and immunoglobulin-like domains protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043663	level of piwi-like protein 1 (human) in blood serum	PR:Q96J94	piwi-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043664	level of kin of IRRE-like protein 1 (human) in blood serum	PR:Q96J84	kin of IRRE-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043665	level of E3 ubiquitin-protein ligase Itchy homolog (human) in blood serum	PR:Q96J02	E3 ubiquitin-protein ligase Itchy homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043666	level of RNA-binding protein 41 (human) in blood serum	PR:Q96IZ5	RNA-binding protein 41 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043667	level of PRKC apoptosis WT1 regulator protein (human) in blood serum	PR:Q96IZ0	PRKC apoptosis WT1 regulator protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043668	level of vesicle-trafficking protein SEC22a (human) in blood serum	PR:Q96IW7	vesicle-trafficking protein SEC22a (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043669	level of SH2 domain-containing adapter protein D (human) in blood serum	PR:Q96IW2	SH2 domain-containing adapter protein D (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043670	level of fatty acid hydroxylase domain-containing protein 2 (human) in blood serum	PR:Q96IV6	fatty acid hydroxylase domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043671	level of putative protein-lysine deacylase ABHD14B (human) in blood serum	PR:Q96IU4	putative protein-lysine deacylase ABHD14B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043672	level of V-set and immunoglobulin domain-containing protein 2 (human) in blood serum	PR:Q96IQ7	V-set and immunoglobulin domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043673	level of Kazal-type serine protease inhibitor domain-containing protein 1 (human) in blood serum	PR:Q96I82	Kazal-type serine protease inhibitor domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043674	level of probable asparagine--tRNA ligase, mitochondrial (human) in blood serum	PR:Q96I59	probable asparagine--tRNA ligase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043675	level of splicing factor 45 (human) in blood serum	PR:Q96I25	splicing factor 45 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043676	level of far upstream element-binding protein 3 (human) in blood serum	PR:Q96I24	far upstream element-binding protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043677	level of selenocysteine lyase (human) in blood serum	PR:Q96I15	selenocysteine lyase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043678	level of transcription cofactor HES-6 (human) in blood serum	PR:Q96HZ4	transcription cofactor HES-6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043679	level of DDRGK domain-containing protein 1 (human) in blood serum	PR:Q96HY6	DDRGK domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043680	level of MORF4 family-associated protein 1-like 1 (human) in blood serum	PR:Q96HT8	MORF4 family-associated protein 1-like 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043681	level of GRAM domain-containing protein 2B (human) in blood serum	PR:Q96HH9	GRAM domain-containing protein 2B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043682	level of small integral membrane protein 10 (human) in blood serum	PR:Q96HG1	small integral membrane protein 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043683	level of secreted frizzled-related protein 2 (human) in blood serum	PR:Q96HF1	secreted frizzled-related protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043684	level of ERO1-like protein alpha (human) in blood serum	PR:Q96HE7	ERO1-like protein alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043685	level of N-acyl-aromatic-L-amino acid amidohydrolase (carboxylate-forming) (human) in blood serum	PR:Q96HD9	N-acyl-aromatic-L-amino acid amidohydrolase (carboxylate-forming) (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043686	level of PDZ and LIM domain protein 5 (human) in blood serum	PR:Q96HC4	PDZ and LIM domain protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043687	level of chemokine-like protein TAFA-4 (human) in blood serum	PR:Q96LR4	chemokine-like protein TAFA-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043688	level of uncharacterized protein C20orf173 (human) in blood serum	PR:Q96LM9	uncharacterized protein C20orf173 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043689	level of DnaJ homolog subfamily C member 30, mitochondrial (human) in blood serum	PR:Q96LL9	DnaJ homolog subfamily C member 30, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043690	level of sentrin-specific protease 8 (human) in blood serum	PR:Q96LD8	sentrin-specific protease 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043691	level of Bcl-2-modifying factor (human) in blood serum	PR:Q96LC9	Bcl-2-modifying factor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043692	level of peptidoglycan recognition protein 3 (human) in blood serum	PR:Q96LB9	peptidoglycan recognition protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043693	level of peptidoglycan recognition protein 4 (human) in blood serum	PR:Q96LB8	peptidoglycan recognition protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043694	level of Fc receptor-like protein 1 (human) in blood serum	PR:Q96LA6	Fc receptor-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043695	level of Fc receptor-like protein 2 (human) in blood serum	PR:Q96LA5	Fc receptor-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043696	level of kinesin-like protein KIF16B (human) in blood serum	PR:Q96L93	kinesin-like protein KIF16B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043697	level of sorting nexin-27 (human) in blood serum	PR:Q96L92	sorting nexin-27 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043698	level of beta-1,3-galactosyltransferase 6 (human) in blood serum	PR:Q96L58	beta-1,3-galactosyltransferase 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043699	level of calpain small subunit 2 (human) in blood serum	PR:Q96L46	calpain small subunit 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043700	level of ecto-ADP-ribosyltransferase 5 (human) in blood serum	PR:Q96L15	ecto-ADP-ribosyltransferase 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043701	level of sushi domain-containing protein 3 (human) in blood serum	PR:Q96L08	sushi domain-containing protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043702	level of uncharacterized protein C4orf36 (human) in blood serum	PR:Q96KX1	uncharacterized protein C4orf36 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043703	level of prolyl hydroxylase EGLN2 (human) in blood serum	PR:Q96KS0	prolyl hydroxylase EGLN2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043704	level of protein LRATD1 (human) in blood serum	PR:Q96KN4	protein LRATD1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043705	level of protein LRATD2 (human) in blood serum	PR:Q96KN1	protein LRATD2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043706	level of cytochrome c oxidase subunit 4 isoform 2, mitochondrial (human) in blood serum	PR:Q96KJ9	cytochrome c oxidase subunit 4 isoform 2, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043707	level of multiple epidermal growth factor-like domains protein 10 (human) in blood serum	PR:Q96KG7	multiple epidermal growth factor-like domains protein 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043708	level of DnaJ homolog subfamily C member 1 (human) in blood serum	PR:Q96KC8	DnaJ homolog subfamily C member 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043709	level of ADP-ribosylation factor-like protein 5B (human) in blood serum	PR:Q96KC2	ADP-ribosylation factor-like protein 5B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043710	level of lymphokine-activated killer T-cell-originated protein kinase (human) in blood serum	PR:Q96KB5	lymphokine-activated killer T-cell-originated protein kinase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043711	level of transmembrane protein 87B (human) in blood serum	PR:Q96K49	transmembrane protein 87B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043712	level of hematopoietic SH2 domain-containing protein (human) in blood serum	PR:Q96JZ2	hematopoietic SH2 domain-containing protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043713	level of protein SERAC1 (human) in blood serum	PR:Q96JX3	protein SERAC1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043714	level of solute carrier family 41 member 2 (human) in blood serum	PR:Q96JW4	solute carrier family 41 member 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043715	level of cadherin-related family member 1 (human) in blood serum	PR:Q96JP9	cadherin-related family member 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043716	level of E3 ubiquitin-protein ligase ZFP91 (human) in blood serum	PR:Q96JP5	E3 ubiquitin-protein ligase ZFP91 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043717	level of DDB1- and CUL4-associated factor 5 (human) in blood serum	PR:Q96JK2	DDB1- and CUL4-associated factor 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043718	level of coiled-coil domain-containing protein 115 (human) in blood serum	PR:Q96NT0	coiled-coil domain-containing protein 115 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043719	level of retinol dehydrogenase 12 (human) in blood serum	PR:Q96NR8	retinol dehydrogenase 12 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043720	level of leucine-rich repeat and fibronectin type-III domain-containing protein 5 (human) in blood serum	PR:Q96NI6	leucine-rich repeat and fibronectin type-III domain-containing protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043721	level of outer dynein arm-docking complex subunit 4 (human) in blood serum	PR:Q96NG3	outer dynein arm-docking complex subunit 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043722	level of protein FAM210A (human) in blood serum	PR:Q96ND0	protein FAM210A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043723	level of centrosomal protein 20 (human) in blood serum	PR:Q96NB1	centrosomal protein 20 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043724	level of t-SNARE domain-containing protein 1 (human) in blood serum	PR:Q96NA8	t-SNARE domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043725	level of Rab-interacting lysosomal protein (human) in blood serum	PR:Q96NA2	Rab-interacting lysosomal protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043726	level of AP-4 complex accessory subunit Tepsin (human) in blood serum	PR:Q96N21	AP-4 complex accessory subunit Tepsin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043727	level of spermatogenesis-associated protein 33 (human) in blood serum	PR:Q96N06	spermatogenesis-associated protein 33 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043728	level of ganglioside-induced differentiation-associated protein 1-like 1 (human) in blood serum	PR:Q96MZ0	ganglioside-induced differentiation-associated protein 1-like 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043729	level of conserved oligomeric Golgi complex subunit 8 (human) in blood serum	PR:Q96MW5	conserved oligomeric Golgi complex subunit 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043730	level of coiled-coil domain-containing protein 43 (human) in blood serum	PR:Q96MW1	coiled-coil domain-containing protein 43 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043731	level of Kremen protein 1 (human) in blood serum	PR:Q96MU8	Kremen protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043732	level of YTH domain-containing protein 1 (human) in blood serum	PR:Q96MU7	YTH domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043733	level of zinc finger protein 560 (human) in blood serum	PR:Q96MR9	zinc finger protein 560 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043734	level of BTB/POZ domain-containing protein KCTD7 (human) in blood serum	PR:Q96MP8	BTB/POZ domain-containing protein KCTD7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043735	level of NACHT, LRR and PYD domains-containing protein 4 (human) in blood serum	PR:Q96MN2	NACHT, LRR and PYD domains-containing protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043736	level of heparan-sulfate 6-O-sulfotransferase 2 (human) in blood serum	PR:Q96MM7	heparan-sulfate 6-O-sulfotransferase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043737	level of pseudokinase FAM20A (human) in blood serum	PR:Q96MK3	pseudokinase FAM20A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043738	level of protein phosphatase 1M (human) in blood serum	PR:Q96MI6	protein phosphatase 1M (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043739	level of protein HEXIM2 (human) in blood serum	PR:Q96MH2	protein HEXIM2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043740	level of E3 SUMO-protein ligase NSE2 (human) in blood serum	PR:Q96MF7	E3 SUMO-protein ligase NSE2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043741	level of coenzyme Q-binding protein COQ10 homolog A, mitochondrial (human) in blood serum	PR:Q96MF6	coenzyme Q-binding protein COQ10 homolog A, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043742	level of coiled-coil domain-containing protein 140 (human) in blood serum	PR:Q96MF4	coiled-coil domain-containing protein 140 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043743	level of bMERB domain-containing protein 1 (human) in blood serum	PR:Q96MC5	bMERB domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043744	level of doublesex- and mab-3-related transcription factor B1 (human) in blood serum	PR:Q96MA1	doublesex- and mab-3-related transcription factor B1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043745	level of calcineurin subunit B type 2 (human) in blood serum	PR:Q96LZ3	calcineurin subunit B type 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043746	level of melanoma-associated antigen B10 (human) in blood serum	PR:Q96LZ2	melanoma-associated antigen B10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043747	level of caspase recruitment domain-containing protein 19 (human) in blood serum	PR:Q96LW7	caspase recruitment domain-containing protein 19 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043748	level of RNA-binding region-containing protein 3 (human) in blood serum	PR:Q96LT9	RNA-binding region-containing protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043749	level of formin-binding protein 1 (human) in blood serum	PR:Q96RU3	formin-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043750	level of ubiquitin carboxyl-terminal hydrolase 28 (human) in blood serum	PR:Q96RU2	ubiquitin carboxyl-terminal hydrolase 28 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043751	level of bile acid receptor (human) in blood serum	PR:Q96RI1	bile acid receptor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043752	level of retinoid-binding protein 7 (human) in blood serum	PR:Q96R05	retinoid-binding protein 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043753	level of histone H2A type 1-A (human) in blood serum	PR:Q96QV6	histone H2A type 1-A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043754	level of hedgehog-interacting protein (human) in blood serum	PR:Q96QV1	hedgehog-interacting protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043755	level of transcriptional activator protein Pur-beta (human) in blood serum	PR:Q96QR8	transcriptional activator protein Pur-beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043756	level of secretoglobin family 3A member 1 (human) in blood serum	PR:Q96QR1	secretoglobin family 3A member 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043757	level of sperm acrosome-associated protein 5 (human) in blood serum	PR:Q96QH8	sperm acrosome-associated protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043758	level of serine/threonine-protein phosphatase 1 regulatory subunit 10 (human) in blood serum	PR:Q96QC0	serine/threonine-protein phosphatase 1 regulatory subunit 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043759	level of alpha-ketoglutarate-dependent dioxygenase alkB homolog 3 (human) in blood serum	PR:Q96Q83	alpha-ketoglutarate-dependent dioxygenase alkB homolog 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043760	level of transmembrane protein 237 (human) in blood serum	PR:Q96Q45	transmembrane protein 237 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043761	level of cyclin-dependent kinase 15 (human) in blood serum	PR:Q96Q40	cyclin-dependent kinase 15 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043762	level of CUB and sushi domain-containing protein 1 (human) in blood serum	PR:Q96PZ7	CUB and sushi domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043763	level of KH domain-containing RNA-binding protein QKI (human) in blood serum	PR:Q96PU8	KH domain-containing RNA-binding protein QKI (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043764	level of guanylate-binding protein 5 (human) in blood serum	PR:Q96PP8	guanylate-binding protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043765	level of erythroid membrane-associated protein (human) in blood serum	PR:Q96PL5	erythroid membrane-associated protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043766	level of beta-tectorin (human) in blood serum	PR:Q96PL2	beta-tectorin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043767	level of defensin beta 118 (human) in blood serum	PR:Q96PH6	defensin beta 118 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043768	level of testis-specific serine/threonine-protein kinase 2 (human) in blood serum	PR:Q96PF2	testis-specific serine/threonine-protein kinase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043769	level of methylmalonyl-CoA epimerase, mitochondrial (human) in blood serum	PR:Q96PE7	methylmalonyl-CoA epimerase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043770	level of inositol polyphosphate-4-phosphatase type I A (human) in blood serum	PR:Q96PE3	inositol polyphosphate-4-phosphatase type I A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043771	level of N-acetylmuramoyl-L-alanine amidase (human) in blood serum	PR:Q96PD5	N-acetylmuramoyl-L-alanine amidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043772	level of leucine-rich repeat-containing protein 3B (human) in blood serum	PR:Q96PB8	leucine-rich repeat-containing protein 3B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043773	level of N-terminal EF-hand calcium-binding protein 3 (human) in blood serum	PR:Q96P71	N-terminal EF-hand calcium-binding protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043774	level of probable G-protein coupled receptor 101 (human) in blood serum	PR:Q96P66	probable G-protein coupled receptor 101 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043775	level of Arf-GAP with GTPase, ANK repeat and PH domain-containing protein 3 (human) in blood serum	PR:Q96P47	Arf-GAP with GTPase, ANK repeat and PH domain-containing protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043776	level of regulation of nuclear pre-mRNA domain-containing protein 1A (human) in blood serum	PR:Q96P16	regulation of nuclear pre-mRNA domain-containing protein 1A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043777	level of nectin-4 (human) in blood serum	PR:Q96NY8	nectin-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043778	level of ankyrin repeat domain-containing protein 27 (human) in blood serum	PR:Q96NW4	ankyrin repeat domain-containing protein 27 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043779	level of protein GUCD1 (human) in blood serum	PR:Q96NT3	protein GUCD1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043780	level of TSC22 domain family protein 3 (human) in blood serum	PR:Q99576	TSC22 domain family protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043781	level of matrix metalloproteinase-19 (human) in blood serum	PR:Q99542	matrix metalloproteinase-19 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043782	level of synaptic vesicle membrane protein VAT-1 homolog (human) in blood serum	PR:Q99536	synaptic vesicle membrane protein VAT-1 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043783	level of sialidase-1 (human) in blood serum	PR:Q99519	sialidase-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043784	level of Arf-GAP with GTPase, ANK repeat and PH domain-containing protein 2 (human) in blood serum	PR:Q99490	Arf-GAP with GTPase, ANK repeat and PH domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043785	level of platelet-activating factor acetylhydrolase 2, cytoplasmic (human) in blood serum	PR:Q99487	platelet-activating factor acetylhydrolase 2, cytoplasmic (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043786	level of stromal cell-derived factor 2 (human) in blood serum	PR:Q99470	stromal cell-derived factor 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043787	level of SH3 and cysteine-rich domain-containing protein (human) in blood serum	PR:Q99469	SH3 and cysteine-rich domain-containing protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043788	level of calponin-2 (human) in blood serum	PR:Q99439	calponin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043789	level of proteasome subunit beta type-7 (human) in blood serum	PR:Q99436	proteasome subunit beta type-7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043790	level of protein kinase C-binding protein NELL2 (human) in blood serum	PR:Q99435	protein kinase C-binding protein NELL2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043791	level of tubulin-folding cofactor B (human) in blood serum	PR:Q99426	tubulin-folding cofactor B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043792	level of cytohesin-2 (human) in blood serum	PR:Q99418	cytohesin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043793	level of c-Myc-binding protein (human) in blood serum	PR:Q99417	c-Myc-binding protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043794	level of glutamate decarboxylase 1 (human) in blood serum	PR:Q99259	glutamate decarboxylase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043795	level of regulator of microtubule dynamics protein 3 (human) in blood serum	PR:Q96TC7	regulator of microtubule dynamics protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043796	level of ATP-dependent zinc metalloprotease YME1L1 (human) in blood serum	PR:Q96TA2	ATP-dependent zinc metalloprotease YME1L1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043797	level of glycoprotein hormone alpha-2 (human) in blood serum	PR:Q96T91	glycoprotein hormone alpha-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043798	level of bifunctional polynucleotide phosphatase/kinase (human) in blood serum	PR:Q96T60	bifunctional polynucleotide phosphatase/kinase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043799	level of mitochondrial inner membrane protease subunit 2 (human) in blood serum	PR:Q96T52	mitochondrial inner membrane protease subunit 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043800	level of oxysterol-binding protein-related protein 9 (human) in blood serum	PR:Q96SU4	oxysterol-binding protein-related protein 9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043801	level of zinc finger protein 382 (human) in blood serum	PR:Q96SR6	zinc finger protein 382 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043802	level of probable carboxypeptidase X1 (human) in blood serum	PR:Q96SM3	probable carboxypeptidase X1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043803	level of glutathione peroxidase 7 (human) in blood serum	PR:Q96SL4	glutathione peroxidase 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043804	level of BTB/POZ domain-containing protein KCTD15 (human) in blood serum	PR:Q96SI1	BTB/POZ domain-containing protein KCTD15 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043805	level of neurabin-2 (human) in blood serum	PR:Q96SB3	neurabin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043806	level of calcium/calmodulin-dependent protein kinase II inhibitor 2 (human) in blood serum	PR:Q96S95	calcium/calmodulin-dependent protein kinase II inhibitor 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043807	level of ubiquitin-like protein 7 (human) in blood serum	PR:Q96S82	ubiquitin-like protein 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043808	level of ATPase WRNIP1 (human) in blood serum	PR:Q96S55	ATPase WRNIP1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043809	level of nodal homolog (human) in blood serum	PR:Q96S42	nodal homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043810	level of methyltransferase-like 26 (human) in blood serum	PR:Q96S19	methyltransferase-like 26 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043811	level of endophilin-A3 (human) in blood serum	PR:Q99963	endophilin-A3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043812	level of endophilin-A1 (human) in blood serum	PR:Q99962	endophilin-A1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043813	level of plakophilin-2 (human) in blood serum	PR:Q99959	plakophilin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043814	level of forkhead box protein C2 (human) in blood serum	PR:Q99958	forkhead box protein C2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043815	level of submaxillary gland androgen-regulated protein 3A (human) in blood serum	PR:Q99954	submaxillary gland androgen-regulated protein 3A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043816	level of cyclic AMP-dependent transcription factor ATF-6 beta (human) in blood serum	PR:Q99941	cyclic AMP-dependent transcription factor ATF-6 beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043817	level of opiorphin prepropeptide (human) in blood serum	PR:Q99935	opiorphin prepropeptide (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043818	level of BAG family molecular chaperone regulator 1 (human) in blood serum	PR:Q99933	BAG family molecular chaperone regulator 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043819	level of chymotrypsin-C (human) in blood serum	PR:Q99895	chymotrypsin-C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043820	level of calcium and integrin-binding protein 1 (human) in blood serum	PR:Q99828	calcium and integrin-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043821	level of tumor susceptibility gene 101 protein (human) in blood serum	PR:Q99816	tumor susceptibility gene 101 protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043822	level of 5-demethoxyubiquinone hydroxylase, mitochondrial (human) in blood serum	PR:Q99807	5-demethoxyubiquinone hydroxylase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043823	level of noelin (human) in blood serum	PR:Q99784	noelin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043824	level of mitogen-activated protein kinase kinase kinase 3 (human) in blood serum	PR:Q99759	mitogen-activated protein kinase kinase kinase 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043825	level of gamma-soluble NSF attachment protein (human) in blood serum	PR:Q99747	gamma-soluble NSF attachment protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043826	level of nucleosome assembly protein 1-like 4 (human) in blood serum	PR:Q99733	nucleosome assembly protein 1-like 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043827	level of BRCA1-associated RING domain protein 1 (human) in blood serum	PR:Q99728	BRCA1-associated RING domain protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043828	level of metalloproteinase inhibitor 4 (human) in blood serum	PR:Q99727	metalloproteinase inhibitor 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043829	level of probable proton-coupled zinc antiporter SLC30A3 (human) in blood serum	PR:Q99726	probable proton-coupled zinc antiporter SLC30A3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043830	level of septin-5 (human) in blood serum	PR:Q99719	septin-5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043831	level of mothers against decapentaplegic homolog 5 (human) in blood serum	PR:Q99717	mothers against decapentaplegic homolog 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043832	level of docking protein 1 (human) in blood serum	PR:Q99704	docking protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043833	level of pituitary homeobox 2 (human) in blood serum	PR:Q99697	pituitary homeobox 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043834	level of cell growth regulator with EF hand domain protein 1 (human) in blood serum	PR:Q99674	cell growth regulator with EF hand domain protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043835	level of calcineurin B homologous protein 1 (human) in blood serum	PR:Q99653	calcineurin B homologous protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043836	level of COP9 signalosome complex subunit 8 (human) in blood serum	PR:Q99627	COP9 signalosome complex subunit 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043837	level of prohibitin-2 (human) in blood serum	PR:Q99623	prohibitin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043838	level of transcriptional enhancer factor TEF-5 (human) in blood serum	PR:Q99594	transcriptional enhancer factor TEF-5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043839	level of T-box transcription factor TBX5 (human) in blood serum	PR:Q99593	T-box transcription factor TBX5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043840	level of protein S100-A13 (human) in blood serum	PR:Q99584	protein S100-A13 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043841	level of protein FEV (human) in blood serum	PR:Q99581	protein FEV (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043842	level of sulfotransferase 4A1 (human) in blood serum	PR:Q9BR01	sulfotransferase 4A1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043843	level of dysbindin domain-containing protein 2 (human) in blood serum	PR:Q9BQY9	dysbindin domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043844	level of WAP four-disulfide core domain protein 6 (human) in blood serum	PR:Q9BQY6	WAP four-disulfide core domain protein 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043845	level of calsyntenin-3 (human) in blood serum	PR:Q9BQT9	calsyntenin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043846	level of hephaestin (human) in blood serum	PR:Q9BQS7	hephaestin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043847	level of allograft inflammatory factor 1-like (human) in blood serum	PR:Q9BQI0	allograft inflammatory factor 1-like (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043848	level of NAD-capped RNA hydrolase NUDT12 (human) in blood serum	PR:Q9BQG2	NAD-capped RNA hydrolase NUDT12 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043849	level of sentrin-specific protease 7 (human) in blood serum	PR:Q9BQF6	sentrin-specific protease 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043850	level of apolipoprotein L2 (human) in blood serum	PR:Q9BQE5	apolipoprotein L2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043851	level of selenoprotein S (human) in blood serum	PR:Q9BQE4	selenoprotein S (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043852	level of adenine nucleotide translocase lysine N-methyltransferase (human) in blood serum	PR:Q9BQD7	adenine nucleotide translocase lysine N-methyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043853	level of KxDL motif-containing protein 1 (human) in blood serum	PR:Q9BQD3	KxDL motif-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043854	level of 2-(3-amino-3-carboxypropyl)histidine synthase subunit 2 (human) in blood serum	PR:Q9BQC3	2-(3-amino-3-carboxypropyl)histidine synthase subunit 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043855	level of cytochrome b-245 chaperone 1 (human) in blood serum	PR:Q9BQA9	cytochrome b-245 chaperone 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043856	level of protein FAM110A (human) in blood serum	PR:Q9BQ89	protein FAM110A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043857	level of ADP-ribose glycohydrolase MACROD1 (human) in blood serum	PR:Q9BQ69	ADP-ribose glycohydrolase MACROD1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043858	level of U6 snRNA phosphodiesterase 1 (human) in blood serum	PR:Q9BQ65	U6 snRNA phosphodiesterase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043859	level of three prime repair exonuclease 2 (human) in blood serum	PR:Q9BQ50	three prime repair exonuclease 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043860	level of 39S ribosomal protein L34, mitochondrial (human) in blood serum	PR:Q9BQ48	39S ribosomal protein L34, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043861	level of testican-3 (human) in blood serum	PR:Q9BQ16	testican-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043862	level of resistin-like beta (human) in blood serum	PR:Q9BQ08	resistin-like beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043863	level of homeodomain-only protein (human) in blood serum	PR:Q9BPY8	homeodomain-only protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043864	level of protein FAM118B (human) in blood serum	PR:Q9BPY3	protein FAM118B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043865	level of 17-beta-hydroxysteroid dehydrogenase 14 (human) in blood serum	PR:Q9BPX1	17-beta-hydroxysteroid dehydrogenase 14 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043866	level of dehydrogenase/reductase SDR family member 9 (human) in blood serum	PR:Q9BPW9	dehydrogenase/reductase SDR family member 9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043867	level of B9 domain-containing protein 2 (human) in blood serum	PR:Q9BPU9	B9 domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043868	level of dihydropyrimidinase-related protein 5 (human) in blood serum	PR:Q9BPU6	dihydropyrimidinase-related protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043869	level of galactosylceramide sulfotransferase (human) in blood serum	PR:Q99999	galactosylceramide sulfotransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043870	level of serine/threonine-protein kinase VRK1 (human) in blood serum	PR:Q99986	serine/threonine-protein kinase VRK1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043871	level of semaphorin-3C (human) in blood serum	PR:Q99985	semaphorin-3C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043872	level of myocilin (human) in blood serum	PR:Q99972	myocilin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043873	level of mediator of RNA polymerase II transcription subunit 10 (human) in blood serum	PR:Q9BTT4	mediator of RNA polymerase II transcription subunit 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043874	level of leucine-rich repeat and fibronectin type-III domain-containing protein 3 (human) in blood serum	PR:Q9BTN0	leucine-rich repeat and fibronectin type-III domain-containing protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043875	level of immediate early response gene 2 protein (human) in blood serum	PR:Q9BTL4	immediate early response gene 2 protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043876	level of PAXIP1-associated glutamate-rich protein 1 (human) in blood serum	PR:Q9BTK6	PAXIP1-associated glutamate-rich protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043877	level of DCN1-like protein 5 (human) in blood serum	PR:Q9BTE7	DCN1-like protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043878	level of alanyl-tRNA editing protein Aarsd1 (human) in blood serum	PR:Q9BTE6	alanyl-tRNA editing protein Aarsd1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043879	level of death-inducer obliterator 1 (human) in blood serum	PR:Q9BTC0	death-inducer obliterator 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043880	level of synaptotagmin-11 (human) in blood serum	PR:Q9BT88	synaptotagmin-11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043881	level of proteasome assembly chaperone 3 (human) in blood serum	PR:Q9BT73	proteasome assembly chaperone 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043882	level of LIM domain-containing protein 2 (human) in blood serum	PR:Q9BT23	LIM domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043883	level of protein canopy homolog 3 (human) in blood serum	PR:Q9BT09	protein canopy homolog 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043884	level of synaptotagmin-17 (human) in blood serum	PR:Q9BSW7	synaptotagmin-17 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043885	level of EF-hand calcium-binding domain-containing protein 4B (human) in blood serum	PR:Q9BSW2	EF-hand calcium-binding domain-containing protein 4B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043886	level of tRNA-splicing endonuclease subunit Sen34 (human) in blood serum	PR:Q9BSV6	tRNA-splicing endonuclease subunit Sen34 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043887	level of cerebral cavernous malformations 2 protein (human) in blood serum	PR:Q9BSQ5	cerebral cavernous malformations 2 protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043888	level of ubiquitin-associated domain-containing protein 1 (human) in blood serum	PR:Q9BSL1	ubiquitin-associated domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043889	level of TERF1-interacting nuclear factor 2 (human) in blood serum	PR:Q9BSI4	TERF1-interacting nuclear factor 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043890	level of translational activator of cytochrome c oxidase 1 (human) in blood serum	PR:Q9BSH4	translational activator of cytochrome c oxidase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043891	level of homocysteine-responsive endoplasmic reticulum-resident ubiquitin-like domain member 2 protein (human) in blood serum	PR:Q9BSE4	homocysteine-responsive endoplasmic reticulum-resident ubiquitin-like domain member 2 protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043892	level of zona pellucida-binding protein 1 (human) in blood serum	PR:Q9BS86	zona pellucida-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043893	level of latexin (human) in blood serum	PR:Q9BS40	latexin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043894	level of peroxiredoxin-like 2A (human) in blood serum	PR:Q9BRX8	peroxiredoxin-like 2A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043895	level of protein pelota homolog (human) in blood serum	PR:Q9BRX2	protein pelota homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043896	level of transcription elongation factor A protein-like 7 (human) in blood serum	PR:Q9BRU2	transcription elongation factor A protein-like 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043897	level of ADP-dependent glucokinase (human) in blood serum	PR:Q9BRR6	ADP-dependent glucokinase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043898	level of cilia- and flagella-associated protein 300 (human) in blood serum	PR:Q9BRQ4	cilia- and flagella-associated protein 300 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043899	level of receptor expression-enhancing protein 2 (human) in blood serum	PR:Q9BRK0	receptor expression-enhancing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043900	level of tudor-interacting repair regulator protein (human) in blood serum	PR:Q9BRJ7	tudor-interacting repair regulator protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043901	level of vacuolar protein-sorting-associated protein 25 (human) in blood serum	PR:Q9BRG1	vacuolar protein-sorting-associated protein 25 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043902	level of serine/threonine-protein phosphatase CPPED1 (human) in blood serum	PR:Q9BRF8	serine/threonine-protein phosphatase CPPED1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043903	level of acyl-CoA-binding domain-containing protein 6 (human) in blood serum	PR:Q9BR61	acyl-CoA-binding domain-containing protein 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043904	level of N-terminal Xaa-Pro-Lys N-methyltransferase 1 (human) in blood serum	PR:Q9BV86	N-terminal Xaa-Pro-Lys N-methyltransferase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043905	level of acireductone dioxygenase (human) in blood serum	PR:Q9BV57	acireductone dioxygenase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043906	level of dual specificity protein phosphatase 26 (human) in blood serum	PR:Q9BV47	dual specificity protein phosphatase 26 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043907	level of vesicle-associated membrane protein 8 (human) in blood serum	PR:Q9BV40	vesicle-associated membrane protein 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043908	level of WD repeat-containing protein 18 (human) in blood serum	PR:Q9BV38	WD repeat-containing protein 18 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043909	level of methylthioribose-1-phosphate isomerase (human) in blood serum	PR:Q9BV20	methylthioribose-1-phosphate isomerase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043910	level of uncharacterized protein C1orf50 (human) in blood serum	PR:Q9BV19	uncharacterized protein C1orf50 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043911	level of TNF receptor-associated factor 4 (human) in blood serum	PR:Q9BUZ4	TNF receptor-associated factor 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043912	level of glutathione-specific gamma-glutamylcyclotransferase 1 (human) in blood serum	PR:Q9BUX1	glutathione-specific gamma-glutamylcyclotransferase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043913	level of arginine/serine-rich protein 1 (human) in blood serum	PR:Q9BUV0	arginine/serine-rich protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043914	level of dehydrogenase/reductase SDR family member 6 (human) in blood serum	PR:Q9BUT1	dehydrogenase/reductase SDR family member 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043915	level of probable ATP-dependent RNA helicase DDX23 (human) in blood serum	PR:Q9BUQ8	probable ATP-dependent RNA helicase DDX23 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043916	level of oxidoreductase HTATIP2 (human) in blood serum	PR:Q9BUP3	oxidoreductase HTATIP2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043917	level of EF-hand domain-containing protein D1 (human) in blood serum	PR:Q9BUP0	EF-hand domain-containing protein D1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043918	level of derlin-1 (human) in blood serum	PR:Q9BUN8	derlin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043919	level of protein MENT (human) in blood serum	PR:Q9BUN1	protein MENT (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043920	level of ribonuclease P protein subunit p25 (human) in blood serum	PR:Q9BUL9	ribonuclease P protein subunit p25 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043921	level of coiled-coil-helix-coiled-coil-helix domain-containing protein 7 (human) in blood serum	PR:Q9BUK0	coiled-coil-helix-coiled-coil-helix domain-containing protein 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043922	level of protein ABHD14A (human) in blood serum	PR:Q9BUJ0	protein ABHD14A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043923	level of spondin-2 (human) in blood serum	PR:Q9BUD6	spondin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043924	level of transmembrane protein 70, mitochondrial (human) in blood serum	PR:Q9BUB7	transmembrane protein 70, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043925	level of MAP kinase-interacting serine/threonine-protein kinase 1 (human) in blood serum	PR:Q9BUB5	MAP kinase-interacting serine/threonine-protein kinase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043926	level of tRNA-specific adenosine deaminase 1 (human) in blood serum	PR:Q9BUB4	tRNA-specific adenosine deaminase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043927	level of deoxyhypusine hydroxylase (human) in blood serum	PR:Q9BU89	deoxyhypusine hydroxylase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043928	level of NADH dehydrogenase [ubiquinone] 1 alpha subcomplex assembly factor 3 (human) in blood serum	PR:Q9BU61	NADH dehydrogenase [ubiquinone] 1 alpha subcomplex assembly factor 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043929	level of thiamine-triphosphatase (human) in blood serum	PR:Q9BU02	thiamine-triphosphatase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043930	level of dehydrogenase/reductase SDR family member 4 (human) in blood serum	PR:Q9BTZ2	dehydrogenase/reductase SDR family member 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043931	level of alpha-tocopherol transfer protein-like (human) in blood serum	PR:Q9BTX7	alpha-tocopherol transfer protein-like (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043932	level of CDK5 and ABL1 enzyme substrate 2 (human) in blood serum	PR:Q9BTV7	CDK5 and ABL1 enzyme substrate 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043933	level of diphthine methyltransferase (human) in blood serum	PR:Q9BTV6	diphthine methyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043934	level of fibronectin type III and SPRY domain-containing protein 1 (human) in blood serum	PR:Q9BTV5	fibronectin type III and SPRY domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043935	level of TM2 domain-containing protein 1 (human) in blood serum	PR:Q9BX74	TM2 domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043936	level of adenosine 5'-monophosphoramidase HINT2 (human) in blood serum	PR:Q9BX68	adenosine 5'-monophosphoramidase HINT2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043937	level of tapasin-related protein (human) in blood serum	PR:Q9BX59	tapasin-related protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043938	level of RNA-binding protein 24 (human) in blood serum	PR:Q9BX46	RNA-binding protein 24 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043939	level of spermatogenesis-associated protein 9 (human) in blood serum	PR:Q9BWV2	spermatogenesis-associated protein 9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043940	level of poly(A) polymerase gamma (human) in blood serum	PR:Q9BWT3	poly(A) polymerase gamma (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043941	level of chitinase domain-containing protein 1 (human) in blood serum	PR:Q9BWS9	chitinase domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043942	level of protein C1orf43 (human) in blood serum	PR:Q9BWL3	protein C1orf43 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043943	level of cell cycle regulator of non-homologous end joining (human) in blood serum	PR:Q9BWK5	cell cycle regulator of non-homologous end joining (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043944	level of RNA-binding protein 4 (human) in blood serum	PR:Q9BWF3	RNA-binding protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043945	level of replication initiator 1 (human) in blood serum	PR:Q9BWE0	replication initiator 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043946	level of acetyl-CoA acetyltransferase, cytosolic (human) in blood serum	PR:Q9BWD1	acetyl-CoA acetyltransferase, cytosolic (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043947	level of ADP-ribose pyrophosphatase, mitochondrial (human) in blood serum	PR:Q9BW91	ADP-ribose pyrophosphatase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043948	level of splicing factor YJU2 (human) in blood serum	PR:Q9BW85	splicing factor YJU2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043949	level of HIRA-interacting protein 3 (human) in blood serum	PR:Q9BW71	HIRA-interacting protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043950	level of cyclin-dependent kinase 2-interacting protein (human) in blood serum	PR:Q9BW66	cyclin-dependent kinase 2-interacting protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043951	level of katanin p60 ATPase-containing subunit A-like 1 (human) in blood serum	PR:Q9BW62	katanin p60 ATPase-containing subunit A-like 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043952	level of tubulin polymerization-promoting protein family member 3 (human) in blood serum	PR:Q9BW30	tubulin polymerization-promoting protein family member 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043953	level of specifically androgen-regulated gene protein (human) in blood serum	PR:Q9BW04	specifically androgen-regulated gene protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043954	level of TIMELESS-interacting protein (human) in blood serum	PR:Q9BVW5	TIMELESS-interacting protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043955	level of mitochondrial import inner membrane translocase subunit Tim21 (human) in blood serum	PR:Q9BVV7	mitochondrial import inner membrane translocase subunit Tim21 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043956	level of transmembrane and ubiquitin-like domain-containing protein 1 (human) in blood serum	PR:Q9BVT8	transmembrane and ubiquitin-like domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043957	level of tRNA (adenine(58)-N(1))-methyltransferase, mitochondrial (human) in blood serum	PR:Q9BVS5	tRNA (adenine(58)-N(1))-methyltransferase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043958	level of protein DPCD (human) in blood serum	PR:Q9BVM2	protein DPCD (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043959	level of transmembrane emp24 domain-containing protein 9 (human) in blood serum	PR:Q9BVK6	transmembrane emp24 domain-containing protein 9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043960	level of dual specificity protein phosphatase 23 (human) in blood serum	PR:Q9BVJ7	dual specificity protein phosphatase 23 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043961	level of alpha-N-acetylgalactosaminide alpha-2,6-sialyltransferase 5 (human) in blood serum	PR:Q9BVH7	alpha-N-acetylgalactosaminide alpha-2,6-sialyltransferase 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043962	level of E3 ubiquitin-protein ligase TRIM62 (human) in blood serum	PR:Q9BVG3	E3 ubiquitin-protein ligase TRIM62 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043963	level of sister chromatid cohesion protein DCC1 (human) in blood serum	PR:Q9BVC3	sister chromatid cohesion protein DCC1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043964	level of ER degradation-enhancing alpha-mannosidase-like protein 2 (human) in blood serum	PR:Q9BV94	ER degradation-enhancing alpha-mannosidase-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043965	level of U11/U12 small nuclear ribonucleoprotein 25 kDa protein (human) in blood serum	PR:Q9BV90	U11/U12 small nuclear ribonucleoprotein 25 kDa protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043966	level of SH3 and multiple ankyrin repeat domains protein 3 (human) in blood serum	PR:Q9BYB0	SH3 and multiple ankyrin repeat domains protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043967	level of dual specificity protein phosphatase 16 (human) in blood serum	PR:Q9BY84	dual specificity protein phosphatase 16 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043968	level of leucine-rich repeat-containing protein 3 (human) in blood serum	PR:Q9BY71	leucine-rich repeat-containing protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043969	level of peroxisomal trans-2-enoyl-CoA reductase (human) in blood serum	PR:Q9BY49	peroxisomal trans-2-enoyl-CoA reductase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043970	level of eukaryotic translation initiation factor 2A (human) in blood serum	PR:Q9BY44	eukaryotic translation initiation factor 2A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043971	level of charged multivesicular body protein 4a (human) in blood serum	PR:Q9BY43	charged multivesicular body protein 4a (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043972	level of inosine triphosphate pyrophosphatase (human) in blood serum	PR:Q9BY32	inosine triphosphate pyrophosphatase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043973	level of protein kinase C and casein kinase substrate in neurons protein 1 (human) in blood serum	PR:Q9BY11	protein kinase C and casein kinase substrate in neurons protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043974	level of protein BEX2 (human) in blood serum	PR:Q9BXY8	protein BEX2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043975	level of oxysterol-binding protein-related protein 1 (human) in blood serum	PR:Q9BXW6	oxysterol-binding protein-related protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043976	level of calcium-binding protein 8 (human) in blood serum	PR:Q9BXU9	calcium-binding protein 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043977	level of ferritin heavy polypeptide-like 17 (human) in blood serum	PR:Q9BXU8	ferritin heavy polypeptide-like 17 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043978	level of isopentenyl-diphosphate Delta-isomerase 2 (human) in blood serum	PR:Q9BXS1	isopentenyl-diphosphate Delta-isomerase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043979	level of collagen alpha-1(XXV) chain (human) in blood serum	PR:Q9BXS0	collagen alpha-1(XXV) chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043980	level of Toll-like receptor 10 (human) in blood serum	PR:Q9BXR5	Toll-like receptor 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043981	level of queuine tRNA-ribosyltransferase catalytic subunit 1 (human) in blood serum	PR:Q9BXR0	queuine tRNA-ribosyltransferase catalytic subunit 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043982	level of pappalysin-2 (human) in blood serum	PR:Q9BXP8	pappalysin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043983	level of serrate RNA effector molecule homolog (human) in blood serum	PR:Q9BXP5	serrate RNA effector molecule homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043984	level of C-type lectin domain family 7 member A (human) in blood serum	PR:Q9BXN2	C-type lectin domain family 7 member A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043985	level of asporin (human) in blood serum	PR:Q9BXN1	asporin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043986	level of periaxin (human) in blood serum	PR:Q9BXM0	periaxin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043987	level of complement C1q tumor necrosis factor-related protein 3 (human) in blood serum	PR:Q9BXJ4	complement C1q tumor necrosis factor-related protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043988	level of complement C1q tumor necrosis factor-related protein 4 (human) in blood serum	PR:Q9BXJ3	complement C1q tumor necrosis factor-related protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043989	level of complement C1q tumor necrosis factor-related protein 1 (human) in blood serum	PR:Q9BXJ1	complement C1q tumor necrosis factor-related protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043990	level of complement C1q tumor necrosis factor-related protein 5 (human) in blood serum	PR:Q9BXJ0	complement C1q tumor necrosis factor-related protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043991	level of N-acetylneuraminate lyase (human) in blood serum	PR:Q9BXD5	N-acetylneuraminate lyase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043992	level of oxysterol-binding protein-related protein 11 (human) in blood serum	PR:Q9BXB4	oxysterol-binding protein-related protein 11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043993	level of leucine-rich repeat-containing G-protein coupled receptor 4 (human) in blood serum	PR:Q9BXB1	leucine-rich repeat-containing G-protein coupled receptor 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043994	level of testis-specific serine/threonine-protein kinase 1 (human) in blood serum	PR:Q9BXA7	testis-specific serine/threonine-protein kinase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043995	level of plasmalemma vesicle-associated protein (human) in blood serum	PR:Q9BX97	plasmalemma vesicle-associated protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043996	level of group XIIB secretory phospholipase A2-like protein (human) in blood serum	PR:Q9BX93	group XIIB secretory phospholipase A2-like protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043997	level of E3 ubiquitin-protein ligase TRIM9 (human) in blood serum	PR:Q9C026	E3 ubiquitin-protein ligase TRIM9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043998	level of protein dpy-30 homolog (human) in blood serum	PR:Q9C005	protein dpy-30 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2043999	level of normal mucosa of esophagus-specific gene 1 protein (human) in blood serum	PR:Q9C002	normal mucosa of esophagus-specific gene 1 protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044000	level of NACHT, LRR and PYD domains-containing protein 1 (human) in blood serum	PR:Q9C000	NACHT, LRR and PYD domains-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044001	level of ropporin-1B (human) in blood serum	PR:Q9BZX4	ropporin-1B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044002	level of uridine-cytidine kinase 2 (human) in blood serum	PR:Q9BZX2	uridine-cytidine kinase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044003	level of forkhead box protein P3 (human) in blood serum	PR:Q9BZS1	forkhead box protein P3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044004	level of testicular spindle-associated protein SHCBP1L (human) in blood serum	PR:Q9BZQ2	testicular spindle-associated protein SHCBP1L (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044005	level of acidic mammalian chitinase (human) in blood serum	PR:Q9BZP6	acidic mammalian chitinase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044006	level of UL16-binding protein 1 (human) in blood serum	PR:Q9BZM6	UL16-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044007	level of UL16-binding protein 2 (human) in blood serum	PR:Q9BZM5	UL16-binding protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044008	level of UL16-binding protein 3 (human) in blood serum	PR:Q9BZM4	UL16-binding protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044009	level of group XIIA secretory phospholipase A2 (human) in blood serum	PR:Q9BZM1	group XIIA secretory phospholipase A2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044010	level of small integral membrane protein 3 (human) in blood serum	PR:Q9BZL3	small integral membrane protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044011	level of tether containing UBX domain for GLUT4 (human) in blood serum	PR:Q9BZE9	tether containing UBX domain for GLUT4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044012	level of UPF0193 protein EVG1 (human) in blood serum	PR:Q9BZE7	UPF0193 protein EVG1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044013	level of transmembrane gamma-carboxyglutamic acid protein 4 (human) in blood serum	PR:Q9BZD6	transmembrane gamma-carboxyglutamic acid protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044014	level of membrane-associated phosphatidylinositol transfer protein 3 (human) in blood serum	PR:Q9BZ71	membrane-associated phosphatidylinositol transfer protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044015	level of dedicator of cytokinesis protein 9 (human) in blood serum	PR:Q9BZ29	dedicator of cytokinesis protein 9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044016	level of interferon-induced helicase C domain-containing protein 1 (human) in blood serum	PR:Q9BYX4	interferon-induced helicase C domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044017	level of histone-lysine N-methyltransferase SETD2 (human) in blood serum	PR:Q9BYW2	histone-lysine N-methyltransferase SETD2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044018	level of transcription regulator protein BACH2 (human) in blood serum	PR:Q9BYV9	transcription regulator protein BACH2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044019	level of centrosomal protein of 41 kDa (human) in blood serum	PR:Q9BYV8	centrosomal protein of 41 kDa (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044020	level of tripartite motif-containing protein 55 (human) in blood serum	PR:Q9BYV6	tripartite motif-containing protein 55 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044021	level of tripartite motif-containing protein 54 (human) in blood serum	PR:Q9BYV2	tripartite motif-containing protein 54 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044022	level of keratin-associated protein 2-4 (human) in blood serum	PR:Q9BYR9	keratin-associated protein 2-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044023	level of sulfiredoxin-1 (human) in blood serum	PR:Q9BYN0	sulfiredoxin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044024	level of seizure 6-like protein (human) in blood serum	PR:Q9BYH1	seizure 6-like protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044025	level of 39S ribosomal protein L1, mitochondrial (human) in blood serum	PR:Q9BYD6	39S ribosomal protein L1, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044026	level of 39S ribosomal protein L32, mitochondrial (human) in blood serum	PR:Q9BYC8	39S ribosomal protein L32, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044027	level of alpha-(1,6)-fucosyltransferase (human) in blood serum	PR:Q9BYC5	alpha-(1,6)-fucosyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044028	level of sharpin (human) in blood serum	PR:Q9H0F6	sharpin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044029	level of Toll-interacting protein (human) in blood serum	PR:Q9H0E2	Toll-interacting protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044030	level of integrin-linked kinase-associated serine/threonine phosphatase 2C (human) in blood serum	PR:Q9H0C8	integrin-linked kinase-associated serine/threonine phosphatase 2C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044031	level of cysteine-rich secretory protein LCCL domain-containing 2 (human) in blood serum	PR:Q9H0B8	cysteine-rich secretory protein LCCL domain-containing 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044032	level of speriolin-like protein (human) in blood serum	PR:Q9H0A9	speriolin-like protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044033	level of polyadenylate-binding protein-interacting protein 1 (human) in blood serum	PR:Q9H074	polyadenylate-binding protein-interacting protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044034	level of disintegrin and metalloproteinase domain-containing protein 19 (human) in blood serum	PR:Q9H013	disintegrin and metalloproteinase domain-containing protein 19 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044035	level of ubiquitin-like modifier-activating enzyme 5 (human) in blood serum	PR:Q9GZZ9	ubiquitin-like modifier-activating enzyme 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044036	level of N-alpha-acetyltransferase 50 (human) in blood serum	PR:Q9GZZ1	N-alpha-acetyltransferase 50 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044037	level of linker for activation of T-cells family member 2 (human) in blood serum	PR:Q9GZY6	linker for activation of T-cells family member 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044038	level of twisted gastrulation protein homolog 1 (human) in blood serum	PR:Q9GZX9	twisted gastrulation protein homolog 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044039	level of eukaryotic translation initiation factor 5A-2 (human) in blood serum	PR:Q9GZV4	eukaryotic translation initiation factor 5A-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044040	level of ankyrin repeat domain-containing protein 2 (human) in blood serum	PR:Q9GZV1	ankyrin repeat domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044041	level of carboxy-terminal domain RNA polymerase II polypeptide A small phosphatase 1 (human) in blood serum	PR:Q9GZU7	carboxy-terminal domain RNA polymerase II polypeptide A small phosphatase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044042	level of egl nine homolog 1 (human) in blood serum	PR:Q9GZT9	egl nine homolog 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044043	level of NIF3-like protein 1 (human) in blood serum	PR:Q9GZT8	NIF3-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044044	level of coiled-coil domain-containing protein 90B, mitochondrial (human) in blood serum	PR:Q9GZT6	coiled-coil domain-containing protein 90B, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044045	level of carbohydrate sulfotransferase 5 (human) in blood serum	PR:Q9GZS9	carbohydrate sulfotransferase 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044046	level of microtubule-associated proteins 1A/1B light chain 3B (human) in blood serum	PR:Q9GZQ8	microtubule-associated proteins 1A/1B light chain 3B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044047	level of COMM domain-containing protein 5 (human) in blood serum	PR:Q9GZQ3	COMM domain-containing protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044048	level of platelet-derived growth factor D (human) in blood serum	PR:Q9GZP0	platelet-derived growth factor D (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044049	level of protein rogdi homolog (human) in blood serum	PR:Q9GZN7	protein rogdi homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044050	level of orphan sodium- and chloride-dependent neurotransmitter transporter NTT5 (human) in blood serum	PR:Q9GZN6	orphan sodium- and chloride-dependent neurotransmitter transporter NTT5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044051	level of homeobox protein TGIF2 (human) in blood serum	PR:Q9GZN2	homeobox protein TGIF2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044052	level of nuclear distribution protein nudE-like 1 (human) in blood serum	PR:Q9GZM8	nuclear distribution protein nudE-like 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044053	level of tubulointerstitial nephritis antigen-like (human) in blood serum	PR:Q9GZM7	tubulointerstitial nephritis antigen-like (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044054	level of N-acetyllactosaminide beta-1,3-N-acetylglucosaminyltransferase 4 (human) in blood serum	PR:Q9C0J1	N-acetyllactosaminide beta-1,3-N-acetylglucosaminyltransferase 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044055	level of endoplasmic reticulum junction formation protein lunapark (human) in blood serum	PR:Q9C0E8	endoplasmic reticulum junction formation protein lunapark (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044056	level of semaphorin-4C (human) in blood serum	PR:Q9C0C4	semaphorin-4C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044057	level of alpha-ketoglutarate-dependent dioxygenase FTO (human) in blood serum	PR:Q9C0B1	alpha-ketoglutarate-dependent dioxygenase FTO (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044058	level of serine/threonine-protein kinase DCLK3 (human) in blood serum	PR:Q9C098	serine/threonine-protein kinase DCLK3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044059	level of beta-defensin 127 (human) in blood serum	PR:Q9H1M4	beta-defensin 127 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044060	level of beta-defensin 129 (human) in blood serum	PR:Q9H1M3	beta-defensin 129 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044061	level of talin rod domain-containing protein 1 (human) in blood serum	PR:Q9H1K6	talin rod domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044062	level of iron-sulfur cluster assembly enzyme ISCU (human) in blood serum	PR:Q9H1K1	iron-sulfur cluster assembly enzyme ISCU (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044063	level of protein Wnt-5b (human) in blood serum	PR:Q9H1J7	protein Wnt-5b (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044064	level of activating signal cointegrator 1 complex subunit 2 (human) in blood serum	PR:Q9H1I8	activating signal cointegrator 1 complex subunit 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044065	level of WAP four-disulfide core domain protein 10A (human) in blood serum	PR:Q9H1F0	WAP four-disulfide core domain protein 10A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044066	level of DNA-directed RNA polymerase III subunit RPC6 (human) in blood serum	PR:Q9H1D9	DNA-directed RNA polymerase III subunit RPC6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044067	level of protein unc-93 homolog B1 (human) in blood serum	PR:Q9H1C4	protein unc-93 homolog B1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044068	level of glycosyltransferase 8 domain-containing protein 2 (human) in blood serum	PR:Q9H1C3	glycosyltransferase 8 domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044069	level of xylosyltransferase 2 (human) in blood serum	PR:Q9H1B5	xylosyltransferase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044070	level of syntenin-2 (human) in blood serum	PR:Q9H190	syntenin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044071	level of nucleotide exchange factor SIL1 (human) in blood serum	PR:Q9H173	nucleotide exchange factor SIL1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044072	level of Z-DNA-binding protein 1 (human) in blood serum	PR:Q9H171	Z-DNA-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044073	level of stathmin-4 (human) in blood serum	PR:Q9H169	stathmin-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044074	level of B-cell lymphoma/leukemia 11A (human) in blood serum	PR:Q9H165	B-cell lymphoma/leukemia 11A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044075	level of protocadherin alpha-C1 (human) in blood serum	PR:Q9H158	protocadherin alpha-C1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044076	level of SLIT and NTRK-like protein 2 (human) in blood serum	PR:Q9H156	SLIT and NTRK-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044077	level of beta-soluble NSF attachment protein (human) in blood serum	PR:Q9H115	beta-soluble NSF attachment protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044078	level of cystatin-like 1 (human) in blood serum	PR:Q9H114	cystatin-like 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044079	level of THAP domain-containing protein 2 (human) in blood serum	PR:Q9H0W7	THAP domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044080	level of VIP36-like protein (human) in blood serum	PR:Q9H0V9	VIP36-like protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044081	level of Ras-related protein Rab-1B (human) in blood serum	PR:Q9H0U4	Ras-related protein Rab-1B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044082	level of Ras-related protein Rab-17 (human) in blood serum	PR:Q9H0T7	Ras-related protein Rab-17 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044083	level of gamma-aminobutyric acid receptor-associated protein-like 1 (human) in blood serum	PR:Q9H0R8	gamma-aminobutyric acid receptor-associated protein-like 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044084	level of haloacid dehalogenase-like hydrolase domain-containing protein 2 (human) in blood serum	PR:Q9H0R4	haloacid dehalogenase-like hydrolase domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044085	level of CYFIP-related Rac1 interactor A (human) in blood serum	PR:Q9H0Q0	CYFIP-related Rac1 interactor A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044086	level of cytosolic 5'-nucleotidase 3A (human) in blood serum	PR:Q9H0P0	cytosolic 5'-nucleotidase 3A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044087	level of pterin-4-alpha-carbinolamine dehydratase 2 (human) in blood serum	PR:Q9H0N5	pterin-4-alpha-carbinolamine dehydratase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044088	level of NEDD4-like E3 ubiquitin-protein ligase WWP1 (human) in blood serum	PR:Q9H0M0	NEDD4-like E3 ubiquitin-protein ligase WWP1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044089	level of ADP-ribosylation factor-like protein 6 (human) in blood serum	PR:Q9H0F7	ADP-ribosylation factor-like protein 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044090	level of transcription elongation factor A protein-like 2 (human) in blood serum	PR:Q9H3H9	transcription elongation factor A protein-like 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044091	level of UPF0696 protein C11orf68 (human) in blood serum	PR:Q9H3H3	UPF0696 protein C11orf68 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044092	level of probable serine carboxypeptidase CPVL (human) in blood serum	PR:Q9H3G5	probable serine carboxypeptidase CPVL (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044093	level of BTB/POZ domain-containing adapter for CUL3-mediated RhoA degradation protein 3 (human) in blood serum	PR:Q9H3F6	BTB/POZ domain-containing adapter for CUL3-mediated RhoA degradation protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044094	level of tumor protein 63 (human) in blood serum	PR:Q9H3D4	tumor protein 63 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044095	level of polyadenylate-binding protein 3 (human) in blood serum	PR:Q9H361	polyadenylate-binding protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044096	level of ubiquilin-3 (human) in blood serum	PR:Q9H347	ubiquilin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044097	level of forkhead box protein P1 (human) in blood serum	PR:Q9H334	forkhead box protein P1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044098	level of variable charge X-linked protein 1 (human) in blood serum	PR:Q9H320	variable charge X-linked protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044099	level of solute carrier organic anion transporter family member 5A1 (human) in blood serum	PR:Q9H2Y9	solute carrier organic anion transporter family member 5A1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044100	level of chordin (human) in blood serum	PR:Q9H2X0	chordin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044101	level of disintegrin and metalloproteinase domain-containing protein 7 (human) in blood serum	PR:Q9H2U9	disintegrin and metalloproteinase domain-containing protein 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044102	level of inorganic pyrophosphatase 2, mitochondrial (human) in blood serum	PR:Q9H2U2	inorganic pyrophosphatase 2, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044103	level of tenomodulin (human) in blood serum	PR:Q9H2S6	tenomodulin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044104	level of kallikrein-15 (human) in blood serum	PR:Q9H2R5	kallikrein-15 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044105	level of diphthine methyl ester synthase (human) in blood serum	PR:Q9H2P9	diphthine methyl ester synthase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044106	level of S-methylmethionine--homocysteine S-methyltransferase BHMT2 (human) in blood serum	PR:Q9H2M3	S-methylmethionine--homocysteine S-methyltransferase BHMT2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044107	level of translation initiation factor IF-3, mitochondrial (human) in blood serum	PR:Q9H2K0	translation initiation factor IF-3, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044108	level of phosducin-like protein 3 (human) in blood serum	PR:Q9H2J4	phosducin-like protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044109	level of peptidyl-prolyl cis-trans isomerase-like 3 (human) in blood serum	PR:Q9H2H8	peptidyl-prolyl cis-trans isomerase-like 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044110	level of gigaxonin (human) in blood serum	PR:Q9H2C0	gigaxonin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044111	level of synaptotagmin-4 (human) in blood serum	PR:Q9H2B2	synaptotagmin-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044112	level of interleukin-25 (human) in blood serum	PR:Q9H293	interleukin-25 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044113	level of caspase recruitment domain-containing protein 9 (human) in blood serum	PR:Q9H257	caspase recruitment domain-containing protein 9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044114	level of cadherin-23 (human) in blood serum	PR:Q9H251	cadherin-23 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044115	level of cytosolic beta-glucosidase (human) in blood serum	PR:Q9H227	cytosolic beta-glucosidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044116	level of EH domain-containing protein 4 (human) in blood serum	PR:Q9H223	EH domain-containing protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044117	level of mediator of RNA polymerase II transcription subunit 28 (human) in blood serum	PR:Q9H204	mediator of RNA polymerase II transcription subunit 28 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044118	level of augurin (human) in blood serum	PR:Q9H1Z8	augurin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044119	level of autophagy protein 5 (human) in blood serum	PR:Q9H1Y0	autophagy protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044120	level of dual specificity protein phosphatase 15 (human) in blood serum	PR:Q9H1R2	dual specificity protein phosphatase 15 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044121	level of Golgi-associated plant pathogenesis-related protein 1 (human) in blood serum	PR:Q9H4G4	Golgi-associated plant pathogenesis-related protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044122	level of band 4.1-like protein 1 (human) in blood serum	PR:Q9H4G0	band 4.1-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044123	level of alpha-N-acetyl-neuraminyl-2,3-beta-galactosyl-1,3-N-acetyl-galactosaminide alpha-2,6-sialyltransferase (human) in blood serum	PR:Q9H4F1	alpha-N-acetyl-neuraminyl-2,3-beta-galactosyl-1,3-N-acetyl-galactosaminide alpha-2,6-sialyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044124	level of differentially expressed in FDCP 6 homolog (human) in blood serum	PR:Q9H4E7	differentially expressed in FDCP 6 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044125	level of calsyntenin-2 (human) in blood serum	PR:Q9H4D0	calsyntenin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044126	level of dipeptidase 2 (human) in blood serum	PR:Q9H4A9	dipeptidase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044127	level of Golgi phosphoprotein 3 (human) in blood serum	PR:Q9H4A6	Golgi phosphoprotein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044128	level of Golgi phosphoprotein 3-like (human) in blood serum	PR:Q9H4A5	Golgi phosphoprotein 3-like (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044129	level of aminopeptidase B (human) in blood serum	PR:Q9H4A4	aminopeptidase B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044130	level of serine/threonine-protein kinase WNK1 (human) in blood serum	PR:Q9H4A3	serine/threonine-protein kinase WNK1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044131	level of microtubule-associated proteins 1A/1B light chain 3A (human) in blood serum	PR:Q9H492	microtubule-associated proteins 1A/1B light chain 3A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044132	level of GDP-fucose protein O-fucosyltransferase 1 (human) in blood serum	PR:Q9H488	GDP-fucose protein O-fucosyltransferase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044133	level of fructosamine-3-kinase (human) in blood serum	PR:Q9H479	fructosamine-3-kinase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044134	level of frizzled-8 (human) in blood serum	PR:Q9H461	frizzled-8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044135	level of RWD domain-containing protein 1 (human) in blood serum	PR:Q9H446	RWD domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044136	level of uncharacterized protein C1orf198 (human) in blood serum	PR:Q9H425	uncharacterized protein C1orf198 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044137	level of SPARC-related modular calcium-binding protein 2 (human) in blood serum	PR:Q9H3U7	SPARC-related modular calcium-binding protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044138	level of protein unc-45 homolog A (human) in blood serum	PR:Q9H3U1	protein unc-45 homolog A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044139	level of semaphorin-6C (human) in blood serum	PR:Q9H3T2	semaphorin-6C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044140	level of thiamin pyrophosphokinase 1 (human) in blood serum	PR:Q9H3S4	thiamin pyrophosphokinase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044141	level of transmembrane protease serine 5 (human) in blood serum	PR:Q9H3S3	transmembrane protease serine 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044142	level of semaphorin-4A (human) in blood serum	PR:Q9H3S1	semaphorin-4A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044143	level of lysine-specific demethylase 4C (human) in blood serum	PR:Q9H3R0	lysine-specific demethylase 4C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044144	level of Cdc42 effector protein 4 (human) in blood serum	PR:Q9H3Q1	Cdc42 effector protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044145	level of negative elongation factor A (human) in blood serum	PR:Q9H3P2	negative elongation factor A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044146	level of thioredoxin-related transmembrane protein 1 (human) in blood serum	PR:Q9H3N1	thioredoxin-related transmembrane protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044147	level of thioredoxin-interacting protein (human) in blood serum	PR:Q9H3M7	thioredoxin-interacting protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044148	level of potassium voltage-gated channel subfamily F member 1 (human) in blood serum	PR:Q9H3M0	potassium voltage-gated channel subfamily F member 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044149	level of cobalamin trafficking protein CblD (human) in blood serum	PR:Q9H3L0	cobalamin trafficking protein CblD (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044150	level of BolA-like protein 2 (human) in blood serum	PR:Q9H3K6	BolA-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044151	level of mitochondrial translation release factor in rescue (human) in blood serum	PR:Q9H3J6	mitochondrial translation release factor in rescue (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044152	level of prostaglandin E synthase 2 (human) in blood serum	PR:Q9H7Z7	prostaglandin E synthase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044153	level of intraflagellar transport protein 22 homolog (human) in blood serum	PR:Q9H7X7	intraflagellar transport protein 22 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044154	level of zinc finger protein 696 (human) in blood serum	PR:Q9H7X3	zinc finger protein 696 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044155	level of required for drug-induced death protein 1 (human) in blood serum	PR:Q9H7X2	required for drug-induced death protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044156	level of multivesicular body subunit 12B (human) in blood serum	PR:Q9H7P6	multivesicular body subunit 12B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044157	level of WD repeat-containing protein 26 (human) in blood serum	PR:Q9H7D7	WD repeat-containing protein 26 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044158	level of Mth938 domain-containing protein (human) in blood serum	PR:Q9H7C9	Mth938 domain-containing protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044159	level of zinc phosphodiesterase ELAC protein 1 (human) in blood serum	PR:Q9H777	zinc phosphodiesterase ELAC protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044160	level of gremlin-2 (human) in blood serum	PR:Q9H772	gremlin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044161	level of ankyrin repeat and SOCS box protein 8 (human) in blood serum	PR:Q9H765	ankyrin repeat and SOCS box protein 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044162	level of prolyl hydroxylase EGLN3 (human) in blood serum	PR:Q9H6Z9	prolyl hydroxylase EGLN3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044163	level of Ran-binding protein 3 (human) in blood serum	PR:Q9H6Z4	Ran-binding protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044164	level of PDZ domain-containing protein MAGIX (human) in blood serum	PR:Q9H6Y5	PDZ domain-containing protein MAGIX (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044165	level of anthrax toxin receptor 1 (human) in blood serum	PR:Q9H6X2	anthrax toxin receptor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044166	level of epidermal growth factor receptor kinase substrate 8-like protein 2 (human) in blood serum	PR:Q9H6S3	epidermal growth factor receptor kinase substrate 8-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044167	level of reticulophagy regulator 1 (human) in blood serum	PR:Q9H6L5	reticulophagy regulator 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044168	level of centriolar satellite-associated tubulin polyglutamylase complex regulator 1 (human) in blood serum	PR:Q9H6J7	centriolar satellite-associated tubulin polyglutamylase complex regulator 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044169	level of coiled-coil domain-containing protein 134 (human) in blood serum	PR:Q9H6E4	coiled-coil domain-containing protein 134 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044170	level of fibronectin type III domain-containing protein 4 (human) in blood serum	PR:Q9H6D8	fibronectin type III domain-containing protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044171	level of IGF-like family receptor 1 (human) in blood serum	PR:Q9H665	IGF-like family receptor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044172	level of SLIT and NTRK-like protein 6 (human) in blood serum	PR:Q9H5Y7	SLIT and NTRK-like protein 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044173	level of CUB domain-containing protein 1 (human) in blood serum	PR:Q9H5V8	CUB domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044174	level of dimethyladenosine transferase 2, mitochondrial (human) in blood serum	PR:Q9H5Q4	dimethyladenosine transferase 2, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044175	level of PDZ domain-containing protein 7 (human) in blood serum	PR:Q9H5P4	PDZ domain-containing protein 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044176	level of dual specificity protein phosphatase 21 (human) in blood serum	PR:Q9H596	dual specificity protein phosphatase 21 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044177	level of alpha-1,3/1,6-mannosyltransferase ALG2 (human) in blood serum	PR:Q9H553	alpha-1,3/1,6-mannosyltransferase ALG2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044178	level of E3 ubiquitin-protein ligase NRDP1 (human) in blood serum	PR:Q9H4P4	E3 ubiquitin-protein ligase NRDP1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044179	level of EH domain-containing protein 1 (human) in blood serum	PR:Q9H4M9	EH domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044180	level of pleckstrin homology domain-containing family A member 4 (human) in blood serum	PR:Q9H4M7	pleckstrin homology domain-containing family A member 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044181	level of TraB domain-containing protein (human) in blood serum	PR:Q9H4I3	TraB domain-containing protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044182	level of zinc fingers and homeoboxes protein 3 (human) in blood serum	PR:Q9H4I2	zinc fingers and homeoboxes protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044183	level of E3 ubiquitin-protein ligase SMURF2 (human) in blood serum	PR:Q9HAU4	E3 ubiquitin-protein ligase SMURF2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044184	level of E3 ubiquitin-protein ligase pellino homolog 2 (human) in blood serum	PR:Q9HAT8	E3 ubiquitin-protein ligase pellino homolog 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044185	level of adhesion G protein-coupled receptor L3 (human) in blood serum	PR:Q9HAR2	adhesion G protein-coupled receptor L3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044186	level of nicotinamide/nicotinic acid mononucleotide adenylyltransferase 1 (human) in blood serum	PR:Q9HAN9	nicotinamide/nicotinic acid mononucleotide adenylyltransferase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044187	level of histone deacetylase complex subunit SAP30L (human) in blood serum	PR:Q9HAJ7	histone deacetylase complex subunit SAP30L (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044188	level of calaxin (human) in blood serum	PR:Q9HAE3	calaxin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044189	level of phosphopantothenate--cysteine ligase (human) in blood serum	PR:Q9HAB8	phosphopantothenate--cysteine ligase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044190	level of RING finger protein 122 (human) in blood serum	PR:Q9H9V4	RING finger protein 122 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044191	level of calcium-binding protein 39-like (human) in blood serum	PR:Q9H9S4	calcium-binding protein 39-like (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044192	level of dysbindin domain-containing protein 1 (human) in blood serum	PR:Q9H9R9	dysbindin domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044193	level of non-homologous end-joining factor 1 (human) in blood serum	PR:Q9H9Q4	non-homologous end-joining factor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044194	level of COP9 signalosome complex subunit 7b (human) in blood serum	PR:Q9H9Q2	COP9 signalosome complex subunit 7b (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044195	level of MAP6 domain-containing protein 1 (human) in blood serum	PR:Q9H9H5	MAP6 domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044196	level of protein argonaute-3 (human) in blood serum	PR:Q9H9G7	protein argonaute-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044197	level of ankyrin repeat family A protein 2 (human) in blood serum	PR:Q9H9E1	ankyrin repeat family A protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044198	level of RecQ-mediated genome instability protein 1 (human) in blood serum	PR:Q9H9A7	RecQ-mediated genome instability protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044199	level of pantothenate kinase 3 (human) in blood serum	PR:Q9H999	pantothenate kinase 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044200	level of queuine tRNA-ribosyltransferase accessory subunit 2 (human) in blood serum	PR:Q9H974	queuine tRNA-ribosyltransferase accessory subunit 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044201	level of mediator of RNA polymerase II transcription subunit 20 (human) in blood serum	PR:Q9H944	mediator of RNA polymerase II transcription subunit 20 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044202	level of jupiter microtubule associated homolog 2 (human) in blood serum	PR:Q9H910	jupiter microtubule associated homolog 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044203	level of bifunctional methylenetetrahydrofolate dehydrogenase/cyclohydrolase 2, mitochondrial (human) in blood serum	PR:Q9H903	bifunctional methylenetetrahydrofolate dehydrogenase/cyclohydrolase 2, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044204	level of protein zwilch homolog (human) in blood serum	PR:Q9H900	protein zwilch homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044205	level of pleckstrin homology domain-containing family F member 2 (human) in blood serum	PR:Q9H8W4	pleckstrin homology domain-containing family F member 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044206	level of protein FAM204A (human) in blood serum	PR:Q9H8W3	protein FAM204A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044207	level of AN1-type zinc finger protein 3 (human) in blood serum	PR:Q9H8U3	AN1-type zinc finger protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044208	level of MOB kinase activator 1A (human) in blood serum	PR:Q9H8S9	MOB kinase activator 1A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044209	level of multimerin-2 (human) in blood serum	PR:Q9H8L6	multimerin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044210	level of MANSC domain-containing protein 1 (human) in blood serum	PR:Q9H8J5	MANSC domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044211	level of gem-associated protein 7 (human) in blood serum	PR:Q9H840	gem-associated protein 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044212	level of ubiquitin-conjugating enzyme E2 Z (human) in blood serum	PR:Q9H832	ubiquitin-conjugating enzyme E2 Z (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044213	level of DnaJ homolog subfamily C member 18 (human) in blood serum	PR:Q9H819	DnaJ homolog subfamily C member 18 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044214	level of GPN-loop GTPase 1 (human) in blood serum	PR:Q9HCN4	GPN-loop GTPase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044215	level of plexin-A4 (human) in blood serum	PR:Q9HCM2	plexin-A4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044216	level of synaptic vesicle membrane protein VAT-1 homolog-like (human) in blood serum	PR:Q9HCJ6	synaptic vesicle membrane protein VAT-1 homolog-like (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044217	level of leucine-rich repeat-containing protein 4C (human) in blood serum	PR:Q9HCJ2	leucine-rich repeat-containing protein 4C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044218	level of synaptotagmin-like protein 2 (human) in blood serum	PR:Q9HCH5	synaptotagmin-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044219	level of E3 ubiquitin-protein ligase SMURF1 (human) in blood serum	PR:Q9HCE7	E3 ubiquitin-protein ligase SMURF1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044220	level of sentrin-specific protease 2 (human) in blood serum	PR:Q9HC62	sentrin-specific protease 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044221	level of WAP four-disulfide core domain protein 1 (human) in blood serum	PR:Q9HC57	WAP four-disulfide core domain protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044222	level of protocadherin-9 (human) in blood serum	PR:Q9HC56	protocadherin-9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044223	level of prokineticin-2 (human) in blood serum	PR:Q9HC23	prokineticin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044224	level of DNA dC->dU-editing enzyme APOBEC-3G (human) in blood serum	PR:Q9HC16	DNA dC->dU-editing enzyme APOBEC-3G (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044225	level of leucine-rich repeat-containing protein 4 (human) in blood serum	PR:Q9HBW1	leucine-rich repeat-containing protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044226	level of sperm acrosome membrane-associated protein 1 (human) in blood serum	PR:Q9HBV2	sperm acrosome membrane-associated protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044227	level of ethanolamine kinase 1 (human) in blood serum	PR:Q9HBU6	ethanolamine kinase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044228	level of cadherin-20 (human) in blood serum	PR:Q9HBT6	cadherin-20 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044229	level of kinetochore protein Spc25 (human) in blood serum	PR:Q9HBM1	kinetochore protein Spc25 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044230	level of NmrA-like family domain-containing protein 1 (human) in blood serum	PR:Q9HBL8	NmrA-like family domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044231	level of leucine-rich repeat and transmembrane domain-containing protein 1 (human) in blood serum	PR:Q9HBL6	leucine-rich repeat and transmembrane domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044232	level of arsenite methyltransferase (human) in blood serum	PR:Q9HBK9	arsenite methyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044233	level of interleukin-21 (human) in blood serum	PR:Q9HBE4	interleukin-21 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044234	level of cadherin-related family member 5 (human) in blood serum	PR:Q9HBB8	cadherin-related family member 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044235	level of Ras-related GTP-binding protein C (human) in blood serum	PR:Q9HB90	Ras-related GTP-binding protein C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044236	level of calcyclin-binding protein (human) in blood serum	PR:Q9HB71	calcyclin-binding protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044237	level of RNA polymerase II elongation factor ELL3 (human) in blood serum	PR:Q9HB65	RNA polymerase II elongation factor ELL3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044238	level of interleukin-1 receptor-like 2 (human) in blood serum	PR:Q9HB29	interleukin-1 receptor-like 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044239	level of pleckstrin homology domain-containing family A member 1 (human) in blood serum	PR:Q9HB21	pleckstrin homology domain-containing family A member 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044240	level of pleckstrin homology domain-containing family A member 3 (human) in blood serum	PR:Q9HB20	pleckstrin homology domain-containing family A member 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044241	level of MYG1 exonuclease (human) in blood serum	PR:Q9HB07	MYG1 exonuclease (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044242	level of UDP-glucuronosyltransferase 1A8 (human) in blood serum	PR:Q9HAW9	UDP-glucuronosyltransferase 1A8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044243	level of GrpE protein homolog 1, mitochondrial (human) in blood serum	PR:Q9HAV7	GrpE protein homolog 1, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044244	level of exportin-5 (human) in blood serum	PR:Q9HAV4	exportin-5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044245	level of calcium-binding protein 2 (human) in blood serum	PR:Q9NPB3	calcium-binding protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044246	level of 5'(3')-deoxyribonucleotidase, mitochondrial (human) in blood serum	PR:Q9NPB1	5'(3')-deoxyribonucleotidase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044247	level of SAYSvFN domain-containing protein 1 (human) in blood serum	PR:Q9NPB0	SAYSvFN domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044248	level of calcium-activated potassium channel subunit beta-3 (human) in blood serum	PR:Q9NPA1	calcium-activated potassium channel subunit beta-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044249	level of triggering receptor expressed on myeloid cells 1 (human) in blood serum	PR:Q9NP99	triggering receptor expressed on myeloid cells 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044250	level of DNA-directed DNA/RNA polymerase mu (human) in blood serum	PR:Q9NP87	DNA-directed DNA/RNA polymerase mu (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044251	level of calcium-binding protein 5 (human) in blood serum	PR:Q9NP86	calcium-binding protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044252	level of serine--tRNA ligase, mitochondrial (human) in blood serum	PR:Q9NP81	serine--tRNA ligase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044253	level of RNA polymerase II subunit A C-terminal domain phosphatase SSU72 (human) in blood serum	PR:Q9NP77	RNA polymerase II subunit A C-terminal domain phosphatase SSU72 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044254	level of palmdelphin (human) in blood serum	PR:Q9NP74	palmdelphin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044255	level of high mobility group protein 20A (human) in blood serum	PR:Q9NP66	high mobility group protein 20A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044256	level of zinc finger CCHC domain-containing protein 17 (human) in blood serum	PR:Q9NP64	zinc finger CCHC domain-containing protein 17 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044257	level of BPI fold-containing family A member 1 (human) in blood serum	PR:Q9NP55	BPI fold-containing family A member 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044258	level of variable charge X-linked protein 3 (human) in blood serum	PR:Q9NNX9	variable charge X-linked protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044259	level of tuftelin (human) in blood serum	PR:Q9NNX1	tuftelin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044260	level of adipocyte plasma membrane-associated protein (human) in blood serum	PR:Q9HDC9	adipocyte plasma membrane-associated protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044261	level of junctophilin-1 (human) in blood serum	PR:Q9HDC5	junctophilin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044262	level of receptor-type tyrosine-protein phosphatase H (human) in blood serum	PR:Q9HD43	receptor-type tyrosine-protein phosphatase H (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044263	level of charged multivesicular body protein 1a (human) in blood serum	PR:Q9HD42	charged multivesicular body protein 1a (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044264	level of O-phosphoseryl-tRNA(Sec) selenium transferase (human) in blood serum	PR:Q9HD40	O-phosphoseryl-tRNA(Sec) selenium transferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044265	level of Bcl-2-like protein 10 (human) in blood serum	PR:Q9HD36	Bcl-2-like protein 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044266	level of endoplasmic reticulum transmembrane helix translocase (human) in blood serum	PR:Q9HD20	endoplasmic reticulum transmembrane helix translocase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044267	level of steroid receptor RNA activator 1 (human) in blood serum	PR:Q9HD15	steroid receptor RNA activator 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044268	level of zinc finger protein 334 (human) in blood serum	PR:Q9HCZ1	zinc finger protein 334 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044269	level of protein S100-A14 (human) in blood serum	PR:Q9HCY8	protein S100-A14 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044270	level of DNA polymerase delta subunit 4 (human) in blood serum	PR:Q9HCU8	DNA polymerase delta subunit 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044271	level of endosialin (human) in blood serum	PR:Q9HCU0	endosialin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044272	level of fibroblast growth factor 22 (human) in blood serum	PR:Q9HCT0	fibroblast growth factor 22 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044273	level of polypeptide N-acetylgalactosaminyltransferase 9 (human) in blood serum	PR:Q9HCQ5	polypeptide N-acetylgalactosaminyltransferase 9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044274	level of casein kinase I isoform gamma-1 (human) in blood serum	PR:Q9HCP0	casein kinase I isoform gamma-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044275	level of stromal cell-derived factor 2-like protein 1 (human) in blood serum	PR:Q9HCN8	stromal cell-derived factor 2-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044276	level of fructose-2,6-bisphosphatase TIGAR (human) in blood serum	PR:Q9NQ88	fructose-2,6-bisphosphatase TIGAR (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044277	level of cartilage acidic protein 1 (human) in blood serum	PR:Q9NQ79	cartilage acidic protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044278	level of Cas scaffolding protein family member 4 (human) in blood serum	PR:Q9NQ75	Cas scaffolding protein family member 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044279	level of 1-phosphatidylinositol 4,5-bisphosphate phosphodiesterase beta-1 (human) in blood serum	PR:Q9NQ66	1-phosphatidylinositol 4,5-bisphosphate phosphodiesterase beta-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044280	level of equatorin (human) in blood serum	PR:Q9NQ60	equatorin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044281	level of leucine zipper transcription factor-like protein 1 (human) in blood serum	PR:Q9NQ48	leucine zipper transcription factor-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044282	level of serine protease inhibitor Kazal-type 5 (human) in blood serum	PR:Q9NQ38	serine protease inhibitor Kazal-type 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044283	level of nuclear receptor-interacting protein 3 (human) in blood serum	PR:Q9NQ35	nuclear receptor-interacting protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044284	level of complement component C1q receptor (human) in blood serum	PR:Q9NPY3	complement component C1q receptor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044285	level of semaphorin-4B (human) in blood serum	PR:Q9NPR2	semaphorin-4B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044286	level of synembryn-A (human) in blood serum	PR:Q9NPQ8	synembryn-A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044287	level of NTF2-related export protein 2 (human) in blood serum	PR:Q9NPJ8	NTF2-related export protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044288	level of mediator of RNA polymerase II transcription subunit 4 (human) in blood serum	PR:Q9NPJ6	mediator of RNA polymerase II transcription subunit 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044289	level of acyl-coenzyme A thioesterase 13 (human) in blood serum	PR:Q9NPJ3	acyl-coenzyme A thioesterase 13 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044290	level of Fanconi anemia group F protein (human) in blood serum	PR:Q9NPI8	Fanconi anemia group F protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044291	level of mRNA-decapping enzyme 1A (human) in blood serum	PR:Q9NPI6	mRNA-decapping enzyme 1A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044292	level of nicotinamide riboside kinase 2 (human) in blood serum	PR:Q9NPI5	nicotinamide riboside kinase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044293	level of interleukin-26 (human) in blood serum	PR:Q9NPH9	interleukin-26 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044294	level of odorant-binding protein 2b (human) in blood serum	PR:Q9NPH6	odorant-binding protein 2b (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044295	level of interleukin-1 receptor accessory protein (human) in blood serum	PR:Q9NPH3	interleukin-1 receptor accessory protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044296	level of lysophosphatidic acid phosphatase type 6 (human) in blood serum	PR:Q9NPH0	lysophosphatidic acid phosphatase type 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044297	level of palmitoyltransferase ZDHHC4 (human) in blood serum	PR:Q9NPG8	palmitoyltransferase ZDHHC4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044298	level of protocadherin-12 (human) in blood serum	PR:Q9NPG4	protocadherin-12 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044299	level of carbohydrate sulfotransferase 11 (human) in blood serum	PR:Q9NPF2	carbohydrate sulfotransferase 11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044300	level of CD320 antigen (human) in blood serum	PR:Q9NPF0	CD320 antigen (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044301	level of neugrin (human) in blood serum	PR:Q9NPE2	neugrin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044302	level of ubiquitin-conjugating enzyme E2 T (human) in blood serum	PR:Q9NPD8	ubiquitin-conjugating enzyme E2 T (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044303	level of myoneurin (human) in blood serum	PR:Q9NPC7	myoneurin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044304	level of lactosylceramide 4-alpha-galactosyltransferase (human) in blood serum	PR:Q9NPC4	lactosylceramide 4-alpha-galactosyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044305	level of E3 ubiquitin-protein ligase CCNB1IP1 (human) in blood serum	PR:Q9NPC3	E3 ubiquitin-protein ligase CCNB1IP1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044306	level of glycerophosphocholine phosphodiesterase GPCPD1 (human) in blood serum	PR:Q9NPB8	glycerophosphocholine phosphodiesterase GPCPD1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044307	level of N-lysine methyltransferase SMYD2 (human) in blood serum	PR:Q9NRG4	N-lysine methyltransferase SMYD2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044308	level of phosphoribosyltransferase domain-containing protein 1 (human) in blood serum	PR:Q9NRG1	phosphoribosyltransferase domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044309	level of DNA polymerase epsilon subunit 3 (human) in blood serum	PR:Q9NRF9	DNA polymerase epsilon subunit 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044310	level of PRKCA-binding protein (human) in blood serum	PR:Q9NRD5	PRKCA-binding protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044311	level of otoraplin (human) in blood serum	PR:Q9NRC9	otoraplin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044312	level of carbohydrate sulfotransferase 12 (human) in blood serum	PR:Q9NRB3	carbohydrate sulfotransferase 12 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044313	level of muscleblind-like protein 1 (human) in blood serum	PR:Q9NR56	muscleblind-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044314	level of basic leucine zipper transcriptional factor ATF-like 3 (human) in blood serum	PR:Q9NR55	basic leucine zipper transcriptional factor ATF-like 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044315	level of histone-lysine N-methyltransferase ASH1L (human) in blood serum	PR:Q9NR48	histone-lysine N-methyltransferase ASH1L (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044316	level of endophilin-B2 (human) in blood serum	PR:Q9NR46	endophilin-B2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044317	level of sialic acid synthase (human) in blood serum	PR:Q9NR45	sialic acid synthase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044318	level of mannosyl-oligosaccharide 1,2-alpha-mannosidase IC (human) in blood serum	PR:Q9NR34	mannosyl-oligosaccharide 1,2-alpha-mannosidase IC (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044319	level of GTP-binding protein SAR1a (human) in blood serum	PR:Q9NR31	GTP-binding protein SAR1a (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044320	level of growth/differentiation factor 3 (human) in blood serum	PR:Q9NR23	growth/differentiation factor 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044321	level of protein mono-ADP-ribosyltransferase PARP11 (human) in blood serum	PR:Q9NR21	protein mono-ADP-ribosyltransferase PARP11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044322	level of acetyl-coenzyme A synthetase, cytoplasmic (human) in blood serum	PR:Q9NR19	acetyl-coenzyme A synthetase, cytoplasmic (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044323	level of zinc finger C4H2 domain-containing protein (human) in blood serum	PR:Q9NQZ6	zinc finger C4H2 domain-containing protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044324	level of StAR-related lipid transfer protein 7, mitochondrial (human) in blood serum	PR:Q9NQZ5	StAR-related lipid transfer protein 7, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044325	level of bridging integrator 3 (human) in blood serum	PR:Q9NQY0	bridging integrator 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044326	level of neural proliferation differentiation and control protein 1 (human) in blood serum	PR:Q9NQX5	neural proliferation differentiation and control protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044327	level of gephyrin (human) in blood serum	PR:Q9NQX3	gephyrin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044328	level of exosome complex component RRP40 (human) in blood serum	PR:Q9NQT5	exosome complex component RRP40 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044329	level of exosome complex component RRP46 (human) in blood serum	PR:Q9NQT4	exosome complex component RRP46 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044330	level of nectin-3 (human) in blood serum	PR:Q9NQS3	nectin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044331	level of cell death regulator Aven (human) in blood serum	PR:Q9NQS1	cell death regulator Aven (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044332	level of omega-amidase NIT2 (human) in blood serum	PR:Q9NQR4	omega-amidase NIT2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044333	level of prefoldin subunit 4 (human) in blood serum	PR:Q9NQP4	prefoldin subunit 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044334	level of Xaa-Pro aminopeptidase 3 (human) in blood serum	PR:Q9NQH7	Xaa-Pro aminopeptidase 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044335	level of regulation of nuclear pre-mRNA domain-containing protein 1B (human) in blood serum	PR:Q9NQG5	regulation of nuclear pre-mRNA domain-containing protein 1B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044336	level of ubiquitin carboxyl-terminal hydrolase CYLD (human) in blood serum	PR:Q9NQC7	ubiquitin carboxyl-terminal hydrolase CYLD (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044337	level of APOBEC1 complementation factor (human) in blood serum	PR:Q9NQ94	APOBEC1 complementation factor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044338	level of teneurin-2 (human) in blood serum	PR:Q9NT68	teneurin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044339	level of ubiquitin-like-conjugating enzyme ATG3 (human) in blood serum	PR:Q9NT62	ubiquitin-like-conjugating enzyme ATG3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044340	level of StAR-related lipid transfer protein 5 (human) in blood serum	PR:Q9NSY2	StAR-related lipid transfer protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044341	level of SAM domain-containing protein SAMSN-1 (human) in blood serum	PR:Q9NSI8	SAM domain-containing protein SAMSN-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044342	level of zinc finger protein 275 (human) in blood serum	PR:Q9NSD4	zinc finger protein 275 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044343	level of alpha-N-acetylgalactosaminide alpha-2,6-sialyltransferase 1 (human) in blood serum	PR:Q9NSC7	alpha-N-acetylgalactosaminide alpha-2,6-sialyltransferase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044344	level of homer protein homolog 3 (human) in blood serum	PR:Q9NSC5	homer protein homolog 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044345	level of homer protein homolog 2 (human) in blood serum	PR:Q9NSB8	homer protein homolog 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044346	level of beta-catenin-interacting protein 1 (human) in blood serum	PR:Q9NSA3	beta-catenin-interacting protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044347	level of semaphorin-3G (human) in blood serum	PR:Q9NS98	semaphorin-3G (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044348	level of E3 ubiquitin-protein ligase RAD18 (human) in blood serum	PR:Q9NS91	E3 ubiquitin-protein ligase RAD18 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044349	level of LanC-like protein 2 (human) in blood serum	PR:Q9NS86	LanC-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044350	level of gastrokine-1 (human) in blood serum	PR:Q9NS71	gastrokine-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044351	level of thrombospondin type-1 domain-containing protein 1 (human) in blood serum	PR:Q9NS62	thrombospondin type-1 domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044352	level of CREB/ATF bZIP transcription factor (human) in blood serum	PR:Q9NS37	CREB/ATF bZIP transcription factor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044353	level of regulator of G-protein signaling 18 (human) in blood serum	PR:Q9NS28	regulator of G-protein signaling 18 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044354	level of sperm protein associated with the nucleus on the X chromosome A (human) in blood serum	PR:Q9NS26	sperm protein associated with the nucleus on the X chromosome A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044355	level of glutaredoxin-2, mitochondrial (human) in blood serum	PR:Q9NS18	glutaredoxin-2, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044356	level of glycoprotein-N-acetylgalactosamine 3-beta-galactosyltransferase 1 (human) in blood serum	PR:Q9NS00	glycoprotein-N-acetylgalactosamine 3-beta-galactosyltransferase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044357	level of phospholipid scramblase 3 (human) in blood serum	PR:Q9NRY6	phospholipid scramblase 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044358	level of SOSS complex subunit C (human) in blood serum	PR:Q9NRY2	SOSS complex subunit C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044359	level of protein kish-B (human) in blood serum	PR:Q9NRX6	protein kish-B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044360	level of 14 kDa phosphohistidine phosphatase (human) in blood serum	PR:Q9NRX4	14 kDa phosphohistidine phosphatase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044361	level of Ras-related protein Rab-6B (human) in blood serum	PR:Q9NRW1	Ras-related protein Rab-6B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044362	level of heme-binding protein 1 (human) in blood serum	PR:Q9NRV9	heme-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044363	level of sorting nexin-15 (human) in blood serum	PR:Q9NRS6	sorting nexin-15 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044364	level of ubiquilin-4 (human) in blood serum	PR:Q9NRR5	ubiquilin-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044365	level of L-aminoadipate-semialdehyde dehydrogenase-phosphopantetheinyl transferase (human) in blood serum	PR:Q9NRN7	L-aminoadipate-semialdehyde dehydrogenase-phosphopantetheinyl transferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044366	level of olfactomedin-like protein 3 (human) in blood serum	PR:Q9NRN5	olfactomedin-like protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044367	level of interleukin-17 receptor B (human) in blood serum	PR:Q9NRM6	interleukin-17 receptor B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044368	level of protein YAE1 homolog (human) in blood serum	PR:Q9NRH1	protein YAE1 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044369	level of Fas apoptotic inhibitory molecule 1 (human) in blood serum	PR:Q9NVQ4	Fas apoptotic inhibitory molecule 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044370	level of histone chaperone ASF1B (human) in blood serum	PR:Q9NVP2	histone chaperone ASF1B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044371	level of DnaJ homolog subfamily C member 17 (human) in blood serum	PR:Q9NVM6	DnaJ homolog subfamily C member 17 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044372	level of protein eva-1 homolog B (human) in blood serum	PR:Q9NVM1	protein eva-1 homolog B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044373	level of ADP-ribosylation factor-like protein 8B (human) in blood serum	PR:Q9NVJ2	ADP-ribosylation factor-like protein 8B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044374	level of DnaJ homolog subfamily C member 11 (human) in blood serum	PR:Q9NVH1	DnaJ homolog subfamily C member 11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044375	level of TBC1 domain family member 13 (human) in blood serum	PR:Q9NVG8	TBC1 domain family member 13 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044376	level of ethanolamine kinase 2 (human) in blood serum	PR:Q9NVF9	ethanolamine kinase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044377	level of alpha-parvin (human) in blood serum	PR:Q9NVD7	alpha-parvin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044378	level of septin-11 (human) in blood serum	PR:Q9NVA2	septin-11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044379	level of nucleotide triphosphate diphosphatase NUDT15 (human) in blood serum	PR:Q9NV35	nucleotide triphosphate diphosphatase NUDT15 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044380	level of S-acyl fatty acid synthase thioesterase, medium chain (human) in blood serum	PR:Q9NV23	S-acyl fatty acid synthase thioesterase, medium chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044381	level of tyrosyl-DNA phosphodiesterase 1 (human) in blood serum	PR:Q9NUW8	tyrosyl-DNA phosphodiesterase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044382	level of GTPase IMAP family member 4 (human) in blood serum	PR:Q9NUV9	GTPase IMAP family member 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044383	level of ATP-dependent RNA helicase DDX19A (human) in blood serum	PR:Q9NUU7	ATP-dependent RNA helicase DDX19A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044384	level of CYFIP-related Rac1 interactor B (human) in blood serum	PR:Q9NUQ9	CYFIP-related Rac1 interactor B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044385	level of ATP-binding cassette sub-family F member 3 (human) in blood serum	PR:Q9NUQ8	ATP-binding cassette sub-family F member 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044386	level of transmembrane protein 106B (human) in blood serum	PR:Q9NUM4	transmembrane protein 106B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044387	level of double-stranded RNA-binding protein Staufen homolog 2 (human) in blood serum	PR:Q9NUL3	double-stranded RNA-binding protein Staufen homolog 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044388	level of T-complex protein 11-like protein 1 (human) in blood serum	PR:Q9NUJ3	T-complex protein 11-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044389	level of palmitoyl-protein thioesterase ABHD10, mitochondrial (human) in blood serum	PR:Q9NUJ1	palmitoyl-protein thioesterase ABHD10, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044390	level of peroxisomal 2,4-dienoyl-CoA reductase [(3E)-enoyl-CoA-producing] (human) in blood serum	PR:Q9NUI1	peroxisomal 2,4-dienoyl-CoA reductase [(3E)-enoyl-CoA-producing] (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044391	level of p53 and DNA damage-regulated protein 1 (human) in blood serum	PR:Q9NUG6	p53 and DNA damage-regulated protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044392	level of TBC1 domain family member 22B (human) in blood serum	PR:Q9NU19	TBC1 domain family member 22B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044393	level of E3 ubiquitin-protein ligase RNF146 (human) in blood serum	PR:Q9NTX7	E3 ubiquitin-protein ligase RNF146 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044394	level of cerebellin-4 (human) in blood serum	PR:Q9NTU7	cerebellin-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044395	level of semaphorin-4G (human) in blood serum	PR:Q9NTN9	semaphorin-4G (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044396	level of copper homeostasis protein cutC homolog (human) in blood serum	PR:Q9NTM9	copper homeostasis protein cutC homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044397	level of obg-like ATPase 1 (human) in blood serum	PR:Q9NTK5	obg-like ATPase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044398	level of protein DEPP1 (human) in blood serum	PR:Q9NTK1	protein DEPP1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044399	level of NAD-dependent protein deacetylase sirtuin-3, mitochondrial (human) in blood serum	PR:Q9NTG7	NAD-dependent protein deacetylase sirtuin-3, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044400	level of pyroglutamyl-peptidase 1 (human) in blood serum	PR:Q9NXJ5	pyroglutamyl-peptidase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044401	level of torsin-4A (human) in blood serum	PR:Q9NXH8	torsin-4A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044402	level of NAD-dependent protein deacylase sirtuin-5, mitochondrial (human) in blood serum	PR:Q9NXA8	NAD-dependent protein deacylase sirtuin-5, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044403	level of WW domain binding protein 1-like (human) in blood serum	PR:Q9NX94	WW domain binding protein 1-like (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044404	level of Golgi-resident adenosine 3',5'-bisphosphate 3'-phosphatase (human) in blood serum	PR:Q9NX62	Golgi-resident adenosine 3',5'-bisphosphate 3'-phosphatase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044405	level of huntingtin-interacting protein K (human) in blood serum	PR:Q9NX55	huntingtin-interacting protein K (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044406	level of ADP-ribosylhydrolase ARH3 (human) in blood serum	PR:Q9NX46	ADP-ribosylhydrolase ARH3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044407	level of H/ACA ribonucleoprotein complex subunit 2 (human) in blood serum	PR:Q9NX24	H/ACA ribonucleoprotein complex subunit 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044408	level of NADH dehydrogenase [ubiquinone] 1 beta subcomplex subunit 11, mitochondrial (human) in blood serum	PR:Q9NX14	NADH dehydrogenase [ubiquinone] 1 beta subcomplex subunit 11, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044409	level of DNA damage-inducible transcript 4 protein (human) in blood serum	PR:Q9NX09	DNA damage-inducible transcript 4 protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044410	level of COMM domain-containing protein 8 (human) in blood serum	PR:Q9NX08	COMM domain-containing protein 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044411	level of thioredoxin-like protein 4B (human) in blood serum	PR:Q9NX01	thioredoxin-like protein 4B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044412	level of interleukin-1 receptor-associated kinase 4 (human) in blood serum	PR:Q9NWZ3	interleukin-1 receptor-associated kinase 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044413	level of probable tRNA(His) guanylyltransferase (human) in blood serum	PR:Q9NWX6	probable tRNA(His) guanylyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044414	level of phospholipase A and acyltransferase 2 (human) in blood serum	PR:Q9NWW9	phospholipase A and acyltransferase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044415	level of glucose-induced degradation protein 8 homolog (human) in blood serum	PR:Q9NWU2	glucose-induced degradation protein 8 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044416	level of 3-oxoacyl-[acyl-carrier-protein] synthase, mitochondrial (human) in blood serum	PR:Q9NWU1	3-oxoacyl-[acyl-carrier-protein] synthase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044417	level of hypoxia-inducible factor 1-alpha inhibitor (human) in blood serum	PR:Q9NWT6	hypoxia-inducible factor 1-alpha inhibitor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044418	level of protein FAM118A (human) in blood serum	PR:Q9NWS6	protein FAM118A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044419	level of PIH1 domain-containing protein 1 (human) in blood serum	PR:Q9NWS0	PIH1 domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044420	level of peptidyl-prolyl cis-trans isomerase FKBP14 (human) in blood serum	PR:Q9NWM8	peptidyl-prolyl cis-trans isomerase FKBP14 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044421	level of CUE domain-containing protein 1 (human) in blood serum	PR:Q9NWM3	CUE domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044422	level of SAFB-like transcription modulator (human) in blood serum	PR:Q9NWH9	SAFB-like transcription modulator (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044423	level of protein BEX4 (human) in blood serum	PR:Q9NWD9	protein BEX4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044424	level of RNA binding protein fox-1 homolog 1 (human) in blood serum	PR:Q9NWB1	RNA binding protein fox-1 homolog 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044425	level of pre-mRNA-splicing factor RBM22 (human) in blood serum	PR:Q9NW64	pre-mRNA-splicing factor RBM22 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044426	level of E3 ubiquitin-protein ligase FANCL (human) in blood serum	PR:Q9NW38	E3 ubiquitin-protein ligase FANCL (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044427	level of adaptin ear-binding coat-associated protein 2 (human) in blood serum	PR:Q9NVZ3	adaptin ear-binding coat-associated protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044428	level of poly(A) RNA polymerase, mitochondrial (human) in blood serum	PR:Q9NVV4	poly(A) RNA polymerase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044429	level of trimeric intracellular cation channel type B (human) in blood serum	PR:Q9NVV0	trimeric intracellular cation channel type B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044430	level of pyridoxine-5'-phosphate oxidase (human) in blood serum	PR:Q9NVS9	pyridoxine-5'-phosphate oxidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044431	level of glycolipid transfer protein (human) in blood serum	PR:Q9NZD2	glycolipid transfer protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044432	level of WW domain-containing oxidoreductase (human) in blood serum	PR:Q9NZC7	WW domain-containing oxidoreductase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044433	level of ETS homologous factor (human) in blood serum	PR:Q9NZC4	ETS homologous factor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044434	level of triggering receptor expressed on myeloid cells 2 (human) in blood serum	PR:Q9NZC2	triggering receptor expressed on myeloid cells 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044435	level of chloride intracellular channel protein 5 (human) in blood serum	PR:Q9NZA1	chloride intracellular channel protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044436	level of neuroligin-3 (human) in blood serum	PR:Q9NZ94	neuroligin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044437	level of stathmin-3 (human) in blood serum	PR:Q9NZ72	stathmin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044438	level of podocalyxin-like protein 2 (human) in blood serum	PR:Q9NZ53	podocalyxin-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044439	level of ADP-ribosylation factor-binding protein GGA3 (human) in blood serum	PR:Q9NZ52	ADP-ribosylation factor-binding protein GGA3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044440	level of CDGSH iron-sulfur domain-containing protein 1 (human) in blood serum	PR:Q9NZ45	CDGSH iron-sulfur domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044441	level of gamma-secretase subunit PEN-2 (human) in blood serum	PR:Q9NZ42	gamma-secretase subunit PEN-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044442	level of sialic acid-binding Ig-like lectin 8 (human) in blood serum	PR:Q9NYZ4	sialic acid-binding Ig-like lectin 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044443	level of neuron-specific vesicular protein calcyon (human) in blood serum	PR:Q9NYX4	neuron-specific vesicular protein calcyon (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044444	level of NF-kappa-B inhibitor-interacting Ras-like protein 1 (human) in blood serum	PR:Q9NYS0	NF-kappa-B inhibitor-interacting Ras-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044445	level of NF-kappa-B inhibitor-interacting Ras-like protein 2 (human) in blood serum	PR:Q9NYR9	NF-kappa-B inhibitor-interacting Ras-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044446	level of BET1-like protein (human) in blood serum	PR:Q9NYM9	BET1-like protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044447	level of tropomodulin-3 (human) in blood serum	PR:Q9NYL9	tropomodulin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044448	level of protein EURL homolog (human) in blood serum	PR:Q9NYK6	protein EURL homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044449	level of delta-like protein 3 (human) in blood serum	PR:Q9NYJ7	delta-like protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044450	level of cytochrome c oxidase assembly factor 4 homolog, mitochondrial (human) in blood serum	PR:Q9NYJ1	cytochrome c oxidase assembly factor 4 homolog, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044451	level of U3 small nucleolar RNA-associated protein 6 homolog (human) in blood serum	PR:Q9NYH9	U3 small nucleolar RNA-associated protein 6 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044452	level of N-acetyllactosaminide beta-1,3-N-acetylglucosaminyltransferase 2 (human) in blood serum	PR:Q9NY97	N-acetyllactosaminide beta-1,3-N-acetylglucosaminyltransferase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044453	level of sodium channel subunit beta-3 (human) in blood serum	PR:Q9NY72	sodium channel subunit beta-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044454	level of odorant-binding protein 2a (human) in blood serum	PR:Q9NY56	odorant-binding protein 2a (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044455	level of protein BTG4 (human) in blood serum	PR:Q9NY30	protein BTG4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044456	level of stabilin-1 (human) in blood serum	PR:Q9NY15	stabilin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044457	level of DnaJ homolog subfamily B member 12 (human) in blood serum	PR:Q9NXW2	DnaJ homolog subfamily B member 12 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044458	level of BTB/POZ domain-containing protein KCTD5 (human) in blood serum	PR:Q9NXV2	BTB/POZ domain-containing protein KCTD5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044459	level of ADP-ribosylation factor-like protein 15 (human) in blood serum	PR:Q9NXU5	ADP-ribosylation factor-like protein 15 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044460	level of glutaminyl-peptide cyclotransferase-like protein (human) in blood serum	PR:Q9NXS2	glutaminyl-peptide cyclotransferase-like protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044461	level of nuclear distribution protein nudE homolog 1 (human) in blood serum	PR:Q9NXR1	nuclear distribution protein nudE homolog 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044462	level of interleukin-17C (human) in blood serum	PR:Q9P0M4	interleukin-17C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044463	level of zinc finger protein with KRAB and SCAN domains 7 (human) in blood serum	PR:Q9P0L1	zinc finger protein with KRAB and SCAN domains 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044464	level of DOMON domain-containing protein FRRS1L (human) in blood serum	PR:Q9P0K9	DOMON domain-containing protein FRRS1L (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044465	level of forkhead box protein J2 (human) in blood serum	PR:Q9P0K8	forkhead box protein J2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044466	level of disintegrin and metalloproteinase domain-containing protein 22 (human) in blood serum	PR:Q9P0K1	disintegrin and metalloproteinase domain-containing protein 22 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044467	level of [pyruvate dehydrogenase [acetyl-transferring]]-phosphatase 1, mitochondrial (human) in blood serum	PR:Q9P0J1	[pyruvate dehydrogenase [acetyl-transferring]]-phosphatase 1, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044468	level of coiled-coil domain-containing protein 167 (human) in blood serum	PR:Q9P0B6	coiled-coil domain-containing protein 167 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044469	level of mediator of RNA polymerase II transcription subunit 11 (human) in blood serum	PR:Q9P086	mediator of RNA polymerase II transcription subunit 11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044470	level of thyroid transcription factor 1-associated protein 26 (human) in blood serum	PR:Q9P031	thyroid transcription factor 1-associated protein 26 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044471	level of cysteine-rich PDZ-binding protein (human) in blood serum	PR:Q9P021	cysteine-rich PDZ-binding protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044472	level of thymocyte nuclear protein 1 (human) in blood serum	PR:Q9P016	thymocyte nuclear protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044473	level of COMM domain-containing protein 9 (human) in blood serum	PR:Q9P000	COMM domain-containing protein 9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044474	level of protein PALS2 (human) in blood serum	PR:Q9NZW5	protein PALS2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044475	level of methionine-R-sulfoxide reductase B1 (human) in blood serum	PR:Q9NZV6	methionine-R-sulfoxide reductase B1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044476	level of opioid growth factor receptor (human) in blood serum	PR:Q9NZT2	opioid growth factor receptor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044477	level of visual system homeobox 1 (human) in blood serum	PR:Q9NZR4	visual system homeobox 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044478	level of tropomodulin-2 (human) in blood serum	PR:Q9NZR1	tropomodulin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044479	level of tropomodulin-4 (human) in blood serum	PR:Q9NZQ9	tropomodulin-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044480	level of NCK-interacting protein with SH3 domain (human) in blood serum	PR:Q9NZQ3	NCK-interacting protein with SH3 domain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044481	level of DnaJ homolog subfamily C member 27 (human) in blood serum	PR:Q9NZQ0	DnaJ homolog subfamily C member 27 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044482	level of complement C1r subcomponent-like protein (human) in blood serum	PR:Q9NZP8	complement C1r subcomponent-like protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044483	level of aryl-hydrocarbon-interacting protein-like 1 (human) in blood serum	PR:Q9NZN9	aryl-hydrocarbon-interacting protein-like 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044484	level of EH domain-containing protein 2 (human) in blood serum	PR:Q9NZN4	EH domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044485	level of EH domain-containing protein 3 (human) in blood serum	PR:Q9NZN3	EH domain-containing protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044486	level of interleukin-1 receptor accessory protein-like 1 (human) in blood serum	PR:Q9NZN1	interleukin-1 receptor accessory protein-like 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044487	level of methionine adenosyltransferase 2 subunit beta (human) in blood serum	PR:Q9NZL9	methionine adenosyltransferase 2 subunit beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044488	level of Hsp70-binding protein 1 (human) in blood serum	PR:Q9NZL4	Hsp70-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044489	level of transcription factor CP2-like protein 1 (human) in blood serum	PR:Q9NZI6	transcription factor CP2-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044490	level of Kv channel-interacting protein 1 (human) in blood serum	PR:Q9NZI2	Kv channel-interacting protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044491	level of interleukin-36 gamma (human) in blood serum	PR:Q9NZH8	interleukin-36 gamma (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044492	level of maspardin (human) in blood serum	PR:Q9NZD8	maspardin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044493	level of ataxin-10 (human) in blood serum	PR:Q9UBB4	ataxin-10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044494	level of protein IMPACT (human) in blood serum	PR:Q9P2X3	protein IMPACT (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044495	level of syntaxin-18 (human) in blood serum	PR:Q9P2W9	syntaxin-18 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044496	level of galactosylgalactosylxylosylprotein 3-beta-glucuronosyltransferase 1 (human) in blood serum	PR:Q9P2W7	galactosylgalactosylxylosylprotein 3-beta-glucuronosyltransferase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044497	level of homologous-pairing protein 2 homolog (human) in blood serum	PR:Q9P2W1	homologous-pairing protein 2 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044498	level of GMP reductase 2 (human) in blood serum	PR:Q9P2T1	GMP reductase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044499	level of E3 ubiquitin-protein ligase HECW2 (human) in blood serum	PR:Q9P2P5	E3 ubiquitin-protein ligase HECW2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044500	level of kelch-like protein 13 (human) in blood serum	PR:Q9P2N7	kelch-like protein 13 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044501	level of LRP2-binding protein (human) in blood serum	PR:Q9P2M1	LRP2-binding protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044502	level of kelch-like protein 14 (human) in blood serum	PR:Q9P2G3	kelch-like protein 14 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044503	level of ribosome-binding protein 1 (human) in blood serum	PR:Q9P2E9	ribosome-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044504	level of chromodomain-helicase-DNA-binding protein 7 (human) in blood serum	PR:Q9P2D1	chromodomain-helicase-DNA-binding protein 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044505	level of prostaglandin F2 receptor negative regulator (human) in blood serum	PR:Q9P2B2	prostaglandin F2 receptor negative regulator (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044506	level of ABI gene family member 3 (human) in blood serum	PR:Q9P2A4	ABI gene family member 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044507	level of BRCA2 and CDKN1A-interacting protein (human) in blood serum	PR:Q9P287	BRCA2 and CDKN1A-interacting protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044508	level of serine/threonine-protein kinase PAK 5 (human) in blood serum	PR:Q9P286	serine/threonine-protein kinase PAK 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044509	level of semaphorin-5B (human) in blood serum	PR:Q9P283	semaphorin-5B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044510	level of teneurin-3 (human) in blood serum	PR:Q9P273	teneurin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044511	level of leucine-rich repeat and fibronectin type III domain-containing protein 1 (human) in blood serum	PR:Q9P244	leucine-rich repeat and fibronectin type III domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044512	level of contactin-3 (human) in blood serum	PR:Q9P232	contactin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044513	level of collagen alpha-1(XX) chain (human) in blood serum	PR:Q9P218	collagen alpha-1(XX) chain (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044514	level of serine/threonine-protein kinase pim-2 (human) in blood serum	PR:Q9P1W9	serine/threonine-protein kinase pim-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044515	level of signal-regulatory protein gamma (human) in blood serum	PR:Q9P1W8	signal-regulatory protein gamma (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044516	level of neurotrimin (human) in blood serum	PR:Q9P121	neurotrimin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044517	level of beta-1,3-galactosyl-O-glycosyl-glycoprotein beta-1,6-N-acetylglucosaminyltransferase 4 (human) in blood serum	PR:Q9P109	beta-1,3-galactosyl-O-glycosyl-glycoprotein beta-1,6-N-acetylglucosaminyltransferase 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044518	level of peroxisomal sarcosine oxidase (human) in blood serum	PR:Q9P0Z9	peroxisomal sarcosine oxidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044519	level of SWI/SNF-related matrix-associated actin-dependent regulator of chromatin subfamily E member 1-related (human) in blood serum	PR:Q9P0W2	SWI/SNF-related matrix-associated actin-dependent regulator of chromatin subfamily E member 1-related (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044520	level of septin-10 (human) in blood serum	PR:Q9P0V9	septin-10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044521	level of SLAM family member 8 (human) in blood serum	PR:Q9P0V8	SLAM family member 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044522	level of sentrin-specific protease 1 (human) in blood serum	PR:Q9P0U3	sentrin-specific protease 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044523	level of GSK3B-interacting protein (human) in blood serum	PR:Q9P0R6	GSK3B-interacting protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044524	level of zinc finger protein 69 (human) in blood serum	PR:Q9UC07	zinc finger protein 69 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044525	level of beta-1,4-galactosyltransferase 6 (human) in blood serum	PR:Q9UBX8	beta-1,4-galactosyltransferase 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044526	level of fibulin-5 (human) in blood serum	PR:Q9UBX5	fibulin-5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044527	level of bridging integrator 2 (human) in blood serum	PR:Q9UBW5	bridging integrator 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044528	level of peflin (human) in blood serum	PR:Q9UBV8	peflin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044529	level of beta-1,4-galactosyltransferase 7 (human) in blood serum	PR:Q9UBV7	beta-1,4-galactosyltransferase 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044530	level of protein Wnt-16 (human) in blood serum	PR:Q9UBV4	protein Wnt-16 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044531	level of nuclear RNA export factor 1 (human) in blood serum	PR:Q9UBU9	nuclear RNA export factor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044532	level of mortality factor 4-like protein 1 (human) in blood serum	PR:Q9UBU8	mortality factor 4-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044533	level of appetite-regulating hormone (human) in blood serum	PR:Q9UBU3	appetite-regulating hormone (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044534	level of dickkopf-related protein 2 (human) in blood serum	PR:Q9UBU2	dickkopf-related protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044535	level of DnaJ homolog subfamily B member 9 (human) in blood serum	PR:Q9UBS3	DnaJ homolog subfamily B member 9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044536	level of ribosomal protein S6 kinase beta-2 (human) in blood serum	PR:Q9UBS0	ribosomal protein S6 kinase beta-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044537	level of beta-ureidopropionase (human) in blood serum	PR:Q9UBR1	beta-ureidopropionase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044538	level of glyoxylate reductase/hydroxypyruvate reductase (human) in blood serum	PR:Q9UBQ7	glyoxylate reductase/hydroxypyruvate reductase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044539	level of exostosin-like 2 (human) in blood serum	PR:Q9UBQ6	exostosin-like 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044540	level of vacuolar protein sorting-associated protein 29 (human) in blood serum	PR:Q9UBQ0	vacuolar protein sorting-associated protein 29 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044541	level of kidney-associated antigen 1 (human) in blood serum	PR:Q9UBP8	kidney-associated antigen 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044542	level of tRNA (guanine-N(7)-)-methyltransferase (human) in blood serum	PR:Q9UBP6	tRNA (guanine-N(7)-)-methyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044543	level of histone deacetylase 6 (human) in blood serum	PR:Q9UBN7	histone deacetylase 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044544	level of alpha-1,3-mannosyl-glycoprotein 4-beta-N-acetylglucosaminyltransferase C (human) in blood serum	PR:Q9UBM8	alpha-1,3-mannosyl-glycoprotein 4-beta-N-acetylglucosaminyltransferase C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044545	level of copine-7 (human) in blood serum	PR:Q9UBL6	copine-7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044546	level of Set1/Ash2 histone methyltransferase complex subunit ASH2 (human) in blood serum	PR:Q9UBL3	Set1/Ash2 histone methyltransferase complex subunit ASH2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044547	level of cAMP-regulated phosphoprotein 21 (human) in blood serum	PR:Q9UBL0	cAMP-regulated phosphoprotein 21 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044548	level of peroxisome proliferator-activated receptor gamma coactivator 1-alpha (human) in blood serum	PR:Q9UBK2	peroxisome proliferator-activated receptor gamma coactivator 1-alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044549	level of guanine nucleotide-binding protein G(I)/G(S)/G(O) subunit gamma-12 (human) in blood serum	PR:Q9UBI6	guanine nucleotide-binding protein G(I)/G(S)/G(O) subunit gamma-12 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044550	level of stomatin-like protein 1 (human) in blood serum	PR:Q9UBI4	stomatin-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044551	level of interleukin-36 receptor antagonist protein (human) in blood serum	PR:Q9UBH0	interleukin-36 receptor antagonist protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044552	level of cornulin (human) in blood serum	PR:Q9UBG3	cornulin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044553	level of cytokine SCM-1 beta (human) in blood serum	PR:Q9UBD3	cytokine SCM-1 beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044554	level of galanin-like peptide (human) in blood serum	PR:Q9UBC7	galanin-like peptide (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044555	level of ProSAAS (human) in blood serum	PR:Q9UHG2	ProSAAS (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044556	level of ubiquilin-2 (human) in blood serum	PR:Q9UHD9	ubiquilin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044557	level of contactin-associated protein-like 2 (human) in blood serum	PR:Q9UHC6	contactin-associated protein-like 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044558	level of LIM domain and actin-binding protein 1 (human) in blood serum	PR:Q9UHB6	LIM domain and actin-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044559	level of ragulator complex protein LAMTOR3 (human) in blood serum	PR:Q9UHA4	ragulator complex protein LAMTOR3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044560	level of Max-like protein X (human) in blood serum	PR:Q9UH92	Max-like protein X (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044561	level of kelch-like protein 3 (human) in blood serum	PR:Q9UH77	kelch-like protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044562	level of switch-associated protein 70 (human) in blood serum	PR:Q9UH65	switch-associated protein 70 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044563	level of neuronal-specific septin-3 (human) in blood serum	PR:Q9UH03	neuronal-specific septin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044564	level of protein NDRG3 (human) in blood serum	PR:Q9UGV2	protein NDRG3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044565	level of LIM domain-containing protein 1 (human) in blood serum	PR:Q9UGP4	LIM domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044566	level of CMRF35-like molecule 8 (human) in blood serum	PR:Q9UGN4	CMRF35-like molecule 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044567	level of tryptophan--tRNA ligase, mitochondrial (human) in blood serum	PR:Q9UGM6	tryptophan--tRNA ligase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044568	level of deleted in malignant brain tumors 1 protein (human) in blood serum	PR:Q9UGM3	deleted in malignant brain tumors 1 protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044569	level of testin (human) in blood serum	PR:Q9UGI8	testin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044570	level of ubiquitin thioesterase ZRANB1 (human) in blood serum	PR:Q9UGI0	ubiquitin thioesterase ZRANB1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044571	level of peptide chain release factor 1-like, mitochondrial (human) in blood serum	PR:Q9UGC7	peptide chain release factor 1-like, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044572	level of inositol oxygenase (human) in blood serum	PR:Q9UGB7	inositol oxygenase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044573	level of CGG triplet repeat-binding protein 1 (human) in blood serum	PR:Q9UFW8	CGG triplet repeat-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044574	level of DnaJ homolog subfamily C member 5B (human) in blood serum	PR:Q9UF47	DnaJ homolog subfamily C member 5B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044575	level of ephrin type-A receptor 6 (human) in blood serum	PR:Q9UF33	ephrin type-A receptor 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044576	level of pleckstrin homology domain-containing family B member 1 (human) in blood serum	PR:Q9UF11	pleckstrin homology domain-containing family B member 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044577	level of macrophage receptor MARCO (human) in blood serum	PR:Q9UEW3	macrophage receptor MARCO (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044578	level of G antigen 2D (human) in blood serum	PR:Q9UEU5	G antigen 2D (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044579	level of vesicle transport through interaction with t-SNAREs homolog 1B (human) in blood serum	PR:Q9UEU0	vesicle transport through interaction with t-SNAREs homolog 1B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044580	level of death domain-associated protein 6 (human) in blood serum	PR:Q9UER7	death domain-associated protein 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044581	level of klotho (human) in blood serum	PR:Q9UEF7	klotho (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044582	level of craniofacial development protein 1 (human) in blood serum	PR:Q9UEE9	craniofacial development protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044583	level of mucosa-associated lymphoid tissue lymphoma translocation protein 1 (human) in blood serum	PR:Q9UDY8	mucosa-associated lymphoid tissue lymphoma translocation protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044584	level of DnaJ homolog subfamily B member 4 (human) in blood serum	PR:Q9UDY4	DnaJ homolog subfamily B member 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044585	level of SEC14-like protein 4 (human) in blood serum	PR:Q9UDX3	SEC14-like protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044586	level of 2-hydroxyacyl-CoA lyase 1 (human) in blood serum	PR:Q9UJ83	2-hydroxyacyl-CoA lyase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044587	level of annexin A10 (human) in blood serum	PR:Q9UJ72	annexin A10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044588	level of mitochondrial peptide methionine sulfoxide reductase (human) in blood serum	PR:Q9UJ68	mitochondrial peptide methionine sulfoxide reductase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044589	level of alpha-N-acetylgalactosaminide alpha-2,6-sialyltransferase 2 (human) in blood serum	PR:Q9UJ37	alpha-N-acetylgalactosaminide alpha-2,6-sialyltransferase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044590	level of plexin-A1 (human) in blood serum	PR:Q9UIW2	plexin-A1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044591	level of serpin B13 (human) in blood serum	PR:Q9UIV8	serpin B13 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044592	level of PHD finger protein 11 (human) in blood serum	PR:Q9UIL8	PHD finger protein 11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044593	level of E3 ISG15--protein ligase HERC5 (human) in blood serum	PR:Q9UII4	E3 ISG15--protein ligase HERC5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044594	level of ATPase inhibitor, mitochondrial (human) in blood serum	PR:Q9UII2	ATPase inhibitor, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044595	level of adenine DNA glycosylase (human) in blood serum	PR:Q9UIF7	adenine DNA glycosylase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044596	level of zinc finger protein 230 (human) in blood serum	PR:Q9UIE0	zinc finger protein 230 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044597	level of cytohesin-4 (human) in blood serum	PR:Q9UIA0	cytohesin-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044598	level of catenin alpha-3 (human) in blood serum	PR:Q9UI47	catenin alpha-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044599	level of dynein axonemal intermediate chain 1 (human) in blood serum	PR:Q9UI46	dynein axonemal intermediate chain 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044600	level of rRNA methyltransferase 2, mitochondrial (human) in blood serum	PR:Q9UI43	rRNA methyltransferase 2, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044601	level of carboxypeptidase A4 (human) in blood serum	PR:Q9UI42	carboxypeptidase A4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044602	level of multifunctional methyltransferase subunit TRM112-like protein (human) in blood serum	PR:Q9UI30	multifunctional methyltransferase subunit TRM112-like protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044603	level of transgelin-3 (human) in blood serum	PR:Q9UI15	transgelin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044604	level of ena/VASP-like protein (human) in blood serum	PR:Q9UI08	ena/VASP-like protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044605	level of nuclear receptor-binding protein (human) in blood serum	PR:Q9UHY1	nuclear receptor-binding protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044606	level of poly(U)-binding-splicing factor PUF60 (human) in blood serum	PR:Q9UHX1	poly(U)-binding-splicing factor PUF60 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044607	level of prefoldin subunit 2 (human) in blood serum	PR:Q9UHV9	prefoldin subunit 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044608	level of galactoside-binding soluble lectin 13 (human) in blood serum	PR:Q9UHV8	galactoside-binding soluble lectin 13 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044609	level of NADH-cytochrome b5 reductase 1 (human) in blood serum	PR:Q9UHQ9	NADH-cytochrome b5 reductase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044610	level of B-cell receptor-associated protein 29 (human) in blood serum	PR:Q9UHQ4	B-cell receptor-associated protein 29 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044611	level of nuclear prelamin A recognition factor (human) in blood serum	PR:Q9UHQ1	nuclear prelamin A recognition factor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044612	level of C-type lectin domain family 2 member D (human) in blood serum	PR:Q9UHP7	C-type lectin domain family 2 member D (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044613	level of cell surface hyaluronidase (human) in blood serum	PR:Q9UHN6	cell surface hyaluronidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044614	level of ATP-dependent RNA helicase DDX25 (human) in blood serum	PR:Q9UHL0	ATP-dependent RNA helicase DDX25 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044615	level of inositol hexakisphosphate kinase 2 (human) in blood serum	PR:Q9UHH9	inositol hexakisphosphate kinase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044616	level of prenylcysteine oxidase 1 (human) in blood serum	PR:Q9UHG3	prenylcysteine oxidase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044617	level of peroxisomal carnitine O-octanoyltransferase (human) in blood serum	PR:Q9UKG9	peroxisomal carnitine O-octanoyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044618	level of DCC-interacting protein 13-alpha (human) in blood serum	PR:Q9UKG1	DCC-interacting protein 13-alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044619	level of disintegrin and metalloproteinase domain-containing protein 29 (human) in blood serum	PR:Q9UKF5	disintegrin and metalloproteinase domain-containing protein 29 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044620	level of disintegrin and metalloproteinase domain-containing protein 30 (human) in blood serum	PR:Q9UKF2	disintegrin and metalloproteinase domain-containing protein 30 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044621	level of mRNA turnover protein 4 homolog (human) in blood serum	PR:Q9UKD2	mRNA turnover protein 4 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044622	level of DnaJ homolog subfamily C member 12 (human) in blood serum	PR:Q9UKB3	DnaJ homolog subfamily C member 12 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044623	level of calcipressin-3 (human) in blood serum	PR:Q9UKA8	calcipressin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044624	level of F-box/LRR-repeat protein 5 (human) in blood serum	PR:Q9UKA1	F-box/LRR-repeat protein 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044625	level of F-box only protein 3 (human) in blood serum	PR:Q9UK99	F-box only protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044626	level of ubiquitin carboxyl-terminal hydrolase 21 (human) in blood serum	PR:Q9UK80	ubiquitin carboxyl-terminal hydrolase 21 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044627	level of jupiter microtubule associated homolog 1 (human) in blood serum	PR:Q9UK76	jupiter microtubule associated homolog 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044628	level of zinc finger protein 580 (human) in blood serum	PR:Q9UK33	zinc finger protein 580 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044629	level of ribosomal protein S6 kinase alpha-6 (human) in blood serum	PR:Q9UK32	ribosomal protein S6 kinase alpha-6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044630	level of transmembrane protein 59-like (human) in blood serum	PR:Q9UK28	transmembrane protein 59-like (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044631	level of N-acetylglucosamine-1-phosphodiester alpha-N-acetylglucosaminidase (human) in blood serum	PR:Q9UK23	N-acetylglucosamine-1-phosphodiester alpha-N-acetylglucosaminidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044632	level of uncharacterized protein C3orf18 (human) in blood serum	PR:Q9UK00	uncharacterized protein C3orf18 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044633	level of stomatin-like protein 2, mitochondrial (human) in blood serum	PR:Q9UJZ1	stomatin-like protein 2, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044634	level of ADP-ribosylation factor-binding protein GGA1 (human) in blood serum	PR:Q9UJY5	ADP-ribosylation factor-binding protein GGA1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044635	level of anaphase-promoting complex subunit 7 (human) in blood serum	PR:Q9UJX3	anaphase-promoting complex subunit 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044636	level of SERTA domain-containing protein 3 (human) in blood serum	PR:Q9UJW9	SERTA domain-containing protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044637	level of zinc finger protein 180 (human) in blood serum	PR:Q9UJW8	zinc finger protein 180 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044638	level of DNA (cytosine-5)-methyltransferase 3-like (human) in blood serum	PR:Q9UJW3	DNA (cytosine-5)-methyltransferase 3-like (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044639	level of probable E3 ubiquitin-protein ligase MID2 (human) in blood serum	PR:Q9UJV3	probable E3 ubiquitin-protein ligase MID2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044640	level of SCP2 sterol-binding domain-containing protein 1 (human) in blood serum	PR:Q9UJQ7	SCP2 sterol-binding domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044641	level of 2-hydroxyacid oxidase 1 (human) in blood serum	PR:Q9UJM8	2-hydroxyacid oxidase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044642	level of 18S rRNA aminocarboxypropyltransferase (human) in blood serum	PR:Q9UJK0	18S rRNA aminocarboxypropyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044643	level of N-acetylglucosamine-1-phosphotransferase subunit gamma (human) in blood serum	PR:Q9UJJ9	N-acetylglucosamine-1-phosphotransferase subunit gamma (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044644	level of motile sperm domain-containing protein 1 (human) in blood serum	PR:Q9UJG1	motile sperm domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044645	level of SH3 domain-binding glutamic acid-rich-like protein 2 (human) in blood serum	PR:Q9UJC5	SH3 domain-binding glutamic acid-rich-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044646	level of ectonucleotide pyrophosphatase/phosphodiesterase family member 5 (human) in blood serum	PR:Q9UJA9	ectonucleotide pyrophosphatase/phosphodiesterase family member 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044647	level of tRNA (adenine(58)-N(1))-methyltransferase non-catalytic subunit TRM6 (human) in blood serum	PR:Q9UJA5	tRNA (adenine(58)-N(1))-methyltransferase non-catalytic subunit TRM6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044648	level of proteasome activator complex subunit 2 (human) in blood serum	PR:Q9UL46	proteasome activator complex subunit 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044649	level of biogenesis of lysosome-related organelles complex 1 subunit 6 (human) in blood serum	PR:Q9UL45	biogenesis of lysosome-related organelles complex 1 subunit 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044650	level of paraneoplastic antigen Ma2 (human) in blood serum	PR:Q9UL42	paraneoplastic antigen Ma2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044651	level of Ras-related protein Rab-22A (human) in blood serum	PR:Q9UL26	Ras-related protein Rab-22A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044652	level of Ras-related protein Rab-21 (human) in blood serum	PR:Q9UL25	Ras-related protein Rab-21 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044653	level of phospholipase A and acyltransferase 4 (human) in blood serum	PR:Q9UL19	phospholipase A and acyltransferase 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044654	level of protein argonaute-1 (human) in blood serum	PR:Q9UL18	protein argonaute-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044655	level of cilia- and flagella-associated protein 45 (human) in blood serum	PR:Q9UL16	cilia- and flagella-associated protein 45 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044656	level of BAG family molecular chaperone regulator 5 (human) in blood serum	PR:Q9UL15	BAG family molecular chaperone regulator 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044657	level of procollagen C-endopeptidase enhancer 2 (human) in blood serum	PR:Q9UKZ9	procollagen C-endopeptidase enhancer 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044658	level of zinc fingers and homeoboxes protein 1 (human) in blood serum	PR:Q9UKY1	zinc fingers and homeoboxes protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044659	level of prion-like protein doppel (human) in blood serum	PR:Q9UKY0	prion-like protein doppel (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044660	level of integrin alpha-11 (human) in blood serum	PR:Q9UKX5	integrin alpha-11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044661	level of ETS-related transcription factor Elf-5 (human) in blood serum	PR:Q9UKW6	ETS-related transcription factor Elf-5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044662	level of guanine nucleotide exchange factor VAV3 (human) in blood serum	PR:Q9UKW4	guanine nucleotide exchange factor VAV3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044663	level of protein argonaute-2 (human) in blood serum	PR:Q9UKV8	protein argonaute-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044664	level of isobutyryl-CoA dehydrogenase, mitochondrial (human) in blood serum	PR:Q9UKU7	isobutyryl-CoA dehydrogenase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044665	level of protein kinase C and casein kinase substrate in neurons protein 3 (human) in blood serum	PR:Q9UKS6	protein kinase C and casein kinase substrate in neurons protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044666	level of kallikrein-9 (human) in blood serum	PR:Q9UKQ9	kallikrein-9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044667	level of disintegrin and metalloproteinase domain-containing protein 28 (human) in blood serum	PR:Q9UKQ2	disintegrin and metalloproteinase domain-containing protein 28 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044668	level of urotensin-2 receptor (human) in blood serum	PR:Q9UKP6	urotensin-2 receptor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044669	level of a disintegrin and metalloproteinase with thrombospondin motifs 6 (human) in blood serum	PR:Q9UKP5	a disintegrin and metalloproteinase with thrombospondin motifs 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044670	level of integrin beta-1-binding protein 2 (human) in blood serum	PR:Q9UKP3	integrin beta-1-binding protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044671	level of PR domain zinc finger protein 4 (human) in blood serum	PR:Q9UKN5	PR domain zinc finger protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044672	level of endoplasmic reticulum mannosyl-oligosaccharide 1,2-alpha-mannosidase (human) in blood serum	PR:Q9UKM7	endoplasmic reticulum mannosyl-oligosaccharide 1,2-alpha-mannosidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044673	level of phosphatidylcholine transfer protein (human) in blood serum	PR:Q9UKL6	phosphatidylcholine transfer protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044674	level of gap junction delta-2 protein (human) in blood serum	PR:Q9UKL4	gap junction delta-2 protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044675	level of ADP-sugar pyrophosphatase (human) in blood serum	PR:Q9UKK9	ADP-sugar pyrophosphatase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044676	level of NTF2-related export protein 1 (human) in blood serum	PR:Q9UKK6	NTF2-related export protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044677	level of paired immunoglobulin-like type 2 receptor alpha (human) in blood serum	PR:Q9UKJ1	paired immunoglobulin-like type 2 receptor alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044678	level of serine/threonine-protein kinase tousled-like 1 (human) in blood serum	PR:Q9UKI8	serine/threonine-protein kinase tousled-like 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044679	level of guanylyl cyclase-activating protein 2 (human) in blood serum	PR:Q9UMX6	guanylyl cyclase-activating protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044680	level of neudesin (human) in blood serum	PR:Q9UMX5	neudesin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044681	level of suppressor of fused homolog (human) in blood serum	PR:Q9UMX1	suppressor of fused homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044682	level of pre-mRNA-processing factor 19 (human) in blood serum	PR:Q9UMS4	pre-mRNA-processing factor 19 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044683	level of NFU1 iron-sulfur cluster scaffold homolog, mitochondrial (human) in blood serum	PR:Q9UMS0	NFU1 iron-sulfur cluster scaffold homolog, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044684	level of C-type lectin domain family 4 member A (human) in blood serum	PR:Q9UMR7	C-type lectin domain family 4 member A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044685	level of ALK tyrosine kinase receptor (human) in blood serum	PR:Q9UM73	ALK tyrosine kinase receptor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044686	level of unconventional myosin-VI (human) in blood serum	PR:Q9UM54	unconventional myosin-VI (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044687	level of mammalian ependymin-related protein 1 (human) in blood serum	PR:Q9UM22	mammalian ependymin-related protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044688	level of alpha-1,3-mannosyl-glycoprotein 4-beta-N-acetylglucosaminyltransferase A (human) in blood serum	PR:Q9UM21	alpha-1,3-mannosyl-glycoprotein 4-beta-N-acetylglucosaminyltransferase A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044689	level of anaphase-promoting complex subunit 10 (human) in blood serum	PR:Q9UM13	anaphase-promoting complex subunit 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044690	level of protein-arginine deiminase type-4 (human) in blood serum	PR:Q9UM07	protein-arginine deiminase type-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044691	level of apoptosis-associated speck-like protein containing a CARD (human) in blood serum	PR:Q9ULZ3	apoptosis-associated speck-like protein containing a CARD (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044692	level of signal-transducing adaptor protein 1 (human) in blood serum	PR:Q9ULZ2	signal-transducing adaptor protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044693	level of apelin (human) in blood serum	PR:Q9ULZ1	apelin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044694	level of nucleosome assembly protein 1-like 2 (human) in blood serum	PR:Q9ULW6	nucleosome assembly protein 1-like 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044695	level of Ras-related protein Rab-26 (human) in blood serum	PR:Q9ULW5	Ras-related protein Rab-26 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044696	level of E3 ubiquitin-protein ligase CBL-C (human) in blood serum	PR:Q9ULV8	E3 ubiquitin-protein ligase CBL-C (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044697	level of frizzled-4 (human) in blood serum	PR:Q9ULV1	frizzled-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044698	level of TBC1 domain family member 24 (human) in blood serum	PR:Q9ULP9	TBC1 domain family member 24 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044699	level of protein NDRG4 (human) in blood serum	PR:Q9ULP0	protein NDRG4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044700	level of plexin-B3 (human) in blood serum	PR:Q9ULL4	plexin-B3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044701	level of RING finger protein 150 (human) in blood serum	PR:Q9ULK6	RING finger protein 150 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044702	level of glutamate receptor ionotropic, delta-1 (human) in blood serum	PR:Q9ULK0	glutamate receptor ionotropic, delta-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044703	level of leucine-rich repeat and fibronectin type-III domain-containing protein 2 (human) in blood serum	PR:Q9ULH4	leucine-rich repeat and fibronectin type-III domain-containing protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044704	level of cell cycle progression protein 1 (human) in blood serum	PR:Q9ULG6	cell cycle progression protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044705	level of malignant T-cell-amplified sequence 1 (human) in blood serum	PR:Q9ULC4	malignant T-cell-amplified sequence 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044706	level of Ras-related protein Rab-23 (human) in blood serum	PR:Q9ULC3	Ras-related protein Rab-23 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044707	level of cadherin-7 (human) in blood serum	PR:Q9ULB5	cadherin-7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044708	level of neurexin-1-alpha (human) in blood serum	PR:Q9ULB1	neurexin-1-alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044709	level of aspartyl aminopeptidase (human) in blood serum	PR:Q9ULA0	aspartyl aminopeptidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044710	level of DNA-binding protein SATB2 (human) in blood serum	PR:Q9UPW6	DNA-binding protein SATB2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044711	level of VPS10 domain-containing receptor SorCS3 (human) in blood serum	PR:Q9UPU3	VPS10 domain-containing receptor SorCS3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044712	level of ubiquitin carboxyl-terminal hydrolase 22 (human) in blood serum	PR:Q9UPT9	ubiquitin carboxyl-terminal hydrolase 22 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044713	level of exocyst complex component 7 (human) in blood serum	PR:Q9UPT5	exocyst complex component 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044714	level of trinucleotide repeat-containing gene 6B protein (human) in blood serum	PR:Q9UPQ9	trinucleotide repeat-containing gene 6B protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044715	level of transferrin receptor protein 2 (human) in blood serum	PR:Q9UP52	transferrin receptor protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044716	level of frizzled-1 (human) in blood serum	PR:Q9UP38	frizzled-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044717	level of leydig cell tumor 10 kDa protein homolog (human) in blood serum	PR:Q9UNZ5	leydig cell tumor 10 kDa protein homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044718	level of 60S ribosomal protein L26-like 1 (human) in blood serum	PR:Q9UNX3	60S ribosomal protein L26-like 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044719	level of multiple inositol polyphosphate phosphatase 1 (human) in blood serum	PR:Q9UNW1	multiple inositol polyphosphate phosphatase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044720	level of protein timeless homolog (human) in blood serum	PR:Q9UNS1	protein timeless homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044721	level of probable dimethyladenosine transferase (human) in blood serum	PR:Q9UNQ2	probable dimethyladenosine transferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044722	level of lactosylceramide alpha-2,3-sialyltransferase (human) in blood serum	PR:Q9UNP4	lactosylceramide alpha-2,3-sialyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044723	level of endothelial protein C receptor (human) in blood serum	PR:Q9UNN8	endothelial protein C receptor (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044724	level of inhibitor of growth protein 4 (human) in blood serum	PR:Q9UNL4	inhibitor of growth protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044725	level of group IID secretory phospholipase A2 (human) in blood serum	PR:Q9UNK4	group IID secretory phospholipase A2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044726	level of syntaxin-8 (human) in blood serum	PR:Q9UNK0	syntaxin-8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044727	level of chymotrypsin-like elastase family member 1 (human) in blood serum	PR:Q9UNI1	chymotrypsin-like elastase family member 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044728	level of protein kinase C and casein kinase substrate in neurons protein 2 (human) in blood serum	PR:Q9UNF0	protein kinase C and casein kinase substrate in neurons protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044729	level of DNA polymerase iota (human) in blood serum	PR:Q9UNA4	DNA polymerase iota (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044730	level of alpha-1,4-N-acetylglucosaminyltransferase (human) in blood serum	PR:Q9UNA3	alpha-1,4-N-acetylglucosaminyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044731	level of Rho GTPase-activating protein 26 (human) in blood serum	PR:Q9UNA1	Rho GTPase-activating protein 26 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044732	level of sodium- and chloride-dependent neutral and basic amino acid transporter B(0+) (human) in blood serum	PR:Q9UN76	sodium- and chloride-dependent neutral and basic amino acid transporter B(0+) (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044733	level of protocadherin alpha-4 (human) in blood serum	PR:Q9UN74	protocadherin alpha-4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044734	level of protocadherin alpha-7 (human) in blood serum	PR:Q9UN72	protocadherin alpha-7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044735	level of protocadherin gamma-C3 (human) in blood serum	PR:Q9UN70	protocadherin gamma-C3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044736	level of protocadherin beta-10 (human) in blood serum	PR:Q9UN67	protocadherin beta-10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044737	level of protein ATP1B4 (human) in blood serum	PR:Q9UN42	protein ATP1B4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044738	level of vacuolar protein sorting-associated protein 4A (human) in blood serum	PR:Q9UN37	vacuolar protein sorting-associated protein 4A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044739	level of protein NDRG2 (human) in blood serum	PR:Q9UN36	protein NDRG2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044740	level of sorting nexin-12 (human) in blood serum	PR:Q9UMY4	sorting nexin-12 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044741	level of histone chaperone ASF1A (human) in blood serum	PR:Q9Y294	histone chaperone ASF1A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044742	level of integral membrane protein 2B (human) in blood serum	PR:Q9Y287	integral membrane protein 2B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044743	level of V-set and immunoglobulin domain-containing protein 4 (human) in blood serum	PR:Q9Y279	V-set and immunoglobulin domain-containing protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044744	level of type 2 lactosamine alpha-2,3-sialyltransferase (human) in blood serum	PR:Q9Y274	type 2 lactosamine alpha-2,3-sialyltransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044745	level of RuvB-like 1 (human) in blood serum	PR:Q9Y265	RuvB-like 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044746	level of DNA polymerase eta (human) in blood serum	PR:Q9Y253	DNA polymerase eta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044747	level of RAC-gamma serine/threonine-protein kinase (human) in blood serum	PR:Q9Y243	RAC-gamma serine/threonine-protein kinase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044748	level of peptidyl-prolyl cis-trans isomerase NIMA-interacting 4 (human) in blood serum	PR:Q9Y237	peptidyl-prolyl cis-trans isomerase NIMA-interacting 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044749	level of C->U-editing enzyme APOBEC-2 (human) in blood serum	PR:Q9Y235	C->U-editing enzyme APOBEC-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044750	level of 4-galactosyl-N-acetylglucosaminide 3-alpha-L-fucosyltransferase 9 (human) in blood serum	PR:Q9Y231	4-galactosyl-N-acetylglucosaminide 3-alpha-L-fucosyltransferase 9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044751	level of RING finger protein 24 (human) in blood serum	PR:Q9Y225	RING finger protein 24 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044752	level of RNA transcription, translation and transport factor protein (human) in blood serum	PR:Q9Y224	RNA transcription, translation and transport factor protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044753	level of bifunctional UDP-N-acetylglucosamine 2-epimerase/N-acetylmannosamine kinase (human) in blood serum	PR:Q9Y223	bifunctional UDP-N-acetylglucosamine 2-epimerase/N-acetylmannosamine kinase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044754	level of 60S ribosome subunit biogenesis protein NIP7 homolog (human) in blood serum	PR:Q9Y221	60S ribosome subunit biogenesis protein NIP7 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044755	level of myotubularin-related protein 6 (human) in blood serum	PR:Q9Y217	myotubularin-related protein 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044756	level of myotubularin-related protein 7 (human) in blood serum	PR:Q9Y216	myotubularin-related protein 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044757	level of HERV-H LTR-associating protein 3 (human) in blood serum	PR:Q9XRX5	HERV-H LTR-associating protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044758	level of SH2B adapter protein 3 (human) in blood serum	PR:Q9UQQ2	SH2B adapter protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044759	level of aminopeptidase NAALADL1 (human) in blood serum	PR:Q9UQQ1	aminopeptidase NAALADL1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044760	level of charged multivesicular body protein 2b (human) in blood serum	PR:Q9UQN3	charged multivesicular body protein 2b (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044761	level of structural maintenance of chromosomes protein 3 (human) in blood serum	PR:Q9UQE7	structural maintenance of chromosomes protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044762	level of calcium-activated chloride channel regulator 2 (human) in blood serum	PR:Q9UQC9	calcium-activated chloride channel regulator 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044763	level of brain-specific angiogenesis inhibitor 1-associated protein 2 (human) in blood serum	PR:Q9UQB8	brain-specific angiogenesis inhibitor 1-associated protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044764	level of pregnancy-specific beta-1-glycoprotein 8 (human) in blood serum	PR:Q9UQ74	pregnancy-specific beta-1-glycoprotein 8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044765	level of pregnancy-specific beta-1-glycoprotein 11 (human) in blood serum	PR:Q9UQ72	pregnancy-specific beta-1-glycoprotein 11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044766	level of alpha-1,3-mannosyl-glycoprotein 4-beta-N-acetylglucosaminyltransferase B (human) in blood serum	PR:Q9UQ53	alpha-1,3-mannosyl-glycoprotein 4-beta-N-acetylglucosaminyltransferase B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044767	level of contactin-6 (human) in blood serum	PR:Q9UQ52	contactin-6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044768	level of microtubule-associated protein RP/EB family member 3 (human) in blood serum	PR:Q9UPY8	microtubule-associated protein RP/EB family member 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044769	level of major intrinsically disordered Notch2-binding receptor 1 (human) in blood serum	PR:Q9UPX6	major intrinsically disordered Notch2-binding receptor 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044770	level of protein turtle homolog B (human) in blood serum	PR:Q9UPX0	protein turtle homolog B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044771	level of protein unc-13 homolog A (human) in blood serum	PR:Q9UPW8	protein unc-13 homolog A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044772	level of START domain-containing protein 10 (human) in blood serum	PR:Q9Y365	START domain-containing protein 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044773	level of protein MEMO1 (human) in blood serum	PR:Q9Y316	protein MEMO1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044774	level of nitric oxide synthase-interacting protein (human) in blood serum	PR:Q9Y314	nitric oxide synthase-interacting protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044775	level of ubiquinone biosynthesis monooxygenase COQ6, mitochondrial (human) in blood serum	PR:Q9Y2Z9	ubiquinone biosynthesis monooxygenase COQ6, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044776	level of tyrosine--tRNA ligase, mitochondrial (human) in blood serum	PR:Q9Y2Z4	tyrosine--tRNA ligase, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044777	level of protein SGT1 homolog (human) in blood serum	PR:Q9Y2Z0	protein SGT1 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044778	level of proteoglycan 3 (human) in blood serum	PR:Q9Y2Y8	proteoglycan 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044779	level of ADP-ribosylation factor-like protein 2-binding protein (human) in blood serum	PR:Q9Y2Y0	ADP-ribosylation factor-like protein 2-binding protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044780	level of calsenilin (human) in blood serum	PR:Q9Y2W7	calsenilin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044781	level of calcium-regulated heat-stable protein 1 (human) in blood serum	PR:Q9Y2V2	calcium-regulated heat-stable protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044782	level of Y-box-binding protein 2 (human) in blood serum	PR:Q9Y2T7	Y-box-binding protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044783	level of guanine deaminase (human) in blood serum	PR:Q9Y2T3	guanine deaminase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044784	level of Axin-2 (human) in blood serum	PR:Q9Y2T1	Axin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044785	level of lambda-crystallin homolog (human) in blood serum	PR:Q9Y2S2	lambda-crystallin homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044786	level of cytochrome c oxidase assembly factor 3 homolog, mitochondrial (human) in blood serum	PR:Q9Y2R0	cytochrome c oxidase assembly factor 3 homolog, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044787	level of ragulator complex protein LAMTOR2 (human) in blood serum	PR:Q9Y2Q5	ragulator complex protein LAMTOR2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044788	level of glutathione S-transferase kappa 1 (human) in blood serum	PR:Q9Y2Q3	glutathione S-transferase kappa 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044789	level of protein-arginine deiminase type-2 (human) in blood serum	PR:Q9Y2J8	protein-arginine deiminase type-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044790	level of netrin-G1 (human) in blood serum	PR:Q9Y2I2	netrin-G1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044791	level of nischarin (human) in blood serum	PR:Q9Y2I1	nischarin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044792	level of phosphatidylinositide phosphatase SAC2 (human) in blood serum	PR:Q9Y2H2	phosphatidylinositide phosphatase SAC2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044793	level of disks large-associated protein 4 (human) in blood serum	PR:Q9Y2H0	disks large-associated protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044794	level of DnaJ homolog subfamily C member 16 (human) in blood serum	PR:Q9Y2G8	DnaJ homolog subfamily C member 16 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044795	level of epididymis-specific alpha-mannosidase (human) in blood serum	PR:Q9Y2E5	epididymis-specific alpha-mannosidase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044796	level of cyclic AMP-dependent transcription factor ATF-5 (human) in blood serum	PR:Q9Y2D1	cyclic AMP-dependent transcription factor ATF-5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044797	level of carbonic anhydrase 5B, mitochondrial (human) in blood serum	PR:Q9Y2D0	carbonic anhydrase 5B, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044798	level of nuclease EXOG, mitochondrial (human) in blood serum	PR:Q9Y2C4	nuclease EXOG, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044799	level of beta-1,3-galactosyltransferase 5 (human) in blood serum	PR:Q9Y2C3	beta-1,3-galactosyltransferase 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044800	level of uronyl 2-sulfotransferase (human) in blood serum	PR:Q9Y2C2	uronyl 2-sulfotransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044801	level of trafficking protein particle complex subunit 4 (human) in blood serum	PR:Q9Y296	trafficking protein particle complex subunit 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044802	level of developmentally-regulated GTP-binding protein 1 (human) in blood serum	PR:Q9Y295	developmentally-regulated GTP-binding protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044803	level of lysyl oxidase homolog 2 (human) in blood serum	PR:Q9Y4K0	lysyl oxidase homolog 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044804	level of dystrobrevin alpha (human) in blood serum	PR:Q9Y4J8	dystrobrevin alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044805	level of talin-2 (human) in blood serum	PR:Q9Y4G6	talin-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044806	level of ubiquitin carboxyl-terminal hydrolase 15 (human) in blood serum	PR:Q9Y4E8	ubiquitin carboxyl-terminal hydrolase 15 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044807	level of plexin-D1 (human) in blood serum	PR:Q9Y4D7	plexin-D1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044808	level of probable RNA-binding protein 19 (human) in blood serum	PR:Q9Y4C8	probable RNA-binding protein 19 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044809	level of neurexin-3-alpha (human) in blood serum	PR:Q9Y4C0	neurexin-3-alpha (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044810	level of kinesin-like protein KIF3A (human) in blood serum	PR:Q9Y496	kinesin-like protein KIF3A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044811	level of zinc finger protein 175 (human) in blood serum	PR:Q9Y473	zinc finger protein 175 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044812	level of T-box transcription factor TBX22 (human) in blood serum	PR:Q9Y458	T-box transcription factor TBX22 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044813	level of deoxynucleoside triphosphate triphosphohydrolase SAMHD1 (human) in blood serum	PR:Q9Y3Z3	deoxynucleoside triphosphate triphosphohydrolase SAMHD1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044814	level of coiled-coil domain-containing protein 9 (human) in blood serum	PR:Q9Y3X0	coiled-coil domain-containing protein 9 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044815	level of N-acetylated-alpha-linked acidic dipeptidase 2 (human) in blood serum	PR:Q9Y3Q0	N-acetylated-alpha-linked acidic dipeptidase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044816	level of signaling threshold-regulating transmembrane adapter 1 (human) in blood serum	PR:Q9Y3P8	signaling threshold-regulating transmembrane adapter 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044817	level of charged multivesicular body protein 3 (human) in blood serum	PR:Q9Y3E7	charged multivesicular body protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044818	level of peptidyl-tRNA hydrolase 2, mitochondrial (human) in blood serum	PR:Q9Y3E5	peptidyl-tRNA hydrolase 2, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044819	level of BolA-like protein 1 (human) in blood serum	PR:Q9Y3E2	BolA-like protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044820	level of hepatoma-derived growth factor-related protein 3 (human) in blood serum	PR:Q9Y3E1	hepatoma-derived growth factor-related protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044821	level of mitochondrial fission 1 protein (human) in blood serum	PR:Q9Y3D6	mitochondrial fission 1 protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044822	level of methionine-R-sulfoxide reductase B2, mitochondrial (human) in blood serum	PR:Q9Y3D2	methionine-R-sulfoxide reductase B2, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044823	level of peptidyl-prolyl cis-trans isomerase-like 1 (human) in blood serum	PR:Q9Y3C6	peptidyl-prolyl cis-trans isomerase-like 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044824	level of EKC/KEOPS complex subunit TPRKB (human) in blood serum	PR:Q9Y3C4	EKC/KEOPS complex subunit TPRKB (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044825	level of nucleolar protein 16 (human) in blood serum	PR:Q9Y3C1	nucleolar protein 16 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044826	level of oligoribonuclease, mitochondrial (human) in blood serum	PR:Q9Y3B8	oligoribonuclease, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044827	level of splicing factor 3B subunit 6 (human) in blood serum	PR:Q9Y3B4	splicing factor 3B subunit 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044828	level of exosome complex component CSL4 (human) in blood serum	PR:Q9Y3B2	exosome complex component CSL4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044829	level of MOB-like protein phocein (human) in blood serum	PR:Q9Y3A3	MOB-like protein phocein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044830	level of ubiquitin-conjugating enzyme E2 J1 (human) in blood serum	PR:Q9Y385	ubiquitin-conjugating enzyme E2 J1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044831	level of calcium-binding protein 39 (human) in blood serum	PR:Q9Y376	calcium-binding protein 39 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044832	level of complex I intermediate-associated protein 30, mitochondrial (human) in blood serum	PR:Q9Y375	complex I intermediate-associated protein 30, mitochondrial (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044833	level of endophilin-B1 (human) in blood serum	PR:Q9Y371	endophilin-B1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044834	level of ectonucleoside triphosphate diphosphohydrolase 2 (human) in blood serum	PR:Q9Y5L3	ectonucleoside triphosphate diphosphohydrolase 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044835	level of CD2-associated protein (human) in blood serum	PR:Q9Y5K6	CD2-associated protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044836	level of ubiquitin carboxyl-terminal hydrolase isozyme L5 (human) in blood serum	PR:Q9Y5K5	ubiquitin carboxyl-terminal hydrolase isozyme L5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044837	level of mitochondrial import inner membrane translocase subunit Tim10 B (human) in blood serum	PR:Q9Y5J6	mitochondrial import inner membrane translocase subunit Tim10 B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044838	level of hairy/enhancer-of-split related with YRPW motif protein 1 (human) in blood serum	PR:Q9Y5J3	hairy/enhancer-of-split related with YRPW motif protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044839	level of protocadherin alpha-C2 (human) in blood serum	PR:Q9Y5I4	protocadherin alpha-C2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044840	level of protocadherin gamma-A1 (human) in blood serum	PR:Q9Y5H4	protocadherin gamma-A1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044841	level of protocadherin gamma-A10 (human) in blood serum	PR:Q9Y5H3	protocadherin gamma-A10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044842	level of protocadherin gamma-A2 (human) in blood serum	PR:Q9Y5H1	protocadherin gamma-A2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044843	level of protocadherin gamma-B1 (human) in blood serum	PR:Q9Y5G3	protocadherin gamma-B1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044844	level of protocadherin gamma-C5 (human) in blood serum	PR:Q9Y5F6	protocadherin gamma-C5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044845	level of protocadherin beta-1 (human) in blood serum	PR:Q9Y5F3	protocadherin beta-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044846	level of protocadherin beta-2 (human) in blood serum	PR:Q9Y5E7	protocadherin beta-2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044847	level of nucleoside diphosphate kinase 7 (human) in blood serum	PR:Q9Y5B8	nucleoside diphosphate kinase 7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044848	level of NEDD8 ultimate buster 1 (human) in blood serum	PR:Q9Y5A7	NEDD8 ultimate buster 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044849	level of BTB/POZ domain-containing protein KCTD3 (human) in blood serum	PR:Q9Y597	BTB/POZ domain-containing protein KCTD3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044850	level of insulin-like peptide INSL6 (human) in blood serum	PR:Q9Y581	insulin-like peptide INSL6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044851	level of protein phosphatase methylesterase 1 (human) in blood serum	PR:Q9Y570	protein phosphatase methylesterase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044852	level of SH3 and multiple ankyrin repeat domains protein 1 (human) in blood serum	PR:Q9Y566	SH3 and multiple ankyrin repeat domains protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044853	level of low-density lipoprotein receptor-related protein 12 (human) in blood serum	PR:Q9Y561	low-density lipoprotein receptor-related protein 12 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044854	level of cold shock domain-containing protein C2 (human) in blood serum	PR:Q9Y534	cold shock domain-containing protein C2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044855	level of sorting and assembly machinery component 50 homolog (human) in blood serum	PR:Q9Y512	sorting and assembly machinery component 50 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044856	level of E3 ubiquitin-protein ligase RNF114 (human) in blood serum	PR:Q9Y508	E3 ubiquitin-protein ligase RNF114 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044857	level of neurogenin-3 (human) in blood serum	PR:Q9Y4Z2	neurogenin-3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044858	level of U6 snRNA-associated Sm-like protein LSm4 (human) in blood serum	PR:Q9Y4Z0	U6 snRNA-associated Sm-like protein LSm4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044859	level of cyanocobalamin reductase / alkylcobalamin dealkylase (human) in blood serum	PR:Q9Y4U1	cyanocobalamin reductase / alkylcobalamin dealkylase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044860	level of sperm flagellar protein 1 (human) in blood serum	PR:Q9Y4P9	sperm flagellar protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044861	level of transducin beta-like protein 2 (human) in blood serum	PR:Q9Y4P3	transducin beta-like protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044862	level of cysteine protease ATG4B (human) in blood serum	PR:Q9Y4P1	cysteine protease ATG4B (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044863	level of hypoxia up-regulated protein 1 (human) in blood serum	PR:Q9Y4L1	hypoxia up-regulated protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044864	level of mitogen-activated protein kinase kinase kinase kinase 5 (human) in blood serum	PR:Q9Y4K4	mitogen-activated protein kinase kinase kinase kinase 5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044865	level of transforming acidic coiled-coil-containing protein 3 (human) in blood serum	PR:Q9Y6A5	transforming acidic coiled-coil-containing protein 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044866	level of chloride intracellular channel protein 4 (human) in blood serum	PR:Q9Y696	chloride intracellular channel protein 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044867	level of ADP-ribosylation factor-like protein 5A (human) in blood serum	PR:Q9Y689	ADP-ribosylation factor-like protein 5A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044868	level of peptidyl-prolyl cis-trans isomerase FKBP7 (human) in blood serum	PR:Q9Y680	peptidyl-prolyl cis-trans isomerase FKBP7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044869	level of heparan sulfate glucosamine 3-O-sulfotransferase 3A1 (human) in blood serum	PR:Q9Y663	heparan sulfate glucosamine 3-O-sulfotransferase 3A1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044870	level of heparan sulfate glucosamine 3-O-sulfotransferase 3B1 (human) in blood serum	PR:Q9Y662	heparan sulfate glucosamine 3-O-sulfotransferase 3B1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044871	level of heparan sulfate glucosamine 3-O-sulfotransferase 4 (human) in blood serum	PR:Q9Y661	heparan sulfate glucosamine 3-O-sulfotransferase 4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044872	level of spindlin-1 (human) in blood serum	PR:Q9Y657	spindlin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044873	level of adhesion G-protein coupled receptor G1 (human) in blood serum	PR:Q9Y653	adhesion G-protein coupled receptor G1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044874	level of carboxypeptidase Q (human) in blood serum	PR:Q9Y646	carboxypeptidase Q (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044875	level of beta-1,3-N-acetylglucosaminyltransferase radical fringe (human) in blood serum	PR:Q9Y644	beta-1,3-N-acetylglucosaminyltransferase radical fringe (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044876	level of neuroplastin (human) in blood serum	PR:Q9Y639	neuroplastin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044877	level of junctional adhesion molecule A (human) in blood serum	PR:Q9Y624	junctional adhesion molecule A (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044878	level of phosphoserine aminotransferase (human) in blood serum	PR:Q9Y617	phosphoserine aminotransferase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044879	level of FH1/FH2 domain-containing protein 1 (human) in blood serum	PR:Q9Y613	FH1/FH2 domain-containing protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044880	level of leucine-rich repeat flightless-interacting protein 2 (human) in blood serum	PR:Q9Y608	leucine-rich repeat flightless-interacting protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044881	level of pseudouridylate synthase 1 homolog (human) in blood serum	PR:Q9Y606	pseudouridylate synthase 1 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044882	level of transcription factor ETV7 (human) in blood serum	PR:Q9Y603	transcription factor ETV7 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044883	level of beta-1,3-galactosyltransferase 1 (human) in blood serum	PR:Q9Y5Z6	beta-1,3-galactosyltransferase 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044884	level of cytosolic Fe-S cluster assembly factor NUBP2 (human) in blood serum	PR:Q9Y5Y2	cytosolic Fe-S cluster assembly factor NUBP2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044885	level of endothelial lipase (human) in blood serum	PR:Q9Y5X9	endothelial lipase (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044886	level of sorting nexin-5 (human) in blood serum	PR:Q9Y5X3	sorting nexin-5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044887	level of sorting nexin-8 (human) in blood serum	PR:Q9Y5X2	sorting nexin-8 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044888	level of sorting nexin-11 (human) in blood serum	PR:Q9Y5W9	sorting nexin-11 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044889	level of mitochondrial pyruvate carrier 1 (human) in blood serum	PR:Q9Y5U8	mitochondrial pyruvate carrier 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044890	level of protein TSSC4 (human) in blood serum	PR:Q9Y5U2	protein TSSC4 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044891	level of DnaJ homolog subfamily C member 15 (human) in blood serum	PR:Q9Y5T4	DnaJ homolog subfamily C member 15 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044892	level of insulin-like peptide INSL5 (human) in blood serum	PR:Q9Y5Q6	insulin-like peptide INSL5 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044893	level of chondrosarcoma-associated gene 2/3 protein (human) in blood serum	PR:Q9Y5P2	chondrosarcoma-associated gene 2/3 protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044894	level of origin recognition complex subunit 6 (human) in blood serum	PR:Q9Y5N6	origin recognition complex subunit 6 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044895	level of mitochondrial import inner membrane translocase subunit Tim13 (human) in blood serum	PR:Q9Y5L4	mitochondrial import inner membrane translocase subunit Tim13 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044896	level of collectin-10 (human) in blood serum	PR:Q9Y6Z7	collectin-10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044897	level of zinc fingers and homeoboxes protein 2 (human) in blood serum	PR:Q9Y6X8	zinc fingers and homeoboxes protein 2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044898	level of E3 SUMO-protein ligase PIAS3 (human) in blood serum	PR:Q9Y6X2	E3 SUMO-protein ligase PIAS3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044899	level of SET-binding protein (human) in blood serum	PR:Q9Y6X0	SET-binding protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044900	level of dual specificity protein phosphatase 10 (human) in blood serum	PR:Q9Y6W6	dual specificity protein phosphatase 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044901	level of scinderin (human) in blood serum	PR:Q9Y6U3	scinderin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044902	level of diacylglycerol kinase beta (human) in blood serum	PR:Q9Y6T7	diacylglycerol kinase beta (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044903	level of Numb-like protein (human) in blood serum	PR:Q9Y6R0	Numb-like protein (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044904	level of harmonin (human) in blood serum	PR:Q9Y6N9	harmonin (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044905	level of cadherin-10 (human) in blood serum	PR:Q9Y6N8	cadherin-10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044906	level of roundabout homolog 1 (human) in blood serum	PR:Q9Y6N7	roundabout homolog 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044907	level of NF-kappa-B essential modulator (human) in blood serum	PR:Q9Y6K9	NF-kappa-B essential modulator (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044908	level of ubiquitin carboxyl-terminal hydrolase 3 (human) in blood serum	PR:Q9Y6I4	ubiquitin carboxyl-terminal hydrolase 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044909	level of epsin-1 (human) in blood serum	PR:Q9Y6I3	epsin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044910	level of potassium voltage-gated channel subfamily E member 3 (human) in blood serum	PR:Q9Y6H6	potassium voltage-gated channel subfamily E member 3 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044911	level of synphilin-1 (human) in blood serum	PR:Q9Y6H5	synphilin-1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044912	level of mitochondrial inner membrane protease ATP23 homolog (human) in blood serum	PR:Q9Y6H3	mitochondrial inner membrane protease ATP23 homolog (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044913	level of cytoplasmic dynein 1 light intermediate chain 1 (human) in blood serum	PR:Q9Y6G9	cytoplasmic dynein 1 light intermediate chain 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044914	level of COMM domain-containing protein 10 (human) in blood serum	PR:Q9Y6G5	COMM domain-containing protein 10 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044915	level of testis-specific chromodomain protein Y 1 (human) in blood serum	PR:Q9Y6F8	testis-specific chromodomain protein Y 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044916	level of inositol 1,4,5-triphosphate receptor associated 1 (human) in blood serum	PR:Q9Y6F6	inositol 1,4,5-triphosphate receptor associated 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044917	level of eIF5-mimic protein 1 (human) in blood serum	PR:Q9Y6E2	eIF5-mimic protein 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044918	level of serine/threonine-protein kinase 24 (human) in blood serum	PR:Q9Y6E0	serine/threonine-protein kinase 24 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044919	level of mitotic spindle assembly checkpoint protein MAD1 (human) in blood serum	PR:Q9Y6D9	mitotic spindle assembly checkpoint protein MAD1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044920	level of GTP-binding protein SAR1b (human) in blood serum	PR:Q9Y6B6	GTP-binding protein SAR1b (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044921	level of signal peptidase complex subunit 1 (human) in blood serum	PR:Q9Y6A9	signal peptidase complex subunit 1 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044922	level of torsin-1A-interacting protein 2 isoform TOR1AIP2 (human) in blood serum	PR:Q8NFQ8-1	torsin-1A-interacting protein 2 isoform TOR1AIP2 (human)	PATO:0000070	amount	UBERON:0001977	blood serum
+OBA:2044923	level of neuroendocrine secretory protein 55 isoform Nesp55 (human) in blood serum	PR:O95467-1	neuroendocrine secretory protein 55 isoform Nesp55 (human)	PATO:0000070	amount	UBERON:0001977	blood serum


### PR DESCRIPTION
This commit intends to add 4740 `level of XXX-PROTEIN in blood serum` trait terms. If applied, this commit will fix #222 and
addresses https://github.com/EBISPOT/efo/issues/1848