### PR TITLE
Add OBA-LOINC mapping tables

### DIFF
--- a/src/mappings/oba-efo.sssom.tsv
+++ b/src/mappings/oba-efo.sssom.tsv
@@ -483,7 +483,6 @@ EFO:0009239	Mature Plasma Cell Count;The determination of the number of mature p
 EFO:0004308	leukocyte count;The number of WHITE BLOOD CELLS per unit volume in venous BLOOD. A differential leukocyte count measures the relative numbers of the different types of white cells.	measurement	skos:exactMatch	OBA:VT0000217	leukocyte quantity		HumanCurated	EFO	OBA	1	2023-08-29				orcid:0000-0001-8314-2140
 EFO:0004764	adipose tissue measurement;Is a quantification of some aspect of adipose tissue	measurement	skos:exactMatch	OBA:VT0005452	adipose amount		HumanCurated	EFO	OBA	1	2023-08-29				orcid:0000-0001-8314-2140
 EFO:0005036	platelet measurement;A measurement quantifying some platelet	measurement	skos:exactMatch	OBA:VT0003179	platelet quantity		HumanCurated	EFO	OBA	1	2023-08-29				orcid:0000-0001-8314-2140
-EFO:0007772	calcaneal bone quantitative ultrasound measurement;bone quantitiave ultrasound of the main bone in the heel	measurement	skos:exactMatch	OBA:0003330	calcaneus size		HumanCurated	EFO	OBA	1	2023-08-29				orcid:0000-0001-8314-2140
 EFO:0007717	carotid artery geometry measurement	measurement	skos:exactMatch	OBA:2045208	carotid artery morphology		HumanCurated	EFO	OBA	1	2023-09-08				orcid:0000-0001-8314-2140
 EFO:0010759	male reproductive system measurement	measurement	skos:exactMatch	OBA:1000521	male reproductive system attribute		HumanCurated	EFO	OBA	1	2023-09-08				orcid:0000-0001-8314-2140
 EFO:0004464	brain measurement	measurement	skos:exactMatch	OBA:2045210	brain attribute		HumanCurated	EFO	OBA	1	2023-09-08				orcid:0000-0001-8314-2140
@@ -753,3 +752,8 @@ EFO:0007852	thiopurine methyltransferase activity measurement	measurement	skos:e
 EFO:0007019	milk allergy measurement	measurement	skos:broadMatch	OBA:2045386	response to milk	response to	HumanCurated	EFO	OBA	1	2023-09-27				orcid:0000-0001-8314-2140
 EFO:0007854	knee peak torque measurement	measurement	skos:broadMatch	OBA:2045387	knee flexor muscle funcionality attribute	functionality	HumanCurated	EFO	OBA	1	2023-09-27				orcid:0000-0001-8314-2140
 EFO:0009335	white matter growth measurement	measurement	skos:exactMatch	OBA:2045388	white matter growth attribute	physical quality of a process	HumanCurated	EFO	OBA	1	2023-09-27				orcid:0000-0001-8314-2140
+EFO:0004338	body weight	measurement	skos:exactMatch	OBA:VT0001259	body mass	mass	HumanCurated	EFO	OBA	1	2024-08-15				orcid:0000-0001-8314-2140
+EFO:0009284	chloride measurement	measurement	skos:broadMatch	OBA:2020003	chemical in blood amount	amount	HumanCurated	EFO	OBA	1	2024-08-15				orcid:0000-0001-8314-2140
+EFO:0009283	potassium measurement	measurement	skos:broadMatch	OBA:2020003	chemical in blood amount	amount	HumanCurated	EFO	OBA	1	2024-08-15				orcid:0000-0001-8314-2140
+EFO:0009282	sodium measurement	measurement	skos:broadMatch	OBA:2020003	chemical in blood amount	amount	HumanCurated	EFO	OBA	1	2024-08-15				orcid:0000-0001-8314-2140
+EFO:0007772	obsolete_calcaneal bone quantitative ultrasound measurement;bone quantitiave ultrasound of the main bone in the heel	measurement	skos:exactMatch	OBA:2045558	heel bone density	mass density	HumanCurated	EFO	OBA	1	2025-02-12				orcid:0000-0001-8314-2140

