### PR TITLE
Refresh imports

### DIFF
--- a/src/ontology/components/obsoletes.owl
+++ b/src/ontology/components/obsoletes.owl
@@ -7,8 +7,8 @@ Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
 
 
 Ontology(<http://purl.obolibrary.org/obo/oba/components/obsoletes.owl>
-<http://purl.obolibrary.org/obo/oba/releases/2025-01-14/components/obsoletes.owl>
-Annotation(owl:versionInfo "2025-01-14")
+<http://purl.obolibrary.org/obo/oba/releases/2025-02-25/components/obsoletes.owl>
+Annotation(owl:versionInfo "2025-02-25")
 
 Declaration(Class(<http://purl.obolibrary.org/obo/OBA_0000037>))
 Declaration(Class(<http://purl.obolibrary.org/obo/OBA_0000039>))

--- a/src/ontology/components/synonyms.owl
+++ b/src/ontology/components/synonyms.owl
@@ -7,8 +7,8 @@ Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
 
 
 Ontology(<http://purl.obolibrary.org/obo/oba/components/synonyms.owl>
-<http://purl.obolibrary.org/obo/oba/releases/2025-01-14/components/synonyms.owl>
-Annotation(owl:versionInfo "2025-01-14")
+<http://purl.obolibrary.org/obo/oba/releases/2025-02-25/components/synonyms.owl>
+Annotation(owl:versionInfo "2025-02-25")
 
 Declaration(Class(<http://purl.obolibrary.org/obo/OBA_0002546>))
 Declaration(Class(<http://purl.obolibrary.org/obo/OBA_0002565>))

--- a/src/ontology/oba-odk.yaml
+++ b/src/ontology/oba-odk.yaml
@@ -97,7 +97,7 @@ components:
 robotemplate_group:
   products:
     - id: obsoletes.owl
-robot_java_args: '-Xmx8G'
+robot_java_args: '-Xmx14G'
 allow_equivalents: asserted-only
 robot_report:
   release_reports: False

--- a/src/ontology/oba-odk.yaml
+++ b/src/ontology/oba-odk.yaml
@@ -97,7 +97,7 @@ components:
 robotemplate_group:
   products:
     - id: obsoletes.owl
-robot_java_args: '-Xmx14G'
+robot_java_args: '--Xmx8G'
 allow_equivalents: asserted-only
 robot_report:
   release_reports: False

--- a/src/ontology/oba-odk.yaml
+++ b/src/ontology/oba-odk.yaml
@@ -97,7 +97,7 @@ components:
 robotemplate_group:
   products:
     - id: obsoletes.owl
-robot_java_args: '--Xmx8G'
+robot_java_args: '-Xmx8G'
 allow_equivalents: asserted-only
 robot_report:
   release_reports: False

--- a/src/patterns/data/default/entity_attribute_part_of.tsv
+++ b/src/patterns/data/default/entity_attribute_part_of.tsv
@@ -2461,7 +2461,7 @@ OBA:1000197		NBO:0000444	eye movement	PATO:0000001	quality
 OBA:1000198		UBERON:0003723	vestibular nerve	PATO:0000001	quality
 OBA:1000199		PR:000017364	von Willebrand factor	PATO:0000001	quality
 OBA:1000200		UBERON:0001653	facial vein	PATO:0000001	quality
-OBA:1000201		GO:0098803	respiratory chain complex PATO:0000001	quality
+OBA:1000201		GO:0098803	respiratory chain complex PATO:0000001	quality	
 OBA:1000202		UBERON:0001867	cartilage of external ear	PATO:0000001	quality
 OBA:1000203		UBERON:0001714	cranial ganglion	PATO:0000001	quality
 OBA:1000204		UBERON:0004330	proximal phalanx of manual digit 4	PATO:0000001	quality
@@ -2483,7 +2483,7 @@ OBA:1000219		NBO:0000129	agitation behavior	PATO:0000001	quality
 OBA:1000220		GO:0009069	serine family amino acid metabolic process	PATO:0000001	quality
 OBA:1000221		UBERON:0004389	epiphysis of metatarsal bone	PATO:0000001	quality
 OBA:1000222		UBERON:0008596	mentalis muscle	PATO:0000001	quality
-OBA:1000223		GO:1903510	mucopolysaccharide metabolic process	PATO:0000001	quality
+OBA:1000223	mucopolysaccharide metabolism trait	GO:0030203	glycosaminoglycan metabolic process	PATO:0000001	quality
 OBA:1000224		UBERON:0006059	falx cerebri	PATO:0000001	quality
 OBA:1000225		NBO:0000018	fear/anxiety related behavior	PATO:0000001	quality
 OBA:1000226		UBERON:0000010	peripheral nervous system	PATO:0000001	quality

--- a/src/patterns/data/default/entity_attribute_part_of.tsv
+++ b/src/patterns/data/default/entity_attribute_part_of.tsv
@@ -2461,7 +2461,7 @@ OBA:1000197		NBO:0000444	eye movement	PATO:0000001	quality
 OBA:1000198		UBERON:0003723	vestibular nerve	PATO:0000001	quality
 OBA:1000199		PR:000017364	von Willebrand factor	PATO:0000001	quality
 OBA:1000200		UBERON:0001653	facial vein	PATO:0000001	quality
-OBA:1000201		GO:0098803	respiratory chain complex PATO:0000001	quality	
+OBA:1000201		GO:0098803	respiratory chain complex	PATO:0000001	quality
 OBA:1000202		UBERON:0001867	cartilage of external ear	PATO:0000001	quality
 OBA:1000203		UBERON:0001714	cranial ganglion	PATO:0000001	quality
 OBA:1000204		UBERON:0004330	proximal phalanx of manual digit 4	PATO:0000001	quality

--- a/src/patterns/pattern.owl
+++ b/src/patterns/pattern.owl
@@ -17,7 +17,10 @@ Declaration(Class(<http://purl.obolibrary.org/obo/HP_0003674>))
 Declaration(Class(<http://purl.obolibrary.org/obo/MONDO_0000001>))
 Declaration(Class(<http://purl.obolibrary.org/obo/PATO_0000001>))
 Declaration(Class(<http://purl.obolibrary.org/obo/PATO_0001236>))
+Declaration(Class(<http://purl.obolibrary.org/obo/PATO_0001470>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001062>))
 Declaration(Class(<http://purl.obolibrary.org/obo/oba/patterns/attribute_location.yaml>))
+Declaration(Class(<http://purl.obolibrary.org/obo/oba/patterns/attribute_ratio.yaml>))
 Declaration(Class(<http://purl.obolibrary.org/obo/oba/patterns/chemical_role_attribute.yaml>))
 Declaration(Class(<http://purl.obolibrary.org/obo/oba/patterns/chemical_role_attribute_location.yaml>))
 Declaration(Class(<http://purl.obolibrary.org/obo/oba/patterns/disease_onset.yaml>))
@@ -33,6 +36,8 @@ Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/RO_0000052>))
 Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/RO_0000087>))
 Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/RO_0002233>))
 Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/RO_0002314>))
+Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/RO_0020202>))
+Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/RO_0020203>))
 Declaration(AnnotationProperty(<http://purl.obolibrary.org/obo/IAO_0000112>))
 Declaration(AnnotationProperty(<http://purl.obolibrary.org/obo/IAO_0000115>))
 Declaration(AnnotationProperty(<http://purl.org/dc/terms/contributor>))
@@ -41,6 +46,7 @@ Declaration(AnnotationProperty(<http://www.geneontology.org/formats/oboInOwl#has
 Declaration(AnnotationProperty(<http://www.geneontology.org/formats/oboInOwl#hasDbXref>))
 Declaration(AnnotationProperty(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>))
 Declaration(AnnotationProperty(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym>))
+Declaration(AnnotationProperty(<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>))
 
 
 
@@ -55,6 +61,20 @@ AnnotationAssertion(<http://purl.org/dc/terms/title> <http://purl.obolibrary.org
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "AUTO:patterns/patterns/attribute_location"^^xsd:string) <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/oba/patterns/attribute_location.yaml> "'thing' 'quality'"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/oba/patterns/attribute_location.yaml> "'thing' in 'quality'"^^xsd:string)
 EquivalentClasses(<http://purl.obolibrary.org/obo/oba/patterns/attribute_location.yaml> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> owl:Thing)))
+
+# Class: <http://purl.obolibrary.org/obo/oba/patterns/attribute_ratio.yaml> ('quality' to 'quality' ratio)
+
+AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "AUTO:patterns/patterns/attribute_ratio"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/oba/patterns/attribute_ratio.yaml> "A compound attribute that is the ratio of 'quality' to 'quality'."^^xsd:string)
+AnnotationAssertion(<http://purl.org/dc/terms/contributor> <http://purl.obolibrary.org/obo/oba/patterns/attribute_ratio.yaml> "orcid"^^xsd:string)
+AnnotationAssertion(<http://purl.org/dc/terms/title> <http://purl.obolibrary.org/obo/oba/patterns/attribute_ratio.yaml> "attribute_ratio"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym> <http://purl.obolibrary.org/obo/oba/patterns/attribute_ratio.yaml> "xsd:string"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> <http://purl.obolibrary.org/obo/oba/patterns/attribute_ratio.yaml> "external_resource"^^xsd:string)
+AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "AUTO:patterns/patterns/attribute_ratio"^^xsd:string) <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/oba/patterns/attribute_ratio.yaml> "the ratio of 'quality' to 'quality'"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/oba/patterns/attribute_ratio.yaml> "xsd:string"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/oba/patterns/attribute_ratio.yaml> "xsd:string"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <http://purl.obolibrary.org/obo/oba/patterns/attribute_ratio.yaml> "xsd:string"^^xsd:string)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/oba/patterns/attribute_ratio.yaml> "'quality' to 'quality' ratio"^^xsd:string)
+EquivalentClasses(<http://purl.obolibrary.org/obo/oba/patterns/attribute_ratio.yaml> ObjectIntersectionOf(ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001470> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0020202> <http://purl.obolibrary.org/obo/PATO_0000001>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0020203> <http://purl.obolibrary.org/obo/PATO_0000001>)) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/UBERON_0001062>)))
 
 # Class: <http://purl.obolibrary.org/obo/oba/patterns/chemical_role_attribute.yaml> ('role' 'quality')
 


### PR DESCRIPTION
Increase maximum available RAM for robot (`robot_java_args`) in `oba-odk.yaml`. This is needed to avoid failures in refreshing imports that requires almost 14G memory.