--- a/src/mappings/oba-loinc-mapping-exclusions.sssom.tsv
+++ b/src/mappings/oba-loinc-mapping-exclusions.sssom.tsv
@@ -1,0 +1,310 @@
+subject_id	subject_label	mapping_justification	author_id	comment
+31208-2	Specimen source identified	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+630-4	Bacteria identified in Urine by Culture	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+600-7	Bacteria identified in Blood by Culture	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+9781-6	Acanthamoeba sp identified in Specimen by Organism specific culture	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+9816-0	Actinomyces sp identified in Specimen by Organism specific culture	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+41273-4	Alpha-1-Fetoprotein interpretation in Amniotic fluid	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+41274-2	Alpha-1-Fetoprotein interpretation in Serum or Plasma	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+49246-2	Alpha-1-Fetoprotein interpretation in Serum or Plasma Narrative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+14618-3	Appearance of Stone	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+35359-9	AR gene targeted mutation analysis in Blood or Tissue by Molecular genetics method	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+10644-3	Arthropod identified in Specimen	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+35466-2	AS+PWS gene targeted mutation analysis in Blood or Tissue by Molecular genetics method	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+68366-4	Bacteria identified in Blood product unit by Culture	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+610-6	Bacteria identified in Body fluid by Aerobe culture	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+17956-4	Bacteria identified in Body fluid by Anaerobe culture	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+611-4	Bacteria identified in Body fluid by Culture	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+606-4	Bacteria identified in Cerebral spinal fluid by Culture	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+32367-5	Bacteria identified in Isolate by Aerobe culture	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+634-6	Bacteria identified in Specimen by Aerobe culture	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+635-3	Bacteria identified in Specimen by Anaerobe culture	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+6463-4	Bacteria identified in Specimen by Culture	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+32355-0	Bacteria identified in Specimen by Respiratory culture	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+623-9	Bacteria identified in Sputum by Cystic fibrosis respiratory culture	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+625-4	Bacteria identified in Stool by Culture	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+626-2	Bacteria identified in Throat by Culture	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+73836-9	Bacteria.fluoroquinolone resistant identified in Anal by Organism specific culture	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+29576-6	Bacterial susceptibility panel	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+57087-9	Biotinidase newborn screening panel	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+94191-4	BRCA1+BRCA2 gene deletion+duplication and full mutation analysis in Blood or Tissue by Molecular genetics method	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+6331-3	Campylobacter sp identified in Stool by Organism specific culture	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+38404-0	CFTR gene targeted mutation analysis in Blood or Tissue by Molecular genetics method	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+72828-7	Chlamydia trachomatis and Neisseria gonorrhoeae DNA panel - Specimen	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+62356-1	Chromosome analysis result in ISCN expression	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+59462-2	Clinical biochemist review of results	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+41751-9	COL3A1 gene targeted mutation analysis in Blood or Tissue by Molecular genetics method	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+30211-7	Collection duration of Specimen	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+13363-7	Collection duration of Stool	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+13362-9	Collection duration of Urine	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+9796-4	Color of Stone	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+9795-6	Composition in Stone	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+19767-3	Cytologist who read Cyto stain of Cervical or vaginal smear or scraping	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+72852-7	Cytomegalovirus resistance panel by Genotype method	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+51968-6	Discrete variation analysis overall interpretation	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+75693-2	Fetal sex in Plasma cell-free DNA by Dosage of chromosome specific cell free (cf) DNA	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+36913-2	FMR1 gene targeted mutation analysis in Blood or Tissue by Molecular genetics method	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+35353-2	FSHD gene targeted mutation analysis in Blood or Tissue by Molecular genetics method	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+36908-2	Gene mutations tested for in Blood or Tissue by Molecular genetics method Nominal	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+51969-4	Genetic analysis report	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+53039-4	Genetic disease analysis overall carrier interpretation	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+46738-1	Genetic.Disorders newborn screen interpretation	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+21299-3	Gestational age method	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+10671-6	Helminth identified in Specimen	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+5859-4	Herpes simplex virus identified in Specimen by Organism specific culture	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+34519-9	HFE gene targeted mutation analysis in Blood or Tissue by Molecular genetics method	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+72560-6	HIV integrase inhibitor susceptibility panel by Genotype method	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+49660-4	HIV susceptibility panel by Genotype method	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+49665-3	HIV susceptibility panel by Phenotype method	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+45023-9	HLA typing for celiac disease panel - Blood or Tissue	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+53783-7	HTT gene mutation panel - Blood or Tissue by Molecular genetics method	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+50621-2	HTT gene targeted mutation analysis in Blood or Tissue by Molecular genetics method	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+48670-4	IgVH gene targeted mutation analysis in Blood or Tissue by Molecular genetics method	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+25700-6	Immunofixation for Serum or Plasma	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+49275-1	Immunofixation for Serum or Plasma Narrative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+13440-3	Immunofixation for Urine	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+49276-9	Immunofixation for Urine Narrative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+69048-7	Immunologist review of results	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+6604-3	Influenza virus identified in Specimen by Organism specific culture	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+52129-4	INR in Platelet poor plasma by Coagulation assay --post heparin neutralization	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+48726-4	JAK2 gene targeted mutation analysis in Blood or Tissue by Molecular genetics method	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+55201-8	KIT gene targeted mutation analysis in Blood or Tissue by Molecular genetics method	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+593-4	Legionella sp identified in Specimen by Organism specific culture	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+62255-5	Lipoprotein insulin resistance score in Serum or Plasma	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+77616-1	Liver fibrosis score in Serum or Plasma Calculated by FibroMeter	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+59464-8	Microbiologist review of results	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+41852-5	Microorganism or agent identified in Specimen	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+32819-5	Microsporidia identified in Stool by Trichrome stain	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+79563-3	Mucopolysaccharidosis type I newborn screening panel	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+48793-4	Necroinflammatory activity grade	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+48792-6	Necroinflammatory activity score	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+34492-9	NOTCH3 gene targeted mutation analysis in Blood or Tissue by Molecular genetics method	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+9800-4	Number of Stones	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+93479-4	Observation interpretation	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+673-4	Ova and parasites identified in Specimen by Light microscopy	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+10701-1	Ova and parasites identified in Stool by Concentration	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+10704-5	Ova and parasites identified in Stool by Light microscopy	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+43227-8	Ova and parasites identified in Stool by Trichrome stain	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+38406-5	PABPN1 gene targeted mutation analysis in Blood or Tissue by Molecular genetics method	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+21026-0	Pathologist interpretation of Blood tests	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+21025-2	Pathologist interpretation of Body fluid tests	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+21024-5	Pathologist interpretation of Cerebral spinal fluid tests	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+50595-8	Pathologist interpretation of Specimen tests	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+14869-2	Pathologist review of Blood tests	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+59465-5	Pathologist review of results	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+19769-9	Pathologist who read Cyto stain of Cervical or vaginal smear or scraping	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+22634-0	Pathology report gross observation Narrative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+22635-7	Pathology report microscopic observation Narrative Other stain	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+22636-5	Pathology report relevant history Narrative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+637-9	Plasmodium sp identified in Blood by Thick film	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+63414-7	Pompe disease newborn screening panel	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+49549-9	Referral lab test method	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+19147-8	Referral lab test reference range	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+19146-0	Referral lab test results	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+50219-5	Respiratory pathogens DNA and RNA 12a panel - Specimen by NAA with probe detection	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+55101-0	Respiratory pathogens panel - Specimen by Organism specific culture	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+69570-0	Risk of ovarian malignancy algorithm score in Serum or Plasma --postmenopausal	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+69569-2	Risk of ovarian malignancy algorithm score in Serum or Plasma --premenopausal	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+43371-4	Salmonella and Shigella sp identified in Stool by Organism specific culture	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+50733-5	Serotonin release interpretation in Serum	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+50734-3	Serotonin release.heparin.porcine in Serum	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+66488-8	Serotonin release.heparin.unfractionated in Serum Narrative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+21726-5	SERPINA1 gene mutations tested for in Blood or Tissue by Molecular genetics method Nominal	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+8251-1	Service comment	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+62333-0	Severe combined immunodeficiency (SCID) newborn screening panel	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+35462-1	SMN1 gene targeted mutation analysis in Blood or Tissue by Molecular genetics method	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+49857-6	SMN1 gene+SMN2 gene targeted mutation analysis in Blood or Tissue by Molecular genetics method	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+54449-4	SMN2 gene targeted mutation analysis in Blood or Tissue by Molecular genetics method	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+66746-9	Specimen type	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+38353-9	Streptococcus sp identified in Specimen by Organism specific culture	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+51867-0	t(9;22)(q34.1;q11)(ABL1,BCR) fusion transcript in Blood or Tissue by FISH	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+62364-5	Test performance information in Specimen Narrative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+79713-4	TPMT gene product metabolic activity interpretation in Blood or Tissue Qualitative by Molecular genetics method	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+36922-3	TPMT gene targeted mutation analysis in Blood or Tissue by Molecular genetics method	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+68458-9	Trichomonas sp identified in Specimen by Organism specific culture	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+49582-0	Trisomy 18 risk cutoff in Fetus	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+19157-7	Tube number of Cerebral spinal fluid	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+6579-7	Vibrio sp identified in Stool by Organism specific culture	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+5884-2	Virus identified in Cerebral spinal fluid by Culture	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+6584-7	Virus identified in Specimen by Culture	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+9804-6	Weight of Stone	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+28549-4	Yersinia sp identified in Stool by Organism specific culture	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+10466-1	Anion gap 3 in Serum or Plasma	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+18314-5	Morphology [Interpretation] in Blood Narrative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+49296-7	Protein Fractions [Interpretation] in Serum or Plasma by Electrophoresis Narrative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+20458-6	Rubella virus IgG Ab [Interpretation] in Serum	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+71773-6	Mycobacterium tuberculosis stimulated gamma interferon [Interpretation] in Blood Qualitative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+48767-8	Annotation comment [Interpretation] Narrative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+19764-0	Statement of adequacy [Interpretation] of Cervical or vaginal smear or scraping by Cyto stain	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+49299-1	Protein Fractions [Interpretation] in Urine by Electrophoresis Narrative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+20475-0	Cytomegalovirus IgG Ab [Interpretation] in Serum or Plasma	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+32769-2	Alpha 1 antitrypsin phenotype [Interpretation] in Serum or Plasma	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+13514-5	Hemoglobin pattern [Interpretation] in Blood by Electrophoresis Narrative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+22638-1	Pathology report comments [Interpretation] Narrative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+54247-2	Drug screen comment [Interpretation] in Urine	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+13068-2	Nuclear Ab pattern [Interpretation] in Serum by Immunofluorescence	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+49293-4	Oligoclonal bands [Interpretation] in Cerebral spinal fluid by Electrophoresis Narrative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+12782-9	Oligoclonal bands [Interpretation] in Cerebral spinal fluid by Electrophoresis	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+12710-0	Hemoglobin pattern [Interpretation] in Blood	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+49092-0	Second trimester quad maternal screen [Interpretation] in Serum or Plasma Narrative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+59060-4	Inflammatory bowel disease Ab 7 [Interpretation] in Serum	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+12851-2	Protein Fractions [Interpretation] in Serum or Plasma by Electrophoresis	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+49283-5	Metanephrine and Normetanephrine [Interpretation] in Urine Narrative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+45265-6	Immunodeficiency markers [Interpretation] in Specimen Narrative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+44909-0	5-Hydroxyindoleacetate and Creatinine [Interpretation] in Urine	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+42771-6	Streptococcus pneumoniae serotype IgG Ab [Interpretation] in Serum Narrative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+49257-9	Catecholamines [Interpretation] in Plasma Narrative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+21347-0	HTLV I+II Ab band pattern [Interpretation] in Serum by Immunoblot	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+49256-1	Catecholamines [Interpretation] in Urine Narrative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+44012-3	Measles virus IgG and IgM [Interpretation] in Serum	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+58738-6	Drugs of abuse [Interpretation] in Meconium	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+21419-7	Neutrophil cytoplasmic Ab pattern [Interpretation] in Serum by Immunofluorescence	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+13503-8	Borrelia burgdorferi IgM band pattern [Interpretation] in Serum by Immunoblot	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+62365-2	Diagnostic impression [Interpretation] in Specimen Narrative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+69568-4	Bacterial vaginosis [Interpretation] in Vaginal fluid Qualitative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+33472-2	Acylcarnitine pattern [Interpretation] in Urine	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+73824-5	Fetal Trisomy 13 risk [Interpretation] based on Plasma cell-free DNA by Dosage of chromosome-specific cfDNA Qualitative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+13502-0	Borrelia burgdorferi IgG band pattern [Interpretation] in Serum by Immunoblot	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+79211-9	Fetal Chromosome X and Y aneuploidy risk [interpretation] in Plasma cell-free DNA Qualitative by Sequencing	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+13500-4	Amino acid pattern [Interpretation] in Serum or Plasma	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+49292-6	Porphyrin fractions [Interpretation] in 24 hour Urine Narrative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+50948-9	Vanillylmandelate and Creatinine [Interpretation] in 24 hour Urine Narrative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+55171-3	Cytoplasmic Ab pattern [Interpretation] in Serum by Immunofluorescence	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+14883-3	Porphyrins [Interpretation] in Serum or Plasma	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+49263-7	Fatty acids.very long chain pattern [Interpretation] in Serum or Plasma Narrative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+59050-5	Chromosome analysis.interphase [Interpretation] in Specimen by FISH Narrative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+75882-1	Lupus anticoagulant three screening tests W Reflex [interpretation]	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+75570-2	Fetal Monosomy X risk [Interpretation] based on Plasma cell-free+WBC DNA by Dosage of chromosome-specific cfDNA Qualitative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+51730-0	Herpes virus 6 IgG and IgM [Interpretation] in Serum Narrative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+50398-7	Narrative diagnostic report [Interpretation]	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+57773-4	Colorado tick fever virus IgG and IgM [Interpretation] in Serum Narrative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+49269-4	Homovanillate and Creatinine [Interpretation] in Urine Narrative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+75602-3	Fetal 1p36 deletion risk [Interpretation] based on Plasma cell-free+WBC DNA by Dosage of chromosome-specific cfDNA Qualitative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+14895-7	Protein Fractions [Interpretation] in Serum or Plasma by Immunofixation	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+49248-8	Amino acid pattern [Interpretation] in Urine Narrative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+21328-0	Beta-N-acetylhexosaminidase A and B [Interpretation] in Blood	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+55192-9	Chromosome analysis.interphase [Interpretation] in Amniotic fluid by FISH Narrative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+14884-1	Porphyrins [Interpretation] in Stool	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+75558-7	Fetal Trisomy 18 risk [Interpretation] based on Plasma cell-free+WBC DNA by Dosage of chromosome-specific cfDNA Qualitative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+75578-5	Fetal 22q11.2 deletion risk [Interpretation] based on Plasma cell-free+WBC DNA by Dosage of chromosome-specific cfDNA Qualitative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+49262-9	Fatty acids pattern [Interpretation] in Serum or Plasma Narrative	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+50397-9	Molecular diagnostic overall interpretation [Presence] in Blood or Tissue by Molecular genetics method	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+72559-8	HIV integrase inhibitor susceptibility panel by Phenotype method	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+3150-0	Inhaled oxygen concentration	semapv:ManualMappingCuration	orcid:0000-0001-8314-2140	not in scope for OBA
+53556-7	Erythrocytes.Plasmodium sp infected/100 erythrocytes in Blood	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+33057-1	Heinz bodies/100 erythrocytes in Blood by Light microscopy	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+12841-3	Prostate Specific Ag Free/Prostate specific Ag.total in Serum or Plasma	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+42484-6	Protein.monoclonal/Protein.total in 24 hour Urine by Electrophoresis	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+42483-8	Protein.monoclonal/Protein.total in Urine by Electrophoresis	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+32149-7	Urate/Total in Stone	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+38252-3	Calcium oxalate monohydrate/Total in Stone	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+40998-7	Calcium hydrogen phosphate dihydrate/Total in Stone	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+49500-2	Calcium oxalate dihydrate/Total in Stone by Infrared spectroscopy	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+32283-4	Valproate Free/Valproate.total in Serum or Plasma	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+69380-4	t(9;22)(q34.1;q11)(ABL1,BCR) b2a2+b3a2 fusion transcript/control transcript (International Scale) [# Ratio] in Blood or Tissue by Molecular genetics method	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+55147-3	t(9;22)(q34.1;q11)(ABL1,BCR) b2a2+b3a2 fusion transcript/control transcript [# Ratio] in Blood or Tissue by Molecular genetics method	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+564-5	Colony count [#] in Specimen by Visual count	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+62358-7	ISCN band level [#] Qualitative	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+33219-7	Epithelial cells.squamous [#/area] in Urine sediment by Automated count	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+33218-9	Bacteria [#/area] in Urine sediment by Automated count	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+11277-1	Epithelial cells.squamous [#/area] in Urine sediment by Microscopy high power field	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+5769-5	Bacteria [#/area] in Urine sediment by Microscopy high power field	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+33223-9	Hyaline casts [#/area] in Urine sediment by Automated count	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+53294-5	Epithelial cells.non-squamous [#/area] in Urine sediment by Automated count	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+41284-1	Epithelial cells.non-squamous [#/area] in Urine sediment by Microscopy high power field	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+5796-8	Hyaline casts [#/area] in Urine sediment by Microscopy low power field	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+9842-6	Casts [#/area] in Urine sediment by Microscopy low power field	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+38459-4	Crystals [#/area] in Urine sediment by Microscopy high power field	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+33905-1	Trichomonas sp [#/area] in Urine sediment by Microscopy high power field	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+46420-6	Leukocyte clumps [#/area] in Urine sediment by Microscopy high power field	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+5822-2	Yeast [#/area] in Urine sediment by Microscopy high power field	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+26052-1	Epithelial cells.renal [#/area] in Urine sediment by Microscopy high power field	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+50233-6	Leukocyte clumps [#/area] in Urine sediment by Automated count	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+5793-5	Granular casts [#/area] in Urine sediment by Microscopy low power field	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+33341-9	Granular casts [#/area] in Urine by Computer assisted method	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+25148-8	Calcium oxalate crystals [#/area] in Urine sediment by Microscopy high power field	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+41215-5	Yeast [#/area] in Urine sediment by Microscopy low power field	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+33221-3	Epithelial cells.renal [#/area] in Urine by Computer assisted method	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+5820-6	WBC casts [#/area] in Urine sediment by Microscopy low power field	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+38995-7	Mixed cellular casts [#/area] in Urine sediment by Microscopy low power field	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+30089-7	Transitional cells [#/area] in Urine sediment by Microscopy high power field	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+33228-8	WBC casts [#/area] in Urine by Computer assisted method	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+46138-4	Urate crystals [#/area] in Urine sediment by Microscopy high power field	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+5807-3	RBC casts [#/area] in Urine sediment by Microscopy low power field	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+53289-5	Mixed cellular casts [#/area] in Urine by Computer assisted method	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+5819-8	Waxy casts [#/area] in Urine sediment by Microscopy low power field	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+33229-6	RBC casts [#/area] in Urine by Computer assisted method	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+53335-6	Casts type not specified [#/area] in Urine by Computer assisted method	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+33230-4	Waxy casts [#/area] in Urine by Computer assisted method	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+41861-6	Yeast.hyphae [#/area] in Urine sediment by Microscopy high power field	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+33222-1	Oval fat bodies (globules) [#/area] in Urine sediment by Automated count	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+46137-6	Triple phosphate crystals [#/area] in Urine sediment by Microscopy high power field	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+33231-2	Fatty casts [#/area] in Urine by Computer assisted method	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+5788-5	Oval fat bodies (globules) [#/area] in Urine sediment by Microscopy high power field	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+29604-6	Cytomegalovirus DNA [#/volume] (viral load) in Blood by NAA with probe detection	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+49796-6	t(9;22)(q34.1;q11)(ABL1,BCR) b2a2+b3a2 fusion transcript [#/volume] in Blood or Tissue by Molecular genetics method	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+792-2	Erythrocytes [#/volume] in Cerebral spinal fluid by Manual count	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+38349-7	Herpes virus 6 DNA [#/volume] (viral load) in Specimen by NAA with probe detection	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+49392-4	Herpes virus 6 DNA [#/volume] (viral load) in Serum or Plasma by NAA with probe detection	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+49412-0	JC virus DNA [#/volume] (viral load) in Specimen by NAA with probe detection	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+49413-8	JC virus DNA [#/volume] (viral load) in Serum or Plasma by NAA with probe detection	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+49403-9	Herpes virus 8 DNA [#/volume] (viral load) in Specimen by NAA with probe detection	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+45321-7	FMR1 gene allele 1 CGG repeats [Entitic number] in Blood or Tissue by Molecular genetics method	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+45322-5	FMR1 gene allele 2 CGG repeats [Entitic number] in Blood or Tissue by Molecular genetics method	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+49637-2	HTT gene allele 1.CAG repeats [Entitic number] in Blood or Tissue by Molecular genetics method	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+49638-0	HTT gene allele 2.CAG repeats [Entitic number] in Blood or Tissue by Molecular genetics method	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+35750-9	DMPK gene allele 2 CTG repeats [Entitic number] in Blood or Tissue by Molecular genetics method	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+35751-7	DMPK gene allele 1 CTG repeats [Entitic number] in Blood or Tissue by Molecular genetics method	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+32660-3	6-Thioguanine [Entitic substance] in Red Blood Cells	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+32654-6	6-Methylmercaptopurine [Entitic substance] in Red Blood Cells	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+9802-0	Size [Entitic volume] of Stone	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+1799-6	Amylase [Enzymatic activity/volume] in Urine	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+24475-6	F2 gene c.20210G>A [Genotype] in Blood or Tissue by Molecular genetics method Nominal	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+28005-7	MTHFR gene c.677C>T [Genotype] in Blood or Tissue by Molecular genetics method Nominal	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+28060-2	MTHFR gene c.1298A>C [Genotype] in Blood or Tissue by Molecular genetics method Nominal	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+664-3	Microscopic observation [Identifier] in Specimen by Gram stain	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+49610-9	Streptococcus pyogenes DNA [Identifier] in Specimen by NAA with probe detection	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+87969-2	Microscopic observation [Identifier] in Blood by Gram stain	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+53947-8	Escherichia coli Stx1 and Stx2 toxin stx1 and stx2 and H7 flagellar fliC genes [Identifier] in Specimen by NAA with probe detection	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+48646-4	Yersinia sp DNA [Identifier] in Specimen by NAA with probe detection	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+49609-1	Vibrio sp DNA [Identifier] in Specimen by NAA with probe detection	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+11545-1	Microscopic observation [Identifier] in Specimen by Acid fast stain	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+57791-6	Organic acidemia conditions suspected [Identifier] in DBS	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+57793-2	Amino acidemia disorder suspected [Identifier] in DBS	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+11546-9	Microscopic observation [Identifier] in Specimen by Other stain	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+13348-8	Monoclonal band observed [Identifier] in Serum or Plasma	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+667-6	Microscopic observation [Identifier] in Specimen by KOH preparation	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+63368-5	Carbapenem resistance genes [Identifier] by NAA with probe detection	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+33270-0	Microscopic observation [Identifier] in Buffy Coat by Light microscopy	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+21709-1	MTHFR gene mutations found [Identifier] in Blood or Tissue by Molecular genetics method Nominal	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+687-4	Mycoplasma sp and Ureaplasma sp [Identifier] in Specimen by Organism specific culture	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+32700-7	Microscopic observation [Identifier] in Blood by Malaria smear	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+49616-6	Legionella sp DNA [Identifier] in Specimen by NAA with probe detection	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+21654-9	CFTR gene mutations found [Identifier] in Blood or Tissue by Molecular genetics method Nominal	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+51865-4	Plasmodium sp Ag [Identifier] in Blood	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+48509-4	Influenza virus A and B RNA [Identifier] in Specimen by NAA with probe detection	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+41107-4	FMR1 gene mutations found [Identifier] in Blood or Tissue by Molecular genetics method Nominal	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+35347-4	Microscopic observation [Identifier] in Specimen by Immunofluorescence	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+40444-2	CMV gene mutations detected [Identifier]	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+33271-8	Microscopic observation [Identifier] in Blood by Malaria thin smear	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+6770-2	Alpha 1 antitrypsin phenotype [Identifier] in Serum or Plasma by Immunofixation	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+66885-5	Bacteria identified based on 16S rRNA gene [Identifier] in Specimen by Sequencing	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+55135-8	BCR-ABL1 kinase domain mutations found [Identifier] in Blood or Tissue by Molecular genetics method Nominal	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+41048-0	TPMT gene mutations found [Identifier] in Blood or Tissue by Molecular genetics method Nominal	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+21619-2	APOE gene mutations found [Identifier] in Blood or Tissue by Molecular genetics method Nominal	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+21717-4	NF1 gene mutations found [Identifier] in Blood or Tissue by Molecular genetics method Nominal	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+21723-2	SERPINA1 gene mutations found [Identifier] in Blood or Tissue by Molecular genetics method Nominal	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+34438-2	Apolipoprotein E phenotype [Identifier] in Blood	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+40995-3	Mitochondria Genes mutations found [Identifier] in Blood or Tissue by Molecular genetics method Nominal	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+93194-9	NUDT15 gene mutations found [Identifier] in Blood or Tissue by Molecular genetics method Nominal	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+21733-1	RET gene mutations found [Identifier] in Blood or Tissue by Molecular genetics method Nominal	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+34727-8	DMPK gene mutations found [Identifier] in Blood or Tissue by Molecular genetics method Nominal	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+24476-4	F2 gene mutations found [Identifier] in Blood or Tissue by Molecular genetics method Nominal	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+43097-5	COL3A1 gene mutations found [Identifier] in Blood or Tissue by Molecular genetics method Nominal	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+43995-0	Trisomy 21 risk [Likelihood] in Fetus	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+48803-1	Neural tube defect risk [Likelihood] in Fetus	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+49090-4	Fetal Trisomy 21 risk [Likelihood] Based on maternal age	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+43994-3	Trisomy 18 risk [Likelihood] in Fetus	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+53774-6	Epstein Barr virus DNA [Log #/volume] (viral load) in Specimen by NAA with probe detection	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+38350-5	Herpes virus 6 DNA [Log #/volume] (viral load) in Specimen by NAA with probe detection	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA
+43201-3	BK virus DNA [Log #/volume] (viral load) in Specimen by NAA with probe detection	semapv:ManualMappingCuration	orcid:0000-0002-6581-7754	not in scope for OBA

--- a/src/mappings/oba-loinc.sssom.tsv
+++ b/src/mappings/oba-loinc.sssom.tsv
@@ -1,0 +1,448 @@
+subject_id	subject_label	subject_category	predicate_id	object_id	object_label	mapping_justification	subject_source	object_source	confidence	mapping_date	author_id
+19153-6	Volume in Urine collected for unspecified duration		skos:exactMatch	OBA:0000173	urinary volume	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+28009-9	Volume of Urine		skos:exactMatch	OBA:0000173	urinary volume	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+31111-8	Reticulocyte production index		skos:broadMatch	OBA:0002272	reticulocyte amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+2714-4	Fractional oxyhemoglobin in Arterial blood		skos:relatedMatch	OBA:0002293	respiratory gaseous exchange by respiratory system amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+11559-2	Fractional oxyhemoglobin in Blood		skos:relatedMatch	OBA:0002293	respiratory gaseous exchange by respiratory system amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+48795-9	Fibrosis score		skos:exactMatch	OBA:0002614	liver degeneration	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+48794-2	Fibrosis stage		skos:exactMatch	OBA:0002614	liver degeneration	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+87430-5	Cystatin C and Glomerular filtration rate by Cystatin-based formula panel - Serum or Plasma		skos:exactMatch	OBA:0003747	glomerular filtration rate	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+2164-2	Creatinine renal clearance in 24 hour Urine and Serum or Plasma		skos:exactMatch	OBA:0004158	renal filtration rate	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+2756-5	pH of Urine		skos:exactMatch	OBA:0004692	urine acidity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+5803-2	pH of Urine by Test strip		skos:exactMatch	OBA:0004692	urine acidity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+19991-9	Alveolar-arterial oxygen Partial pressure difference		skos:broadMatch	OBA:1000805	respiratory gaseous exchange by respiratory system quality	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+76274-0	Ventilation-perfusion index Respiratory system		skos:broadMatch	OBA:1000805	respiratory gaseous exchange by respiratory system quality	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+1757-4	Albumin renal clearance in 24 hour Urine and Serum or Plasma		skos:exactMatch	OBA:1000854	renal filtration quality	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+2693-0	Osmolality of Stool		skos:exactMatch	OBA:1001084	feces osmolality	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+73561-3	Insulin-like growth factor-I [Z-score] in Serum or Plasma		skos:exactMatch	OBA:2042067	level of insulin-like growth factor I in blood serum	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+72203-3	Parathyrin.intact intraoperative panel - Serum or Plasma		skos:exactMatch	OBA:2043094	level of parathyroid hormone in blood serum	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+20657-3	Taurine [Moles/volume] in Serum or Plasma		skos:exactMatch	OBA:2045209	level of taurine in blood serum	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+30341-2	Erythrocyte sedimentation rate		skos:exactMatch	OBA:2045235	blood sedimentation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+4537-7	Erythrocyte sedimentation rate by Westergren method		skos:exactMatch	OBA:2045235	blood sedimentation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+50562-8	Specific gravity of Urine by Refractometry automated		skos:exactMatch	OBA:2045259	urine relative density	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+5811-5	Specific gravity of Urine by Test strip		skos:exactMatch	OBA:2045259	urine relative density	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+18047-1	Left ventricular Ejection fraction by US 2D modified biplane		skos:broadMatch	OBA:2045275	heart function attribute	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+18048-9	Left ventricular Ejection fraction by US 2D modified single-plane		skos:broadMatch	OBA:2045275	heart function attribute	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+8634-8	Q-T interval		skos:broadMatch	OBA:2045275	heart function attribute	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+8636-3	Q-T interval corrected		skos:broadMatch	OBA:2045275	heart function attribute	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+4667-2	Osmotic fragility of Red Blood Cells		skos:exactMatch	OBA:2045276	erythrocyte attribute	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+57084-6	Fatty acid oxidation newborn screen panel		skos:exactMatch	OBA:2045289	fatty acid desaturase enzyme activity attribute	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+601-5	Fungus identified in Blood by Culture		skos:broadMatch	OBA:2045296	defense response to other organism process attribute	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+42805-2	Fungus identified in Specimen		skos:broadMatch	OBA:2045296	defense response to other organism process attribute	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+580-1	Fungus identified in Specimen by Culture		skos:broadMatch	OBA:2045296	defense response to other organism process attribute	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+82195-9	Gastrointestinal pathogens DNA and RNA panel - Stool by NAA with non-probe detection		skos:broadMatch	OBA:2045296	defense response to other organism process attribute	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+29579-0	Mycobacterial susceptibility panel by Method for Slow-growing mycobacteria		skos:broadMatch	OBA:2045296	defense response to other organism process attribute	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+543-9	Mycobacterium sp identified in Specimen by Organism specific culture		skos:relatedMatch	OBA:2045296	defense response to other organism process attribute	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+34736-9	Calcium oxalate index in 24 hour Urine		skos:exactMatch	OBA:2045405	amount of calcium oxalate in urine	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+47528-5	Cytology report of Cervical or vaginal smear or scraping Cyto stain		skos:broadMatch	OBA:2045406	epithelial cell of cervix morphology	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+43391-2	Bacterial vaginosis score		skos:broadMatch	OBA:2045407	response to bacterium process attribute	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+533-0	Mycobacterium sp identified in Blood by Organism specific culture		skos:relatedMatch	OBA:2045407	response to bacterium process attribute	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+2743-3	pH of Amniotic fluid		skos:exactMatch	OBA:2045408	amniotic fluid pH	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+41276-7	Anion gap in Blood		skos:broadMatch	OBA:2045409	blood pH	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+11555-0	Base excess in Blood by calculation		skos:broadMatch	OBA:2045409	blood pH	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+18185-9	Gestational age		skos:broadMatch	OBA:2045410	multicellular organism age	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+11884-4	Gestational age Estimated		skos:broadMatch	OBA:2045410	multicellular organism age	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+53693-8	Gestational age Estimated from conception date		skos:broadMatch	OBA:2045410	multicellular organism age	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+29638-4	Weight of Tissue		skos:exactMatch	OBA:2045411	tissue mass	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+47526-9	Cytology report of Specimen Cyto stain		skos:broadMatch	OBA:2045412	anatomical entity morphology	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+3154-2	Weight of Specimen		skos:broadMatch	OBA:2045413	anatomical entity mass	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+32167-9	Clarity of Urine		skos:exactMatch	OBA:2045414	urine opacity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+2695-5	Osmolality of Urine		skos:exactMatch	OBA:2045415	urine osmolality	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+29605-3	Appearance of Synovial fluid		skos:broadMatch	OBA:2045416	synovial fluid attribute	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+41238-7	Viscosity of Synovial fluid		skos:exactMatch	OBA:2045417	synovial fluid viscosity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+10333-3	Appearance of Cerebral spinal fluid		skos:exactMatch	OBA:2045418	appearance of cerebrospinal fluid	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+10335-8	Color of Cerebral spinal fluid		skos:exactMatch	OBA:2045419	cerebrospinal fluid color	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+12146-7	Fetal Nuchal fold Thickness US		skos:broadMatch	OBA:2045420	skin of neck thickness	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+13359-5	Character of Semen		skos:exactMatch	OBA:2045421	semen attribute	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+50677-4	Semen analysis post vasectomy panel		skos:broadMatch	OBA:2045421	semen attribute	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+3160-9	Volume of Semen		skos:exactMatch	OBA:2045422	semen volume	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+9631-3	Viscosity of Semen		skos:exactMatch	OBA:2045423	semen viscosity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+32789-0	Viscosity of Semen Qualitative		skos:exactMatch	OBA:2045423	semen viscosity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+2752-4	pH of Semen		skos:exactMatch	OBA:2045424	semen pH	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+2753-2	pH of Serum or Plasma		skos:exactMatch	OBA:2045425	plasma pH	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+2692-2	Osmolality of Serum or Plasma		skos:exactMatch	OBA:2045426	blood plasma osmolality	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+3128-6	Viscosity of Serum		skos:exactMatch	OBA:2045427	blood serum viscosity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+11029-6	Consistency of Stool		skos:exactMatch	OBA:2045428	feces consistency	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+30078-0	Weight of Stool		skos:exactMatch	OBA:2045429	feces mass	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+2755-7	pH of Stool		skos:exactMatch	OBA:2045430	feces pH	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+9335-1	Appearance of Body fluid		skos:broadMatch	OBA:2045431	body fluid attribute	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+6824-7	Color of Body fluid		skos:exactMatch	OBA:2045432	body fluid color	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+60840-6	Base excess in Extracellular fluid by calculation		skos:broadMatch	OBA:2045433	body fluid pH	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+2748-2	pH of Body fluid		skos:exactMatch	OBA:2045433	body fluid pH	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+28638-5	Base excess in Arterial cord blood by calculation		skos:broadMatch	OBA:2045434	umbilical cord blood pH	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+28639-3	Base excess in Venous cord blood by calculation		skos:broadMatch	OBA:2045434	umbilical cord blood pH	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+28646-8	pH of Arterial cord blood		skos:broadMatch	OBA:2045434	umbilical cord blood pH	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+28647-6	pH of Venous cord blood		skos:broadMatch	OBA:2045434	umbilical cord blood pH	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+2749-0	pH of Gastric fluid		skos:exactMatch	OBA:2045435	stomach content pH	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+9349-2	pH total acid of Gastric fluid		skos:exactMatch	OBA:2045435	stomach content pH	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+1925-7	Base excess in Arterial blood by calculation		skos:broadMatch	OBA:2045436	arterial blood pH	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+19235-1	Base excess standard in Arterial blood by calculation		skos:broadMatch	OBA:2045436	arterial blood pH	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+2744-1	pH of Arterial blood		skos:exactMatch	OBA:2045436	arterial blood pH	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+33254-4	pH of Arterial blood adjusted to patient's actual temperature		skos:exactMatch	OBA:2045436	arterial blood pH	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+1927-3	Base excess in Venous blood by calculation		skos:broadMatch	OBA:2045437	venous blood pH	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+19237-7	Base excess standard in Venous blood by calculation		skos:broadMatch	OBA:2045437	venous blood pH	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+2746-6	pH of Venous blood		skos:exactMatch	OBA:2045437	venous blood pH	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+39486-6	pH of Venous blood adjusted to patient's actual temperature		skos:exactMatch	OBA:2045437	venous blood pH	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+1926-5	Base excess in Capillary blood by calculation		skos:broadMatch	OBA:2045438	capillary blood pH	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+19236-9	Base excess standard in Capillary blood by calculation		skos:broadMatch	OBA:2045438	capillary blood pH	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+2745-8	pH of Capillary blood		skos:exactMatch	OBA:2045438	capillary blood pH	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+39485-8	pH of Capillary blood adjusted to patient's actual temperature		skos:exactMatch	OBA:2045438	capillary blood pH	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+8277-6	Body surface area		skos:exactMatch	OBA:2045439	body surface area	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+49061-5	Hepatic iron index		skos:exactMatch	OBA:2045440	hepatic iron amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+19218-7	Oxygen content in Arterial blood		skos:exactMatch	OBA:2045442	arterial blood oxygen level	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+20564-1	Oxygen saturation in Blood		skos:exactMatch	OBA:2045443	oxygen concentration in blood	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+28642-7	Oxygen saturation in Arterial cord blood		skos:broadMatch	OBA:2045444	oxygen concentration in umbilical cord blood	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+28643-5	Oxygen saturation in Venous cord blood		skos:broadMatch	OBA:2045444	oxygen concentration in umbilical cord blood	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+51733-4	Oxygen saturation Calculated from oxygen partial pressure in Arterial blood		skos:broadMatch	OBA:2045445	oxygen concentration in arterial blood	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+2708-6	Oxygen saturation in Arterial blood		skos:exactMatch	OBA:2045445	oxygen concentration in arterial blood	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+51731-8	Oxygen saturation Calculated from oxygen partial pressure in Venous blood		skos:broadMatch	OBA:2045446	oxygen concentration in venous blood	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+2711-0	Oxygen saturation in Venous blood		skos:exactMatch	OBA:2045446	oxygen concentration in venous blood	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+51732-6	Oxygen saturation Calculated from oxygen partial pressure in Capillary blood		skos:broadMatch	OBA:2045447	oxygen concentration in capillary blood	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+2709-4	Oxygen saturation in Capillary blood		skos:exactMatch	OBA:2045447	oxygen concentration in capillary blood	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+73818-7	Heparin induced platelet IgG Ab in Serum or Plasma by Immunoassay		skos:broadMatch	OBA:2045448	attribute of response to heparin in plasma	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+32215-6	Thyroxine (T4) free index in Serum or Plasma by calculation		skos:broadMatch	OBA:2045449	plasma thyroxine level	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+64116-7	Hemoglobin observations newborn screening panel		skos:broadMatch	OBA:2045450	blood hemoglobin attribute	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+19058-7	Allergens identified in Serum		skos:broadMatch	OBA:2045451	attribute of response to  allergen in serum	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+3050-2	Triiodothyronine resin uptake (T3RU) in Serum or Plasma		skos:exactMatch	OBA:2045452	attribute of response to thyroid hormone in plasma	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+5767-9	Appearance of Urine		skos:broadMatch	OBA:VT0000056	urine trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+81323-8	Urine collection associated observations panel - 24 hour Urine		skos:broadMatch	OBA:VT0000056	urine trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+8302-2	Body height		skos:exactMatch	OBA:VT0001253	body height	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+3137-7	Body height Measured		skos:exactMatch	OBA:VT0001253	body height	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+11957-8	Fetal Crown Rump length US		skos:broadMatch	OBA:VT0001256	body length	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+29463-7	Body weight		skos:exactMatch	OBA:VT0001259	body mass	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+8339-4	Birth weight Measured		skos:broadMatch	OBA:VT0001259	body mass	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+3141-9	Body weight Measured		skos:exactMatch	OBA:VT0001259	body mass	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+41270-0	Drugs identified in Urine		skos:broadMatch	OBA:VT0001757	urine molecular composition	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+6301-6	INR in Platelet poor plasma by Coagulation assay		skos:broadMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+34714-6	INR in Blood by Coagulation assay		skos:broadMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+3184-9	Activated clotting time (ACT) of Blood by Coagulation assay		skos:broadMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+80659-6	Activated clotting time (ACT) of Blood induced by Kaolin		skos:broadMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+16631-4	aPTT in Blood by Coagulation 1:1 saline		skos:relatedMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+3173-2	aPTT in Blood by Coagulation assay		skos:relatedMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+43734-3	aPTT in Platelet poor plasma by Coagulation 1:1 saline		skos:relatedMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+14979-9	aPTT in Platelet poor plasma by Coagulation assay		skos:relatedMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+52123-7	aPTT in Platelet poor plasma by Coagulation assay --post heparin neutralization		skos:relatedMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+3282-1	aPTT W excess hexagonal phase phospholipid in Platelet poor plasma by Coagulation assay		skos:relatedMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+33930-9	aPTT W excess hexagonal phospholipid (StaClot LA confirm)		skos:relatedMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+44950-4	aPTT.factor substitution in Control Platelet poor plasma by Coagulation assay --1H post incubation with normal plasma		skos:relatedMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+30322-2	aPTT.factor substitution in Platelet poor plasma --1 hour post incubation		skos:relatedMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+30323-0	aPTT.factor substitution in Platelet poor plasma by Coagulation assay --1H post incubation with normal plasma		skos:relatedMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+33890-5	aPTT.factor substitution in Platelet poor plasma by Coagulation assay --2H post incubation with normal plasma		skos:relatedMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+5946-9	aPTT.factor substitution in Platelet poor plasma by Coagulation assay --immediately after addition of normal plasma		skos:relatedMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+34571-0	aPTT.lupus sensitive (LA screen)		skos:relatedMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+75506-6	aPTT.lupus sensitive W excess phospholipid (LA confirm)		skos:relatedMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+66748-5	Clot angle in Blood by Thromboelastography		skos:relatedMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+66751-9	Clot strength in Blood by Thromboelastography		skos:relatedMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+66760-0	Coagulation index in Blood by Thromboelastography		skos:exactMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+6303-2	dRVVT (LA screen)		skos:relatedMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+57838-5	dRVVT W excess phospholipid (LA confirm)		skos:relatedMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+75513-2	dRVVT with 1:1 PNP (LA mix)		skos:relatedMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+5902-2	Prothrombin time (PT)		skos:broadMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+33884-8	Prothrombin time (PT) factor substitution in Control Platelet poor plasma by Coagulation assay --1H post incubation with normal plasma		skos:broadMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+33356-7	Prothrombin time (PT) factor substitution in Platelet poor plasma by Coagulation assay --1H post incubation with normal plasma		skos:broadMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+5959-2	Prothrombin time (PT) factor substitution in Platelet poor plasma by Coagulation assay --immediately after addition of normal plasma		skos:broadMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+5964-2	Prothrombin time (PT) in Blood by Coagulation assay		skos:broadMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+5901-4	Prothrombin time (PT) in Control Platelet poor plasma by Coagulation assay		skos:broadMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+52122-9	Prothrombin time (PT) in Platelet poor plasma by Coagulation assay --post heparin neutralization		skos:broadMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+6683-7	Reptilase time		skos:broadMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+33526-5	Reptilase time.factor substitution in Platelet poor plasma by Coagulation assay --immediately after addition of normal plasma		skos:broadMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+69423-2	Rosner index in Platelet poor plasma by Coagulation assay		skos:broadMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+3243-3	Thrombin time		skos:broadMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+33525-7	Thrombin time.factor substitution in Platelet poor plasma by Coagulation assay --immediately after addition of normal plasma		skos:broadMatch	OBA:VT0002551	blood coagulation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+50553-7	Color of Urine by Auto		skos:exactMatch	OBA:VT0003619	urine color	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+5778-6	Color of Urine		skos:exactMatch	OBA:VT0003619	urine color	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+8310-5	Body temperature		skos:exactMatch	OBA:VT0005535	body temperature trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+59063-8	Lymphocyte proliferation panel - Blood		skos:exactMatch	OBA:VT0010184	lymphocyte proliferation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+38213-5	FLACC pain assessment panel		skos:broadMatch	OBA:VT0015100	nociception system physiology trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+38221-8	Pain severity Wong-Baker FACES pain rating scale		skos:broadMatch	OBA:VT0015100	nociception system physiology trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+55230-7	Immunophenotyping study		skos:broadMatch	OBA:VT1000783	immune system trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+4690-4	Viscosity of Blood		skos:exactMatch	OBA:VT3000004	blood viscosity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0001-8314-2140
+33516-6	Immature reticulocytes/Reticulocytes.total in Blood		skos:broadMatch	OBA:0002272	reticulocyte amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+8119-0	CD20 cells/100 cells in Blood		skos:broadMatch	OBA:0002633	B cell amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+8117-4	CD19 cells/100 cells in Blood		skos:broadMatch	OBA:0002633	B cell amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+43273-2	CD19+CD27+IgD+ cells/100 cells in Blood or Tissue		skos:broadMatch	OBA:0002633	B cell amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+20593-0	CD19 cells/100 cells in Specimen		skos:broadMatch	OBA:0002633	B cell amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+9558-8	CD20 cells [#/volume] in Blood		skos:broadMatch	OBA:0002633	B cell amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+8116-6	CD19 cells [#/volume] in Blood		skos:broadMatch	OBA:0002633	B cell amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+15195-1	CD3-CD19+ cells [#/volume] in Blood		skos:broadMatch	OBA:0002633	B cell amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+8124-0	CD3 cells/100 cells in Blood		skos:broadMatch	OBA:0002636	T cell amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+20599-7	CD3 cells/100 cells in Specimen		skos:broadMatch	OBA:0002636	T cell amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+34963-9	CD3+TCR alpha beta+ cells [#/volume] in Blood		skos:broadMatch	OBA:0002636	T cell amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+8122-4	CD3 cells [#/volume] in Blood		skos:broadMatch	OBA:0002636	T cell amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+8123-2	CD3+CD4+ (T4 helper) cells/100 cells in Blood		skos:broadMatch	OBA:0002637	CD4-positive helper T cell amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+54218-3	CD3+CD4+ (T4 helper) cells/CD3+CD8+ (T8 suppressor cells) cells [# Ratio] in Blood		skos:broadMatch	OBA:0002812	helper T cell amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+24467-3	CD3+CD4+ (T4 helper) cells [#/volume] in Blood		skos:broadMatch	OBA:0002812	helper T cell amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+32623-1	Platelet mean volume [Entitic volume] in Blood by Automated count		skos:closeMatch	OBA:0003277	platelet volume	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+53831-4	CD59 deficient Granulocytes/100 cells in Blood		skos:relatedMatch	OBA:0003294	granulocyte amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+28541-1	Metamyelocytes/100 leukocytes in Blood		skos:relatedMatch	OBA:0003294	granulocyte amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+26498-6	Myelocytes/100 leukocytes in Blood		skos:relatedMatch	OBA:0003294	granulocyte amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+26524-9	Promyelocytes/100 leukocytes in Blood		skos:relatedMatch	OBA:0003294	granulocyte amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+71695-1	Immature granulocytes/100 leukocytes in Blood by Automated count		skos:broadMatch	OBA:0003294	granulocyte amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+19023-1	Granulocytes/100 leukocytes in Blood by Automated count		skos:broadMatch	OBA:0003294	granulocyte amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+740-1	Metamyelocytes/100 leukocytes in Blood by Manual count		skos:relatedMatch	OBA:0003294	granulocyte amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+749-2	Myelocytes/100 leukocytes in Blood by Manual count		skos:relatedMatch	OBA:0003294	granulocyte amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+783-1	Promyelocytes/100 leukocytes in Blood by Manual count		skos:relatedMatch	OBA:0003294	granulocyte amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+26478-8	Lymphocytes/100 leukocytes in Blood		skos:relatedMatch	OBA:0003352	lymphocyte amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+736-9	Lymphocytes/100 leukocytes in Blood by Automated count		skos:broadMatch	OBA:0003352	lymphocyte amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+737-7	Lymphocytes/100 leukocytes in Blood by Manual count		skos:broadMatch	OBA:0003352	lymphocyte amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+13941-0	Lymphocytes/100 leukocytes in Body fluid by Manual count		skos:broadMatch	OBA:0003352	lymphocyte amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+30421-2	Lymphocytes/100 leukocytes in Bronchial specimen		skos:broadMatch	OBA:0003352	lymphocyte amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+10328-3	Lymphocytes/100 leukocytes in Cerebral spinal fluid by Manual count		skos:broadMatch	OBA:0003352	lymphocyte amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+26483-8	Lymphocytes/100 leukocytes in Synovial fluid		skos:broadMatch	OBA:0003352	lymphocyte amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+8112-5	CD3-CD16+CD56+ (Natural killer) cells/100 cells in Blood		skos:broadMatch	OBA:0003353	natural killer cell amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+32519-1	CD3-CD16+CD56+ (Natural killer) cells/100 cells in Specimen		skos:broadMatch	OBA:0003353	natural killer cell amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+17174-4	CD54 cells/100 cells in Blood		skos:relatedMatch	OBA:0003714	professional antigen presenting cell functionality	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+74520-8	Complement alternate pathway AH50 actual/normal in Serum by Immunoassay		skos:broadMatch	OBA:0003715	complement activation, alternative pathway rate	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+6800-7	Spermatozoa Motile/100 spermatozoa in Semen		skos:broadMatch	OBA:0004007	sperm functionality	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+14194-5	Spermatozoa Progressive/100 spermatozoa in Semen		skos:broadMatch	OBA:0004007	sperm functionality	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+21532-7	Spermatozoa Motile/100 spermatozoa in Semen --2 hours post ejaculation		skos:broadMatch	OBA:0004007	sperm functionality	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+21535-0	Spermatozoa Motile/100 spermatozoa in Semen --6 hours post ejaculation		skos:broadMatch	OBA:0004007	sperm functionality	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+57446-7	Spermatozoa Immotile/100 spermatozoa in Semen --post concentration		skos:broadMatch	OBA:0004007	sperm functionality	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+13844-6	CD34 blasts/100 blasts in Blood		skos:broadMatch	OBA:0004071	hematopoietic stem cell amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+51162-6	CD34 blasts/100 blasts in Bone marrow		skos:broadMatch	OBA:0004071	hematopoietic stem cell amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+12195-4	Creatinine renal clearance/1.73 sq M in 24 hour Urine and Serum or Plasma		skos:broadMatch	OBA:0004158	renal filtration rate	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+19114-8	Lamellar bodies [#/volume] in Amniotic fluid		skos:relatedMatch	OBA:0005252	alveolar lamellar body amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+35652-7	Epithelial cells/100 cells in Body fluid		skos:relatedMatch	OBA:0005336	pigmented ciliary epithelial cell amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+26020-8	Creatine Kinase.macromolecular type 2/Creatine kinase.total in Serum or Plasma		skos:broadMatch	OBA:0006026	creatine kinase complex amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+26019-0	Creatine Kinase.macromolecular type 1/Creatine kinase.total in Serum or Plasma		skos:broadMatch	OBA:0006026	creatine kinase complex amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+12189-7	Creatine kinase.MB/Creatine kinase.total in Serum or Plasma by calculation		skos:broadMatch	OBA:0006026	creatine kinase complex amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+12187-1	Creatine kinase.MB/Creatine kinase.total in Serum or Plasma by Electrophoresis		skos:broadMatch	OBA:0006026	creatine kinase complex amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+15048-2	Creatine kinase.BB/Creatine kinase.total in Serum or Plasma by Electrophoresis		skos:broadMatch	OBA:0006026	creatine kinase complex amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+15049-0	Creatine kinase.MM/Creatine kinase.total in Serum or Plasma by Electrophoresis		skos:broadMatch	OBA:0006026	creatine kinase complex amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+15013-6	Alkaline phosphatase.bone/Alkaline phosphatase.total in Serum or Plasma		skos:broadMatch	OBA:2040574	level of intestinal alkaline phosphatase in blood serum	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+15015-1	Alkaline phosphatase.liver/Alkaline phosphatase.total in Serum or Plasma		skos:broadMatch	OBA:2040574	level of intestinal alkaline phosphatase in blood serum	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+15014-4	Alkaline phosphatase.intestinal/Alkaline phosphatase.total in Serum or Plasma		skos:broadMatch	OBA:2040574	level of intestinal alkaline phosphatase in blood serum	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+13989-9	Gamma globulin/Protein.total in 24 hour Urine by Electrophoresis		skos:relatedMatch	OBA:2045206	level of serum globulin type protein	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+13988-1	Beta globulin/Protein.total in 24 hour Urine by Electrophoresis		skos:relatedMatch	OBA:2045206	level of serum globulin type protein	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+13984-0	Alpha 1 globulin/Protein.total in 24 hour Urine by Electrophoresis		skos:relatedMatch	OBA:2045206	level of serum globulin type protein	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+13987-3	Alpha 2 globulin/Protein.total in 24 hour Urine by Electrophoresis		skos:relatedMatch	OBA:2045206	level of serum globulin type protein	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+13990-7	Alpha 1 globulin/Protein.total in Urine by Electrophoresis		skos:relatedMatch	OBA:2045206	level of serum globulin type protein	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+13994-9	Beta globulin/Protein.total in Urine by Electrophoresis		skos:relatedMatch	OBA:2045206	level of serum globulin type protein	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+27811-9	Antithrombin actual/normal in Platelet poor plasma by Chromogenic method		skos:broadMatch	OBA:2045225	blood clotting level	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+27818-4	Protein C actual/normal in Platelet poor plasma by Chromogenic method		skos:broadMatch	OBA:2045225	blood clotting level	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+31102-7	Protein S actual/normal in Platelet poor plasma by Chromogenic method		skos:broadMatch	OBA:2045225	blood clotting level	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+53622-7	von Willebrand factor (vWf) cleaving protease actual/normal in Platelet poor plasma by Chromogenic method		skos:broadMatch	OBA:2045225	blood clotting level	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+28660-9	Plasminogen actual/normal in Platelet poor plasma by Chromogenic method		skos:broadMatch	OBA:2045225	blood clotting level	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+27815-0	Coagulation factor XIII activity actual/normal in Platelet poor plasma by Chromogenic method		skos:broadMatch	OBA:2045225	blood clotting level	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+3209-4	Coagulation factor VIII activity actual/normal in Platelet poor plasma by Coagulation assay		skos:broadMatch	OBA:2045225	blood clotting level	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+3289-6	Prothrombin activity actual/normal in Platelet poor plasma by Coagulation assay		skos:broadMatch	OBA:2045225	blood clotting level	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+27822-6	Protein S actual/normal in Platelet poor plasma by Coagulation assay		skos:broadMatch	OBA:2045225	blood clotting level	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+3226-8	Coagulation factor XI activity actual/normal in Platelet poor plasma by Coagulation assay		skos:broadMatch	OBA:2045225	blood clotting level	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+3198-9	Coagulation factor VII activity actual/normal in Platelet poor plasma by Coagulation assay		skos:broadMatch	OBA:2045225	blood clotting level	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+3232-6	Coagulation factor XII activity actual/normal in Platelet poor plasma by Coagulation assay		skos:broadMatch	OBA:2045225	blood clotting level	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+27819-2	Protein C actual/normal in Platelet poor plasma by Coagulation assay		skos:broadMatch	OBA:2045225	blood clotting level	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+27816-8	von Willebrand factor (vWf) Ag actual/normal in Platelet poor plasma by Immunoassay		skos:broadMatch	OBA:2045225	blood clotting level	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+68324-3	von Willebrand factor (vWf).activity actual/normal in Platelet poor plasma by Immunoassay		skos:broadMatch	OBA:2045225	blood clotting level	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+27821-8	Protein S Free Ag actual/normal in Platelet poor plasma by Immunoassay		skos:broadMatch	OBA:2045225	blood clotting level	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+27823-4	Protein S Ag actual/normal in Platelet poor plasma by Immunoassay		skos:broadMatch	OBA:2045225	blood clotting level	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+27820-0	Protein C Ag actual/normal in Platelet poor plasma by Immunoassay		skos:broadMatch	OBA:2045225	blood clotting level	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+50377-1	von Willebrand factor (vWf).collagen binding activity actual/normal in Platelet poor plasma by Immunoassay		skos:broadMatch	OBA:2045225	blood clotting level	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+38521-1	Coagulation factor VIII Ag actual/normal in Platelet poor plasma by Immunoassay		skos:broadMatch	OBA:2045225	blood clotting level	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+6014-5	von Willebrand factor (vWf) ristocetin cofactor actual/normal in Platelet poor plasma by Platelet aggregation		skos:broadMatch	OBA:2045225	blood clotting level	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+66745-1	Clot Lysis [Length fraction] in Blood by Thromboelastography --30 minutes post maximum clot amplitude		skos:relatedMatch	OBA:2045225	blood clotting level	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+52778-8	Maximum clot firmness [Length] in Blood by Thromboelastography		skos:relatedMatch	OBA:2045225	blood clotting level	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+52783-8	Maximum clot firmness.extrinsic coagulation system activated [Length] in Blood by Rotational TEG		skos:relatedMatch	OBA:2045225	blood clotting level	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+91125-5	Maximum amplitude kaolin induced [Length] in Blood by Resonance TEG --after addition of heparinase		skos:relatedMatch	OBA:2045225	blood clotting level	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+91126-3	Maximum amplitude activator F induced [Length] in Blood by Resonance TEG		skos:relatedMatch	OBA:2045225	blood clotting level	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+91127-1	Maximum amplitude ADP induced [Length] in Blood by Resonance TEG		skos:relatedMatch	OBA:2045225	blood clotting level	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+94577-4	Maximum amplitude arachidonate induced [Length] in Blood by Resonance TEG		skos:relatedMatch	OBA:2045225	blood clotting level	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+21000-5	Erythrocyte distribution width [Entitic volume] by Automated count		skos:broadMatch	OBA:2045276	erythrocyte attribute	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+2742-5	Angiotensin converting enzyme [Enzymatic activity/volume] in Serum or Plasma		skos:broadMatch	OBA:2045290	angiotensin converting enzyme activity attribute	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+12480-0	Angiotensin converting enzyme [Enzymatic activity/volume] in Cerebral spinal fluid		skos:broadMatch	OBA:2045290	angiotensin converting enzyme activity attribute	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+73895-5	Hemoglobin [Entitic substance] in Reticulocytes by Automated count		skos:broadMatch	OBA:2045306	reticulocyte hemoglobin variability attribute	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+8101-8	CD3+CD8+ (T8 suppressor) cells/100 cells in Blood		skos:relatedMatch	OBA:2045351	cytotoxic and regulatory T-cell molecule level	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+32518-3	CD3+CD8+ (T8 suppressor) cells/100 cells in Specimen		skos:relatedMatch	OBA:2045351	cytotoxic and regulatory T-cell molecule level	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+14135-8	CD3+CD8+ (T8 suppressor) cells [#/volume] in Blood		skos:relatedMatch	OBA:2045351	cytotoxic and regulatory T-cell molecule level	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+787-2	MCV [Entitic volume] by Automated count		skos:relatedMatch	OBA:2045381	hematocrit	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+17782-4	Lipoprotein.beta.subparticle [Entitic length] in Serum or Plasma		skos:broadMatch	OBA:2050113	LDL particle size	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+62253-0	Lipoprotein.alpha [Entitic length] in Serum or Plasma		skos:broadMatch	OBA:2050113	LDL particle size	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+62254-8	Lipoprotein.pre-beta [Entitic length] in Serum or Plasma		skos:broadMatch	OBA:2050113	LDL particle size	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+47215-9	Lipoprotein.beta.subparticle.medium [Entitic length] in Serum or Plasma		skos:broadMatch	OBA:2050113	LDL particle size	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+47213-4	Cholesterol in LDL real size pattern [Identifier] in Serum or Plasma		skos:relatedMatch	OBA:2050113	LDL particle size	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+3187-2	Coagulation factor IX activity actual/normal in Platelet poor plasma by Coagulation assay		skos:broadMatch	OBA:2050244	coagulation factor IX amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+3193-0	Coagulation factor V activity actual/normal in Platelet poor plasma by Coagulation assay		skos:broadMatch	OBA:2050268	coagulation factor V amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+28657-5	Coagulation factor X activated actual/normal in Platelet poor plasma by Chromogenic method		skos:broadMatch	OBA:2050298	coagulation factor X amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+3218-5	Coagulation factor X activity actual/normal in Platelet poor plasma by Coagulation assay		skos:broadMatch	OBA:2050298	coagulation factor X amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+785-6	MCH [Entitic mass] by Automated count		skos:relatedMatch	OBA:2060175	amount of hemoglobin in blood	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+58442-5	Other elements [Identifier] in Urine sediment by Light microscopy		skos:broadMatch	OBA:VT0000056	urine trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+1756-6	Albumin in CSF/Albumin in Serum or Plasma		skos:relatedMatch	OBA:VT0000199	blood albumin amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+20493-3	Histiocytes/100 cells in Body fluid by Light microscopy		skos:broadMatch	OBA:VT0000217	leukocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+40489-7	Histiocytes/100 cells in Synovial fluid by Manual count		skos:broadMatch	OBA:VT0000217	leukocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+26446-5	Blasts/100 leukocytes in Blood		skos:relatedMatch	OBA:VT0000217	leukocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+26473-9	Leukocytes other/100 leukocytes in Body fluid		skos:broadMatch	OBA:VT0000217	leukocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+13522-8	Blasts/100 leukocytes in Body fluid by Manual count		skos:relatedMatch	OBA:VT0000217	leukocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+13521-0	Blasts/100 leukocytes in Cerebral spinal fluid by Manual count		skos:relatedMatch	OBA:VT0000217	leukocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+14860-1	Leukocytes other/100 leukocytes in Synovial fluid by Manual count		skos:relatedMatch	OBA:VT0000217	leukocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+46702-7	Leukocytes [#/area] in Urine sediment by Automated count		skos:broadMatch	OBA:VT0000217	leukocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+6690-2	Leukocytes [#/volume] in Blood by Automated count		skos:broadMatch	OBA:VT0000217	leukocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+30405-5	Leukocytes [#/volume] in Urine		skos:broadMatch	OBA:VT0000217	leukocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+26466-3	Leukocytes [#/volume] in Body fluid		skos:broadMatch	OBA:VT0000217	leukocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+30376-8	Blasts [#/volume] in Blood		skos:relatedMatch	OBA:VT0000217	leukocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+26465-5	Leukocytes [#/volume] in Cerebral spinal fluid		skos:broadMatch	OBA:VT0000217	leukocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+10579-1	Leukocytes [#/volume] in Semen		skos:broadMatch	OBA:VT0000217	leukocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+26469-7	Leukocytes [#/volume] in Synovial fluid		skos:broadMatch	OBA:VT0000217	leukocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+708-8	Blasts [#/volume] in Blood by Manual count		skos:broadMatch	OBA:VT0000217	leukocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+33028-2	Leukocytes [#/volume] in Blood from Blood product unit		skos:broadMatch	OBA:VT0000217	leukocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+805-2	Leukocytes [#/volume] in Cerebral spinal fluid by Automated count		skos:broadMatch	OBA:VT0000217	leukocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+26511-6	Neutrophils/100 leukocytes in Blood		skos:relatedMatch	OBA:VT0000222	neutrophil quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+26505-8	Segmented neutrophils/100 leukocytes in Blood		skos:relatedMatch	OBA:VT0000222	neutrophil quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+26508-2	Band form neutrophils/100 leukocytes in Blood		skos:relatedMatch	OBA:VT0000222	neutrophil quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+770-8	Neutrophils/100 leukocytes in Blood by Automated count		skos:broadMatch	OBA:VT0000222	neutrophil quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+31160-5	Polymorphonuclear cells/100 leukocytes in Blood by Manual count		skos:relatedMatch	OBA:VT0000222	neutrophil quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+764-1	Band form neutrophils/100 leukocytes in Blood by Manual count		skos:relatedMatch	OBA:VT0000222	neutrophil quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+30230-7	Segmented neutrophils/100 leukocytes in Body fluid by Manual count		skos:relatedMatch	OBA:VT0000222	neutrophil quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+13354-6	Band form neutrophils/100 leukocytes in Body fluid by Manual count		skos:relatedMatch	OBA:VT0000222	neutrophil quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+9306-2	Polymorphonuclear cells/100 leukocytes in Body fluid by Manual count		skos:relatedMatch	OBA:VT0000222	neutrophil quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+14107-7	Segmented neutrophils/100 leukocytes in Cerebral spinal fluid by Manual count		skos:relatedMatch	OBA:VT0000222	neutrophil quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+12278-8	Band form neutrophils/100 leukocytes in Cerebral spinal fluid by Manual count		skos:relatedMatch	OBA:VT0000222	neutrophil quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+58801-2	Polymorphonuclear cells/100 leukocytes in Peritoneal dialysis fluid		skos:relatedMatch	OBA:VT0000222	neutrophil quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+26522-3	Polymorphonuclear cells/100 leukocytes in Synovial fluid		skos:relatedMatch	OBA:VT0000222	neutrophil quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+751-8	Neutrophils [#/volume] in Blood by Automated count		skos:broadMatch	OBA:VT0000222	neutrophil quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+753-4	Neutrophils [#/volume] in Blood by Manual count		skos:broadMatch	OBA:VT0000222	neutrophil quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+763-3	Band form neutrophils [#/volume] in Blood by Manual count		skos:broadMatch	OBA:VT0000222	neutrophil quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+26507-4	Band form neutrophils [#/volume] in Blood		skos:broadMatch	OBA:VT0000222	neutrophil quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+60554-3	CD59 deficient monocytes/100 cells in Blood		skos:relatedMatch	OBA:VT0000223	monocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+26485-3	Monocytes/100 leukocytes in Blood		skos:broadMatch	OBA:VT0000223	monocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+5905-5	Monocytes/100 leukocytes in Blood by Automated count		skos:broadMatch	OBA:VT0000223	monocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+744-3	Monocytes/100 leukocytes in Blood by Manual count		skos:broadMatch	OBA:VT0000223	monocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+10330-9	Monocytes/100 leukocytes in Body fluid by Manual count		skos:broadMatch	OBA:VT0000223	monocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+10329-1	Monocytes/100 leukocytes in Cerebral spinal fluid by Manual count		skos:broadMatch	OBA:VT0000223	monocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+742-7	Monocytes [#/volume] in Blood by Automated count		skos:broadMatch	OBA:VT0000223	monocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+743-5	Monocytes [#/volume] in Blood by Manual count		skos:broadMatch	OBA:VT0000223	monocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+53115-2	Immature granulocytes [#/volume] in Blood by Automated count		skos:broadMatch	OBA:VT0000334	granulocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+739-3	Metamyelocytes [#/volume] in Blood by Manual count		skos:broadMatch	OBA:VT0000334	granulocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+748-4	Myelocytes [#/volume] in Blood by Manual count		skos:broadMatch	OBA:VT0000334	granulocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+30394-1	Granulocytes [#/volume] in Blood		skos:broadMatch	OBA:VT0000334	granulocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+781-5	Promyelocytes [#/volume] in Blood by Manual count		skos:broadMatch	OBA:VT0000334	granulocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+30433-7	Metamyelocytes [#/volume] in Blood		skos:broadMatch	OBA:VT0000334	granulocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+30446-9	Myelocytes [#/volume] in Blood		skos:relatedMatch	OBA:VT0000334	granulocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+26523-1	Promyelocytes [#/volume] in Blood		skos:relatedMatch	OBA:VT0000334	granulocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+731-0	Lymphocytes [#/volume] in Blood by Automated count		skos:broadMatch	OBA:VT0000717	lymphocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+732-8	Lymphocytes [#/volume] in Blood by Manual count		skos:broadMatch	OBA:VT0000717	lymphocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+33662-8	Erythrocytes.CD59 deficient/100 erythrocytes in Blood		skos:broadMatch	OBA:VT0001586	erythrocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+46419-8	Erythrocytes [#/area] in Urine sediment by Automated count		skos:broadMatch	OBA:VT0001586	erythrocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+13945-1	Erythrocytes [#/area] in Urine sediment by Microscopy high power field		skos:broadMatch	OBA:VT0001586	erythrocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+789-8	Erythrocytes [#/volume] in Blood by Automated count		skos:broadMatch	OBA:VT0001586	erythrocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+771-6	Nucleated erythrocytes [#/volume] in Blood by Automated count		skos:broadMatch	OBA:VT0001586	erythrocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+30392-5	Nucleated erythrocytes [#/volume] in Blood		skos:broadMatch	OBA:VT0001586	erythrocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+20409-9	Erythrocytes [#/volume] in Urine by Test strip		skos:broadMatch	OBA:VT0001586	erythrocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+23860-0	Erythrocytes [#/volume] in Body fluid by Automated count		skos:broadMatch	OBA:VT0001586	erythrocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+791-4	Erythrocytes [#/volume] in Cerebral spinal fluid by Automated count		skos:broadMatch	OBA:VT0001586	erythrocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+26458-0	Erythrocytes [#/volume] in Synovial fluid		skos:broadMatch	OBA:VT0001586	erythrocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+6741-3	Erythrocytes [#/volume] in Body fluid by Manual count		skos:broadMatch	OBA:VT0001586	erythrocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+19225-2	Deoxyhemoglobin/Hemoglobin.total in Arterial blood		skos:broadMatch	OBA:VT0001588	blood hemoglobin amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+2030-5	Carboxyhemoglobin/Hemoglobin.total in Arterial blood		skos:broadMatch	OBA:VT0001588	blood hemoglobin amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+4548-4	Hemoglobin A1c/Hemoglobin.total in Blood		skos:broadMatch	OBA:VT0001588	blood hemoglobin amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+2614-6	Methemoglobin/Hemoglobin.total in Blood		skos:broadMatch	OBA:VT0001588	blood hemoglobin amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+20563-3	Carboxyhemoglobin/Hemoglobin.total in Blood		skos:broadMatch	OBA:VT0001588	blood hemoglobin amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+4625-0	Hemoglobin S/Hemoglobin.total in Blood		skos:broadMatch	OBA:VT0001588	blood hemoglobin amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+4551-8	Hemoglobin A2/Hemoglobin.total in Blood		skos:broadMatch	OBA:VT0001588	blood hemoglobin amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+4563-3	Hemoglobin C/Hemoglobin.total in Blood		skos:broadMatch	OBA:VT0001588	blood hemoglobin amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+4576-5	Hemoglobin F/Hemoglobin.total in Blood		skos:broadMatch	OBA:VT0001588	blood hemoglobin amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+4575-7	Hemoglobin E/Hemoglobin.total in Blood		skos:broadMatch	OBA:VT0001588	blood hemoglobin amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+4569-0	Hemoglobin D/Hemoglobin.total in Blood		skos:broadMatch	OBA:VT0001588	blood hemoglobin amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+4547-6	Hemoglobin A1/Hemoglobin.total in Blood		skos:broadMatch	OBA:VT0001588	blood hemoglobin amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+48343-8	Hemoglobin.other/Hemoglobin.total in Blood		skos:broadMatch	OBA:VT0001588	blood hemoglobin amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+4552-6	Hemoglobin A2/Hemoglobin.total in Blood by Electrophoresis		skos:broadMatch	OBA:VT0001588	blood hemoglobin amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+20572-4	Hemoglobin A/Hemoglobin.total in Blood by Electrophoresis		skos:broadMatch	OBA:VT0001588	blood hemoglobin amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+32683-5	Hemoglobin S/Hemoglobin.total in Blood by Electrophoresis		skos:broadMatch	OBA:VT0001588	blood hemoglobin amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+32682-7	Hemoglobin F/Hemoglobin.total in Blood by Electrophoresis		skos:broadMatch	OBA:VT0001588	blood hemoglobin amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+32017-6	Hemoglobin.other/Hemoglobin.total in Blood by Electrophoresis		skos:broadMatch	OBA:VT0001588	blood hemoglobin amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+32681-9	Hemoglobin C/Hemoglobin.total in Blood by Electrophoresis		skos:broadMatch	OBA:VT0001588	blood hemoglobin amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+4633-4	Hemoglobin F/Hemoglobin.total in Blood by Kleihauer-Betke method		skos:broadMatch	OBA:VT0001588	blood hemoglobin amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+2032-1	Carboxyhemoglobin/Hemoglobin.total in Venous blood		skos:broadMatch	OBA:VT0001588	blood hemoglobin amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+6742-1	Erythrocyte morphology finding [Identifier] in Blood		skos:broadMatch	OBA:VT0002447	erythrocyte morphology trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+713-8	Eosinophils/100 leukocytes in Blood by Automated count		skos:broadMatch	OBA:VT0002602	eosinophil quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+714-6	Eosinophils/100 leukocytes in Blood by Manual count		skos:broadMatch	OBA:VT0002602	eosinophil quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+12209-3	Eosinophils/100 leukocytes in Body fluid by Manual count		skos:broadMatch	OBA:VT0002602	eosinophil quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+12208-5	Eosinophils/100 leukocytes in Cerebral spinal fluid by Manual count		skos:broadMatch	OBA:VT0002602	eosinophil quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+30378-4	Eosinophils/100 leukocytes in Nose		skos:broadMatch	OBA:VT0002602	eosinophil quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+12210-1	Eosinophils/100 leukocytes in Urine sediment by Manual count		skos:broadMatch	OBA:VT0002602	eosinophil quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+711-2	Eosinophils [#/volume] in Blood by Automated count		skos:broadMatch	OBA:VT0002602	eosinophil quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+712-0	Eosinophils [#/volume] in Blood by Manual count		skos:broadMatch	OBA:VT0002602	eosinophil quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+30180-4	Basophils/100 leukocytes in Blood		skos:relatedMatch	OBA:VT0002607	basophil quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+706-2	Basophils/100 leukocytes in Blood by Automated count		skos:broadMatch	OBA:VT0002607	basophil quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+707-0	Basophils/100 leukocytes in Blood by Manual count		skos:broadMatch	OBA:VT0002607	basophil quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+12179-8	Basophils/100 leukocytes in Body fluid by Manual count		skos:broadMatch	OBA:VT0002607	basophil quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+13519-4	Basophils/100 leukocytes in Cerebral spinal fluid by Manual count		skos:broadMatch	OBA:VT0002607	basophil quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+704-7	Basophils [#/volume] in Blood by Automated count		skos:broadMatch	OBA:VT0002607	basophil quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+705-4	Basophils [#/volume] in Blood by Manual count		skos:broadMatch	OBA:VT0002607	basophil quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+13986-5	Albumin/Protein.total in 24 hour Urine by Electrophoresis		skos:broadMatch	OBA:VT0002871	urine albumin amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+13992-3	Albumin/Protein.total in Urine by Electrophoresis		skos:broadMatch	OBA:VT0002871	urine albumin amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+30166-3	Thyroid stimulating immunoglobulins actual/normal in Serum		skos:broadMatch	OBA:VT0002876	thyroid gland physiology trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+17849-1	Reticulocytes/100 erythrocytes in Blood by Automated count		skos:broadMatch	OBA:VT0003135	reticulocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+60474-4	Reticulocytes [#/volume] in Blood by Automated count		skos:broadMatch	OBA:VT0003135	reticulocyte quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+777-3	Platelets [#/volume] in Blood by Automated count		skos:broadMatch	OBA:VT0003179	platelet quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+26515-7	Platelets [#/volume] in Blood		skos:broadMatch	OBA:VT0003179	platelet quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+24049-9	Alpha galactosidase A [Enzymatic activity/mass] in Leukocytes		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+49231-4	Cholinesterase [Enzymatic activity/mass] in Red Blood Cells		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+49228-0	Porphobilinogen deaminase [Enzymatic activity/mass] in Red Blood Cells		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+32552-2	Pyruvate kinase [Enzymatic activity/mass] in Red Blood Cells		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+50759-0	Beta-N-acetylhexosaminidase.A [Enzymatic activity/mass] in Leukocytes		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+24078-8	Cerebroside sulfatase [Enzymatic activity/mass] in Leukocytes		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+1742-6	Alanine aminotransferase [Enzymatic activity/volume] in Serum or Plasma		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+1920-8	Aspartate aminotransferase [Enzymatic activity/volume] in Serum or Plasma		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+6768-6	Alkaline phosphatase [Enzymatic activity/volume] in Serum or Plasma		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+3040-3	Lipase [Enzymatic activity/volume] in Serum or Plasma		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+14804-9	Lactate dehydrogenase [Enzymatic activity/volume] in Serum or Plasma by Lactate to pyruvate reaction		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+2157-6	Creatine kinase [Enzymatic activity/volume] in Serum or Plasma		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+2532-0	Lactate dehydrogenase [Enzymatic activity/volume] in Serum or Plasma		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+2324-2	Gamma glutamyl transferase [Enzymatic activity/volume] in Serum or Plasma		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+1798-8	Amylase [Enzymatic activity/volume] in Serum or Plasma		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+76630-3	Amylase [Enzymatic activity/volume] in Blood		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+1795-4	Amylase [Enzymatic activity/volume] in Body fluid		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+1761-6	Aldolase [Enzymatic activity/volume] in Serum or Plasma		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+2529-6	Lactate dehydrogenase [Enzymatic activity/volume] in Body fluid		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+2915-7	Renin [Enzymatic activity/volume] in Plasma		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+2357-2	Glucose-6-Phosphate dehydrogenase [Enzymatic activity/volume] in Red Blood Cells		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+16182-8	Alkaline phosphatase isoenzymes [Enzymatic activity/volume] in Serum or Plasma by Heat stability		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+1779-8	Alkaline phosphatase.liver [Enzymatic activity/volume] in Serum or Plasma		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+1777-2	Alkaline phosphatase.bone [Enzymatic activity/volume] in Serum or Plasma		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+53819-9	Thiopurine methyltransferase [Enzymatic activity/volume] in Blood		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+15212-4	Lipase [Enzymatic activity/volume] in Body fluid		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+21563-2	Thiopurine methyltransferase [Enzymatic activity/volume] in Red Blood Cells		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+14803-1	Lactate dehydrogenase [Enzymatic activity/volume] in Body fluid by Lactate to pyruvate reaction		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+35704-6	Adenosine deaminase [Enzymatic activity/volume] in Pleural fluid		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+60024-7	Lactate dehydrogenase [Enzymatic activity/volume] in Cerebral spinal fluid by Lactate to pyruvate reaction		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+1690-7	5'-Nucleotidase [Enzymatic activity/volume] in Serum or Plasma		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+4659-9	Leukocyte phosphatase [Enzymatic activity/volume] in Leukocytes		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+86951-1	Lipoprotein associated phospholipase A2 [Enzymatic activity/volume] in Serum or Plasma		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+38355-4	Chitotriosidase [Enzymatic activity/volume] in Serum or Plasma		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+17837-6	Acid phosphatase tartrate resistant [Enzymatic activity/volume] in Serum		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+2537-9	Lactate dehydrogenase 1 [Enzymatic activity/volume] in Serum or Plasma		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+2540-3	Lactate dehydrogenase 2 [Enzymatic activity/volume] in Serum or Plasma		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+2543-7	Lactate dehydrogenase 3 [Enzymatic activity/volume] in Serum or Plasma		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+2546-0	Lactate dehydrogenase 4 [Enzymatic activity/volume] in Serum or Plasma		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+2549-4	Lactate dehydrogenase 5 [Enzymatic activity/volume] in Serum or Plasma		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+1809-3	Amylase.salivary [Enzymatic activity/volume] in Serum or Plasma		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+1805-1	Amylase.pancreatic [Enzymatic activity/volume] in Serum or Plasma		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+12173-1	Non prostatic acid phosphatase [Enzymatic activity/volume] in Serum or Plasma		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+1743-4	Alanine aminotransferase [Enzymatic activity/volume] in Serum or Plasma by With P-5'-P		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+49760-2	Adenosine deaminase [Enzymatic activity/volume] in Pericardial fluid		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+49759-4	Adenosine deaminase [Enzymatic activity/volume] in Peritoneal fluid		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+30239-8	Aspartate aminotransferase [Enzymatic activity/volume] in Serum or Plasma by With P-5'-P		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+2098-2	Cholinesterase [Enzymatic activity/volume] in Serum or Plasma		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+1715-2	Acid phosphatase [Enzymatic activity/volume] in Serum or Plasma		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+10970-2	Galactose 1 phosphate uridyl transferase [Enzymatic activity/volume] in Blood		skos:broadMatch	OBA:VT0005584	enzyme/coenzyme activity trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+9728-7	CD3-CD16+CD56+ (Natural killer) cells [#/volume] in Blood		skos:broadMatch	OBA:VT0008043	NK cell quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+20604-5	CD3-CD16+CD56+ (Natural killer) cells [#/volume] in Specimen		skos:broadMatch	OBA:VT0008043	NK cell quantity	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+55813-0	Alpha aminobutyrate/Amino acids.total in Serum or Plasma		skos:broadMatch	OBA:VT0010120	protein amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+23825-3	Beta-N-acetylhexosaminidase.A/Beta-n-acetylhexosaminidase.total in Leukocytes		skos:broadMatch	OBA:VT0010120	protein amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+10634-4	Complement C1 esterase inhibitor.functional/Complement C1 esterase inhibitor.total in Serum or Plasma		skos:broadMatch	OBA:VT0010120	protein amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+2536-1	Lactate dehydrogenase 1/Lactate dehydrogenase.total in Serum or Plasma by Electrophoresis		skos:broadMatch	OBA:VT0010477	blood lactate dehydrogenase amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+2539-5	Lactate dehydrogenase 2/Lactate dehydrogenase.total in Serum or Plasma by Electrophoresis		skos:broadMatch	OBA:VT0010477	blood lactate dehydrogenase amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+2542-9	Lactate dehydrogenase 3/Lactate dehydrogenase.total in Serum or Plasma by Electrophoresis		skos:broadMatch	OBA:VT0010477	blood lactate dehydrogenase amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+2545-2	Lactate dehydrogenase 4/Lactate dehydrogenase.total in Serum or Plasma by Electrophoresis		skos:broadMatch	OBA:VT0010477	blood lactate dehydrogenase amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+2548-6	Lactate dehydrogenase 5/Lactate dehydrogenase.total in Serum or Plasma by Electrophoresis		skos:broadMatch	OBA:VT0010477	blood lactate dehydrogenase amount	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+56006-0	Platelet aggregation ADP induced in Blood --10 umol/L		skos:broadMatch	OBA:VT3000002	platelet aggregation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+56007-8	Platelet aggregation arachidonate induced in Blood --500 umol/L		skos:broadMatch	OBA:VT3000002	platelet aggregation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+56011-0	Platelet aggregation ADP induced ATP secretion in Blood --10 umol/L		skos:broadMatch	OBA:VT3000002	platelet aggregation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+56013-6	Platelet aggregation arachidonate induced ATP secretion in Blood --500 umol/L		skos:broadMatch	OBA:VT3000002	platelet aggregation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+53568-2	Platelet aggregation arachidonate induced in Platelet rich plasma --500 ug/mL		skos:broadMatch	OBA:VT3000002	platelet aggregation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+56010-2	Platelet aggregation ristocetin induced in Blood --250 ug/mL		skos:broadMatch	OBA:VT3000002	platelet aggregation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+56008-6	Platelet aggregation collagen induced in Blood --1 ug/mL		skos:broadMatch	OBA:VT3000002	platelet aggregation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+56009-4	Platelet aggregation collagen induced in Blood --5 ug/mL		skos:broadMatch	OBA:VT3000002	platelet aggregation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+56014-4	Platelet aggregation collagen induced ATP secretion in Blood --5 ug/mL		skos:broadMatch	OBA:VT3000002	platelet aggregation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+56015-1	Platelet aggregation collagen induced ATP secretion in Blood --1 ug/mL		skos:broadMatch	OBA:VT3000002	platelet aggregation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+56027-6	Platelet aggregation ristocetin induced in Blood --1.0 mg/mL		skos:broadMatch	OBA:VT3000002	platelet aggregation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754
+56019-3	Platelet aggregation thrombin induced ATP secretion in Blood --1 U/mL		skos:broadMatch	OBA:VT3000002	platelet aggregation trait	semapv:ManualMappingCuration	LOINC	OBA	1	2024-09-03	orcid:0000-0002-6581-7754

--- a/src/ontology/oba.Makefile
+++ b/src/ontology/oba.Makefile
@@ -125,6 +125,8 @@ OBA_EFO_GS=https://docs.google.com/spreadsheets/d/e/2PACX-1vSfh18vZmG6xXrknmklcE
 OBA_VT_GS=https://docs.google.com/spreadsheets/d/e/2PACX-1vSfh18vZmG6xXrknmklcEIlNnHqte598aFMczdm6SpYXVdnFL2iBthAA-z11s7bBR3s2kaf_d3XahrI/pub?gid=506793298&single=true&output=tsv
 OBA_EFO_EXCLUSIONS_GS=https://docs.google.com/spreadsheets/d/e/2PACX-1vSfh18vZmG6xXrknmklcEIlNnHqte598aFMczdm6SpYXVdnFL2iBthAA-z11s7bBR3s2kaf_d3XahrI/pub?gid=698990842&single=true&output=tsv
 OBA_VT_EXCLUSIONS_GS=https://docs.google.com/spreadsheets/d/e/2PACX-1vSfh18vZmG6xXrknmklcEIlNnHqte598aFMczdm6SpYXVdnFL2iBthAA-z11s7bBR3s2kaf_d3XahrI/pub?gid=2051840457&single=true&output=tsv
+OBA_LOINC_GS=https://docs.google.com/spreadsheets/d/e/2PACX-1vSfh18vZmG6xXrknmklcEIlNnHqte598aFMczdm6SpYXVdnFL2iBthAA-z11s7bBR3s2kaf_d3XahrI/pub?gid=1483465731&single=true&output=tsv
+OBA_LOINC_EXCLUSIONS_GS=https://docs.google.com/spreadsheets/d/e/2PACX-1vSfh18vZmG6xXrknmklcEIlNnHqte598aFMczdm6SpYXVdnFL2iBthAA-z11s7bBR3s2kaf_d3XahrI/pub?gid=1165604508&single=true&output=tsv
 
 ../mappings/oba-efo.sssom.tsv:
 	wget "$(OBA_EFO_GS)" -O $@
@@ -138,12 +140,20 @@ OBA_VT_EXCLUSIONS_GS=https://docs.google.com/spreadsheets/d/e/2PACX-1vSfh18vZmG6
 ../mappings/oba-vt-mapping-exclusions.sssom.tsv:
 	wget "$(OBA_VT_EXCLUSIONS_GS)" -O $@
 
+../mappings/oba-loinc.sssom.tsv:
+	wget "$(OBA_LOINC_GS)" -O $@
+
+../mappings/oba-loinc-mapping-exclusions.sssom.tsv:
+	wget "$(OBA_LOINC_EXCLUSIONS_GS)" -O $@
+
 .PHONY: sync_sssom_google_sheets
 sync_sssom_google_sheets:
 	$(MAKE) ../mappings/oba-efo.sssom.tsv -B
 	$(MAKE) ../mappings/oba-vt.sssom.tsv -B
 	$(MAKE) ../mappings/oba-efo-mapping-exclusions.sssom.tsv -B
 	$(MAKE) ../mappings/oba-vt-mapping-exclusions.sssom.tsv -B
+	$(MAKE) ../mappings/oba-loinc.sssom.tsv -B
+	$(MAKE) ../mappings/oba-loinc-mapping-exclusions.sssom.tsv -B
 
 ##################################
 ### Custom QC checks #############


### PR DESCRIPTION
If applied, this commit will
1. add a new OBA-LOINC mapping table,
2. add a new OBA-LOINC exclusions table,
3. update "Automated OBA Alignment Pipeline: Templates" section of OBA  `oba.Makefile` to allow automatic synchronisation of the files in 1) and 2) from the [relevant google sheet](https://docs.google.com/spreadsheets/d/13qh7dLE38vMyz91oRqj6GzKjFohNazNKAJxKG6Plw1o/edit?gid=1483465731#gid=1483465731),
4. fix and update the OBA-EFO mapping table `oba-efo.sssom.tsv` to reflect recent addition of new terms and correct some mappings.